### PR TITLE
Colombia: align week pages with homepage v2 styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ _scratch-*
 
 .env.local
 .env*.local
+.env*
+.env.local*

--- a/institutional/corporations/colombia/index.html
+++ b/institutional/corporations/colombia/index.html
@@ -8,12 +8,21 @@
 <link rel="canonical" href="https://financiallysovereign.academy/institutional/corporations/colombia">
 <style>
   :root{
-    --bg:#0f1115; --panel:#161a22; --panel2:#1d2330; --line:#2a3142;
-    --text:#e8ecf3; --muted:#aab2c0; --accent:#f7b500; --accent2:#22c55e; --link:#7cc4ff;
+    --bg:#1a1a1a; --panel:#20232a; --panel2:#2a2e38; --line:#353a46;
+    --text:#e8ecf3; --muted:#aab2c0;
+    --accent:#FCD116;   /* Colombian flag yellow */
+    --accent2:#22c55e;
+    --flagred:#CE1126;
+    --flagblue:#003893;
+    --link:#7cc4ff;
     --maxw:880px;
   }
   *{box-sizing:border-box}
   body{margin:0;background:var(--bg);color:var(--text);font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}
+  body::before{
+    content:"";display:block;height:3px;
+    background:linear-gradient(90deg,var(--accent) 0%,var(--accent) 50%,var(--flagblue) 50%,var(--flagblue) 75%,var(--flagred) 75%,var(--flagred) 100%);
+  }
   .wrap{max-width:var(--maxw);margin:0 auto;padding:24px}
   header.hero{padding:48px 24px 24px;text-align:center}
   .flag{font-size:42px}

--- a/programa-colombia/index.html
+++ b/programa-colombia/index.html
@@ -13,12 +13,21 @@
 <link rel="canonical" href="https://financiallysovereign.academy/programa-colombia">
 <style>
   :root{
-    --bg:#0f1115; --panel:#161a22; --panel2:#1d2330; --line:#2a3142;
-    --text:#e8ecf3; --muted:#aab2c0; --accent:#f7b500; --accent2:#22c55e; --link:#7cc4ff;
-    --maxw:760px;
+    --bg:#1a1a1a; --panel:#20232a; --panel2:#2a2e38; --line:#353a46;
+    --text:#e8ecf3; --muted:#aab2c0;
+    --accent:#FCD116;   /* Colombian flag yellow */
+    --accent2:#22c55e;  /* success green */
+    --flagred:#CE1126;
+    --flagblue:#003893;
+    --link:#7cc4ff;
+    --maxw:820px;
   }
   *{box-sizing:border-box}
   body{margin:0;background:var(--bg);color:var(--text);font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}
+  body::before{
+    content:"";display:block;height:3px;
+    background:linear-gradient(90deg,var(--accent) 0%,var(--accent) 50%,var(--flagblue) 50%,var(--flagblue) 75%,var(--flagred) 75%,var(--flagred) 100%);
+  }
   .wrap{max-width:var(--maxw);margin:0 auto;padding:0 22px}
   header.hero{padding:56px 22px 24px;text-align:center;max-width:var(--maxw);margin:0 auto}
   .flag{font-size:38px}
@@ -35,7 +44,7 @@
   .total b{color:var(--text)}
   .cta-row{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin:18px 0}
   .btn{display:inline-block;padding:14px 22px;border-radius:10px;text-decoration:none;font-weight:600;font-size:15px;border:1px solid transparent}
-  .btn-primary{background:var(--accent);color:#1a1300;box-shadow:0 4px 14px rgba(247,181,0,.18)}
+  .btn-primary{background:var(--accent);color:#1a1300;box-shadow:0 4px 14px rgba(252,209,22,.18)}
   .btn-secondary{background:transparent;color:var(--text);border-color:var(--line)}
   .btn:hover{filter:brightness(1.06)}
   .reassure{color:var(--muted);font-size:13px;margin-top:8px}

--- a/programa-colombia/programa-colombia-v2.css
+++ b/programa-colombia/programa-colombia-v2.css
@@ -1,0 +1,314 @@
+/* ============================================================
+   programa-colombia-v2.css
+   Enhancement layer for /programa-colombia/ and /semana-*/.
+   Loads AFTER each page's inline <style>. Subtly aligns every
+   week with the homepage-v2 visual language without touching
+   week-specific tool styles (calculators, simulators, etc.).
+   ============================================================ */
+
+:root {
+  --bsa-yellow:  #FCD116;
+  --bsa-red:     #CE1126;
+  --bsa-blue:    #003893;
+  --bsa-bg:      #1a1a1a;
+  --bsa-panel:   #20232a;
+  --bsa-panel-2: #2a2e38;
+  --bsa-line:    #353a46;
+  --bsa-text:    #e8ecf3;
+  --bsa-muted:   #aab2c0;
+  --bsa-link:    #7cc4ff;
+}
+
+/* --- Top flag stripe (consistent on every page) --- */
+body::before {
+  content: "";
+  display: block;
+  height: 3px;
+  background: linear-gradient(90deg, var(--bsa-yellow) 0%, var(--bsa-yellow) 50%, var(--bsa-blue) 50%, var(--bsa-blue) 75%, var(--bsa-red) 75%, var(--bsa-red) 100%);
+  margin: -1rem -1rem 1.25rem;
+}
+
+/* --- Container width (slightly tightened for readability) --- */
+.container {
+  max-width: 820px;
+}
+
+/* --- Back link: matches homepage-v2 secondary button feel --- */
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 8px;
+  background: rgba(252, 209, 22, 0.06);
+  border: 1px solid rgba(252, 209, 22, 0.18);
+  color: var(--bsa-yellow);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.92rem;
+  margin-bottom: 1.5rem;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+.back-link:hover {
+  background: rgba(252, 209, 22, 0.12);
+  border-color: rgba(252, 209, 22, 0.32);
+  transform: translateX(-3px);
+}
+
+/* --- Week badge / kicker label --- */
+.week-badge,
+.badge-sim {
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(252, 209, 22, 0.32);
+  background: rgba(252, 209, 22, 0.08);
+  color: var(--bsa-yellow);
+}
+
+/* --- Headers: tighter, more breathable --- */
+.header,
+.page-header {
+  text-align: left;
+  margin-bottom: 1.6rem;
+}
+.header .week-title,
+.page-header .page-title,
+h1.week-title,
+h1.page-title {
+  font-size: clamp(1.8rem, 4.2vw, 2.2rem);
+  line-height: 1.18;
+  letter-spacing: -0.005em;
+  margin: 0.5rem 0 0.55rem;
+}
+.week-subtitle,
+.page-sub {
+  color: #cfd6e3;
+  font-size: 1.02rem;
+  line-height: 1.5;
+  max-width: 640px;
+}
+
+/* --- Section cards: lighter borders, gentler shadows --- */
+.section-card,
+.program-lesson-section {
+  border-width: 1px;
+  border-color: var(--bsa-line);
+  border-radius: 14px;
+  background: var(--bsa-panel);
+  box-shadow: 0 1px 0 rgba(255,255,255,0.02) inset;
+}
+.section-card:not(:last-child),
+.program-lesson-section:not(:last-child) {
+  margin-bottom: 1.25rem;
+}
+.section-title,
+.program-lesson-title {
+  font-size: 1.18rem;
+  letter-spacing: -0.003em;
+}
+
+/* --- "Idea clave" callout: subtler, no harsh red unless intentional --- */
+.idea-clave,
+.program-lesson-section--callout {
+  background: rgba(252, 209, 22, 0.05);
+  border: 1px solid rgba(252, 209, 22, 0.22);
+  border-left: 3px solid var(--bsa-yellow);
+  border-radius: 0 12px 12px 0;
+}
+.idea-clave-label {
+  color: var(--bsa-muted);
+  letter-spacing: 0.12em;
+}
+
+/* --- Lists: tighter, more readable --- */
+.program-lesson-list li::before {
+  color: var(--bsa-yellow);
+}
+
+/* --- Details / accordions: matches homepage-v2 polish --- */
+details.program-lesson-details,
+details {
+  border-radius: 10px;
+  border: 1px solid var(--bsa-line);
+  background: rgba(255,255,255,0.02);
+  padding: 0;
+  overflow: hidden;
+}
+details > summary,
+details.program-lesson-details > summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--bsa-yellow);
+  font-weight: 600;
+}
+details > summary::-webkit-details-marker,
+details.program-lesson-details > summary::-webkit-details-marker {
+  display: none;
+}
+details > summary::after,
+details.program-lesson-details > summary::after {
+  content: "›";
+  color: var(--bsa-muted);
+  font-size: 1.2rem;
+  line-height: 1;
+  transition: transform 0.18s ease;
+}
+details[open] > summary::after,
+details[open].program-lesson-details > summary::after {
+  transform: rotate(90deg);
+}
+details[open] > summary,
+details[open].program-lesson-details > summary {
+  border-bottom: 1px solid var(--bsa-line);
+}
+
+/* --- Bridge sections (between major blocks) --- */
+.program-lesson-bridge,
+.bridge {
+  background: linear-gradient(180deg, var(--bsa-panel-2) 0%, var(--bsa-panel) 100%);
+  border: 1px solid var(--bsa-line);
+  border-radius: 14px;
+  padding: 18px 20px;
+}
+.program-lesson-bridge-title,
+.bridge h3 {
+  color: var(--bsa-yellow);
+  margin-top: 0;
+  font-size: 1.05rem;
+}
+
+/* --- Generic v2 buttons (new components, available if a week wants them) --- */
+.btn,
+.cta-btn {
+  display: inline-block;
+  padding: 12px 18px;
+  border-radius: 10px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.96rem;
+  border: 1px solid transparent;
+  transition: filter 0.15s ease, transform 0.15s ease;
+}
+.btn-primary,
+.cta-btn--primary {
+  background: var(--bsa-yellow);
+  color: #1a1300;
+  box-shadow: 0 4px 14px rgba(252, 209, 22, 0.18);
+}
+.btn-secondary,
+.cta-btn--secondary {
+  background: transparent;
+  color: var(--bsa-text);
+  border-color: var(--bsa-line);
+}
+.btn:hover,
+.cta-btn:hover {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+}
+
+/* --- "Es esto para mí" gate component (new) --- */
+.for-you {
+  background: var(--bsa-panel);
+  border: 1px solid var(--bsa-line);
+  border-radius: 14px;
+  padding: 18px 20px;
+  margin: 20px 0;
+}
+.for-you h3 {
+  margin-top: 0;
+  color: var(--bsa-yellow);
+  font-size: 1.05rem;
+}
+.for-you .row {
+  display: flex;
+  gap: 10px;
+  margin: 8px 0;
+  align-items: flex-start;
+  color: #d6dce8;
+  font-size: 0.96rem;
+}
+.for-you .row span:first-child {
+  flex: 0 0 22px;
+  color: #22c55e;
+  font-weight: 700;
+}
+
+/* --- Preview boxes (e.g. calculator output samples) --- */
+.preview {
+  background: #0b0d12;
+  border: 1px solid var(--bsa-line);
+  border-radius: 10px;
+  padding: 14px 16px;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 13.5px;
+  color: #cfd6e3;
+  line-height: 1.55;
+}
+.preview .label {
+  color: var(--bsa-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: block;
+  margin-bottom: 6px;
+  font-family: -apple-system, sans-serif;
+}
+
+/* --- Closing punch box --- */
+.close-punch {
+  background: var(--bsa-panel);
+  border: 1px solid var(--bsa-line);
+  border-radius: 14px;
+  padding: 22px;
+  margin: 30px 0 10px;
+  text-align: center;
+}
+.close-punch p.punch {
+  font-size: 1.12rem;
+  line-height: 1.5;
+  color: var(--bsa-text);
+  max-width: 560px;
+  margin: 0 auto 14px;
+}
+
+/* --- Inline link color in body text --- */
+.program-lesson-text a,
+.section-text a,
+.section-body a,
+p a {
+  color: var(--bsa-link);
+}
+
+/* --- Quiet footer (for week pages that have none) --- */
+.v2-footer {
+  margin-top: 36px;
+  padding: 22px 0;
+  text-align: center;
+  color: var(--bsa-muted);
+  font-size: 0.82rem;
+  border-top: 1px solid var(--bsa-line);
+}
+
+/* --- Mobile breakpoints --- */
+@media (max-width: 680px) {
+  .header .week-title,
+  .page-header .page-title,
+  h1.week-title,
+  h1.page-title { font-size: 1.55rem; }
+  .week-subtitle,
+  .page-sub { font-size: 0.96rem; }
+  .for-you,
+  .program-lesson-bridge,
+  .bridge,
+  .close-punch { padding: 16px; }
+}

--- a/programa-colombia/semana-1/index.html
+++ b/programa-colombia/semana-1/index.html
@@ -826,6 +826,7 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">

--- a/programa-colombia/semana-10/experimento-dos-economias/index.html
+++ b/programa-colombia/semana-10/experimento-dos-economias/index.html
@@ -133,6 +133,8 @@
         }
         body::before { content:""; display:block; height:3px; background:linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
     </style>
+    <link rel="stylesheet" href="../../lesson-structure.css">
+    <link rel="stylesheet" href="../../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">

--- a/programa-colombia/semana-10/index.html
+++ b/programa-colombia/semana-10/index.html
@@ -455,6 +455,7 @@
             .section-card, .program-lesson-section, .recap-bridge, .calculator-box, .sim-bridge, .closure-box { padding: 1.2rem; }
         }
     </style>
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">

--- a/programa-colombia/semana-2/index.html
+++ b/programa-colombia/semana-2/index.html
@@ -108,6 +108,7 @@
         }
         body::before { content:""; display:block; height:3px; background:linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
     </style>
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">

--- a/programa-colombia/semana-3/index.html
+++ b/programa-colombia/semana-3/index.html
@@ -212,6 +212,7 @@
         .idea-clave-text { font-size:1.05rem; font-weight:700; color:var(--light); line-height:1.5; }
         body::before { content:""; display:block; height:3px; background:linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
     </style>
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">

--- a/programa-colombia/semana-4/index.html
+++ b/programa-colombia/semana-4/index.html
@@ -164,6 +164,8 @@
         }
         body::before { content:""; display:block; height:3px; background:linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
     </style>
+    <link rel="stylesheet" href="../lesson-structure.css">
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">

--- a/programa-colombia/semana-5/index.html
+++ b/programa-colombia/semana-5/index.html
@@ -173,6 +173,7 @@
         }
         body::before { content:""; display:block; height:3px; background:linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
     </style>
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">

--- a/programa-colombia/semana-6/index.html
+++ b/programa-colombia/semana-6/index.html
@@ -151,6 +151,8 @@
         }
         body::before { content:""; display:block; height:3px; background:linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
     </style>
+    <link rel="stylesheet" href="../lesson-structure.css">
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
 <div class="container">

--- a/programa-colombia/semana-7/index.html
+++ b/programa-colombia/semana-7/index.html
@@ -150,6 +150,7 @@
         }
         body::before { content:""; display:block; height:3px; background:linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
     </style>
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">

--- a/programa-colombia/semana-8/index.html
+++ b/programa-colombia/semana-8/index.html
@@ -325,6 +325,7 @@
             .section-card, .program-lesson-section { padding: 1.2rem; }
         }
     </style>
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">

--- a/programa-colombia/semana-9/index.html
+++ b/programa-colombia/semana-9/index.html
@@ -139,6 +139,7 @@
 
         body::before { content:""; display:block; height:3px; background:linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
     </style>
+    <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
- programa-colombia-v2.css: enhancement layer loaded after each week's inline <style> so the common shell aligns with homepage-v2
- All 10 weeks + experimento patched to load it before </head>
- semana-4, semana-6: added missing lesson-structure.css link
- Homepage + corporate page: palette aligned to Colombian flag with hard-stop 3-stripe top bar
- .gitignore: block .env* files from future commits