### PR TITLE
Semana 2: bridge between sem-1 and sem-3, with neutral incidence framing

### DIFF
--- a/archive/semana-2-bridge-2026-05/semana-2.previous.html
+++ b/archive/semana-2-bridge-2026-05/semana-2.previous.html
@@ -3,640 +3,348 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Semana 2: Entender mi pago con claridad | Programa Colombia</title>
-    <meta name="description" content="Decodificador de comprobante de nómina. Entiende descuentos, retenciones, y cuánto dinero te queda realmente disponible.">
+    <title>Semana 2: ¿Con qué dinero cuento de verdad? | Programa Colombia</title>
+    <meta name="description" content="Tres números distintos viven dentro de tu salario. Esta semana los separas para saber cuánto puedes realmente organizar.">
     <style>
         :root {
-            --primary: #FCD116;
-            --dark: #1a1a1a;
-            --dark2: #2d2d2d;
-            --light: #e0e0e0;
-            --dim: #b3b3b3;
-            --red: #ef4444;
-            --yellow: #fcd116;
-            --grad: #FCD116;
+            --primary: #FCD116; --dark: #1a1a1a; --dark2: #2d2d2d;
+            --light: #e0e0e0; --dim: #b3b3b3; --red: #CE1126; --blue: #003893;
+            --yellow: #fcd116; --green: #22c55e; --grad: #FCD116;
         }
-        * { margin:0; padding:0; box-sizing:border-box; }
-        body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; padding:1rem; }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--dark); color: var(--light); line-height: 1.6; padding: 1rem; }
+        body::before { content: ""; display: block; height: 3px; background: linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
+        .container { max-width: 820px; margin: 0 auto; }
+        .back-link { display: inline-flex; align-items: center; gap: 0.5rem; color: var(--primary); text-decoration: none; margin-bottom: 1.5rem; font-weight: 600; transition: transform 0.2s; }
+        .back-link:hover { transform: translateX(-4px); }
 
-        .container { max-width:820px; margin:0 auto; }
-        .back-link { display:inline-flex; align-items:center; gap:0.5rem; color:var(--primary); text-decoration:none; margin-bottom:2rem; font-weight:600; transition:transform 0.2s; }
-        .back-link:hover { transform:translateX(-4px); }
-        
-        .header { text-align:center; margin-bottom:3rem; }
-        .week-title { font-size:2.5rem; color:var(--primary); margin-bottom:0.5rem; }
-        .week-subtitle { font-size:1.2rem; color:var(--dim); margin-bottom:2rem; }
-        
-        .intro-section { background:var(--dark2); border:2px solid rgba(252,209,22,0.2); border-radius:1rem; padding:2rem; margin-bottom:3rem; }
-        .intro-title { font-size:1.8rem; color:var(--primary); margin-bottom:1rem; }
-        .intro-text { color:var(--dim); font-size:1.1rem; margin-bottom:2rem; }
-        
-        .comparison-section { background:linear-gradient(135deg,rgba(252,209,22,0.1) 0%,rgba(252,209,22,0.1) 100%); border:2px solid var(--primary); border-radius:1rem; padding:3rem 2rem; margin:3rem 0; }
-        .comp-title { font-size:2rem; color:var(--primary); margin-bottom:1rem; text-align:center; }
-        .comp-description { color:var(--dim); font-size:1.1rem; margin-bottom:2rem; text-align:center; max-width:600px; margin-left:auto; margin-right:auto; }
-        
-        .employment-types { display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:1rem; margin-top:2rem; }
-        .employment-card { width:100%; background:var(--dark); border:2px solid rgba(252,209,22,0.15); border-radius:1rem; padding:1.4rem; transition:all 0.3s; text-align:left; color:inherit; cursor:pointer; }
-        .employment-card:hover { border-color:var(--primary); transform:translateY(-2px); }
-        .employment-card.is-active { border-color:var(--primary); background:rgba(252,209,22,0.06); box-shadow:0 10px 24px rgba(0,0,0,0.15); }
-        .employment-card:focus-visible { outline:2px solid rgba(252,209,22,0.5); outline-offset:2px; }
-        .employment-title { color:var(--primary); font-size:1.2rem; font-weight:700; margin-bottom:0.8rem; text-align:left; }
-        .employment-features { display:block; margin-bottom:1.5rem; }
-        .employment-feature { display:block; color:var(--dim); padding:0.5rem 0 0.5rem 1.5rem; position:relative; }
-        .employment-feature::before { content:'•'; position:absolute; left:0; color:var(--primary); font-weight:bold; }
-        .employment-note { color:var(--dim); font-size:0.95rem; line-height:1.7; margin-top:1.2rem; }
-        
-        .calculator-section { background:var(--dark2); border:2px solid rgba(252,209,22,0.15); border-radius:1rem; padding:2rem; margin:2rem 0; }
-        .calc-title { font-size:1.8rem; color:var(--primary); margin-bottom:1rem; text-align:center; }
-        .calc-description { color:var(--dim); font-size:1rem; margin-bottom:2rem; text-align:center; }
-        
-        .calc-input-section { display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:2rem; margin-bottom:2rem; }
-        .calc-input-group { }
-        .calc-label { display:block; color:var(--light); font-weight:600; margin-bottom:0.5rem; }
-        .calc-input { width:100%; padding:0.75rem; background:var(--dark); border:2px solid rgba(252,209,22,0.3); border-radius:0.5rem; color:var(--light); font-size:1rem; font-family:'Courier New',monospace; }
-        .calc-input:focus { outline:none; border-color:var(--primary); }
-        .calc-select { width:100%; padding:0.75rem; background:var(--dark); border:2px solid rgba(252,209,22,0.3); border-radius:0.5rem; color:var(--light); font-size:1rem; }
-        .calc-preview { display:block; color:var(--dim); font-size:0.85rem; margin-top:0.5rem; }
-        .mode-summary { background:var(--dark); border:2px solid rgba(252,209,22,0.2); border-radius:0.75rem; padding:1rem; min-height:100%; }
-        .mode-chip { display:inline-flex; align-items:center; gap:0.4rem; padding:0.35rem 0.7rem; background:rgba(252,209,22,0.15); color:var(--primary); border-radius:999px; font-size:0.82rem; font-weight:700; margin-bottom:0.65rem; }
-        .mode-copy { color:var(--dim); font-size:0.92rem; line-height:1.6; }
-        .helper-card { background:rgba(252,209,22,0.06); border:1px solid rgba(252,209,22,0.2); border-radius:0.75rem; padding:1rem; }
-        .helper-card-title { color:var(--light); font-size:0.95rem; font-weight:700; margin-bottom:0.35rem; }
-        .helper-card-copy { color:var(--dim); font-size:0.85rem; line-height:1.6; }
-        
-        .paycheck-breakdown { background:var(--dark); border:2px solid var(--primary); border-radius:1rem; padding:2rem; margin-top:2rem; }
-        .breakdown-title { color:var(--primary); font-size:1.5rem; margin-bottom:1.5rem; text-align:center; }
-        .breakdown-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:1rem; }
-        .breakdown-item { background:var(--dark2); border:1px solid rgba(252,209,22,0.2); border-radius:0.5rem; padding:1.5rem; }
-        .breakdown-label { color:var(--dim); font-size:0.9rem; margin-bottom:0.5rem; }
-        .breakdown-amount { color:var(--primary); font-size:1.3rem; font-weight:700; font-family:'Courier New',monospace; }
-        .breakdown-percentage { color:var(--dim); font-size:0.8rem; margin-top:0.25rem; }
-        
-        .final-result { background:linear-gradient(135deg,rgba(252,209,22,0.2) 0%,rgba(252,209,22,0.1) 100%); border:3px solid var(--yellow); border-radius:1rem; padding:2rem; margin-top:2rem; text-align:center; }
-        .final-amount { color:var(--yellow); font-size:3rem; font-weight:900; font-family:'Courier New',monospace; margin-bottom:0.5rem; }
-        .final-label { color:var(--light); font-size:1.2rem; font-weight:600; margin-bottom:1rem; }
-        .final-note { color:var(--dim); font-size:0.9rem; }
-        
-        .deduction-explanation { background:var(--dark2); border:2px solid rgba(252,209,22,0.15); border-radius:1rem; padding:2rem; margin:2rem 0; }
-        .explanation-title { font-size:1.5rem; color:var(--primary); margin-bottom:1rem; }
-        .deduction-grid { display:grid; gap:1rem; margin-top:1rem; }
-        .deduction-item { background:var(--dark); border-left:4px solid var(--primary); padding:1rem; border-radius:0.25rem; }
-        .deduction-name { color:var(--primary); font-weight:600; margin-bottom:0.5rem; }
-        .deduction-description { color:var(--dim); font-size:0.9rem; }
-        .optional-details { border:1px solid rgba(252,209,22,0.24); border-radius:0.9rem; background:rgba(255,255,255,0.02); }
-        .optional-details summary { list-style:none; cursor:pointer; padding:1rem 1.1rem; }
-        .optional-details summary::-webkit-details-marker { display:none; }
-        .optional-summary-title { display:block; color:var(--yellow); font-weight:700; margin-bottom:0.2rem; }
-        .optional-summary-copy { display:block; color:var(--dim); font-size:0.9rem; line-height:1.55; }
-        .optional-body { padding:0 1.1rem 1.1rem; }
-        
-        .tip-box { background:rgba(252,209,22,0.1); border:2px solid var(--yellow); border-radius:0.75rem; padding:1.5rem; margin:2rem 0; }
-        .tip-header { color:var(--yellow); font-weight:700; margin-bottom:0.5rem; display:flex; align-items:center; gap:0.5rem; }
-        
-        .next-week { background:var(--dark2); border:2px solid var(--primary); border-radius:1rem; padding:2rem; margin-top:2rem; text-align:center; }
-        .next-week h3 { color:var(--primary); margin-bottom:1rem; }
-        
-        .btn { padding:1rem 2rem; border:none; border-radius:0.75rem; font-weight:700; font-size:1.1rem; cursor:pointer; transition:all 0.3s; text-decoration:none; display:inline-block; }
-        .btn-primary { background:var(--grad); color:#1a1a1a; }
-        .btn-primary:hover { background:#e6830e; transform:translateY(-2px); }
-        
-        @media (max-width:768px) {
-            .calc-input-section { grid-template-columns:1fr; }
-            .breakdown-grid { grid-template-columns:1fr; }
-            .final-amount { font-size:2.5rem; }
+        .header { text-align: center; margin-bottom: 2.25rem; }
+        .week-badge { display: inline-block; background: rgba(252,209,22,0.15); border: 1px solid var(--primary); border-radius: 2rem; padding: 0.3rem 1rem; font-size: 0.85rem; color: var(--primary); margin-bottom: 1rem; }
+        .week-title { font-size: 2.2rem; color: var(--primary); margin-bottom: 0.5rem; line-height: 1.2; letter-spacing: -0.005em; }
+        .week-subtitle { font-size: 1.05rem; color: var(--light); font-weight: 500; }
+
+        .section { margin-bottom: 2rem; }
+
+        .intro { background: var(--dark2); border-radius: 1rem; padding: 1.5rem 1.6rem; }
+        .intro p { color: var(--dim); font-size: 1rem; line-height: 1.75; margin-bottom: 0.6rem; }
+        .intro p:last-child { margin-bottom: 0; }
+        .intro p strong { color: var(--light); }
+
+        .idea-clave { background: rgba(252,209,22,0.06); border: 1px solid rgba(252,209,22,0.25); border-left: 4px solid var(--primary); border-radius: 0 0.75rem 0.75rem 0; padding: 1.15rem 1.4rem; }
+        .idea-clave-label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.09em; color: rgba(252,209,22,0.6); margin-bottom: 0.45rem; }
+        .idea-clave-text { font-size: 1.05rem; font-weight: 700; color: var(--light); line-height: 1.55; }
+
+        .section-heading { font-size: 1.25rem; font-weight: 700; color: var(--light); margin-bottom: 0.6rem; letter-spacing: -0.003em; }
+        .section-body { color: var(--dim); font-size: 0.97rem; line-height: 1.75; margin-bottom: 0.7rem; }
+        .section-body:last-child { margin-bottom: 0; }
+        .section-body strong { color: var(--light); }
+
+        /* Cascade visualization — the three numbers visibly shrink */
+        .cascade { display: grid; gap: 0.6rem; margin-top: 1rem; }
+        .cascade-row { display: flex; align-items: center; gap: 0.85rem; padding: 1rem 1.15rem; border-radius: 0.9rem; transition: all 0.2s; }
+        .cascade-row.bruto    { background: rgba(252,209,22,0.04); border: 1px solid rgba(252,209,22,0.18); }
+        .cascade-row.llega    { background: rgba(252,209,22,0.06); border: 1px solid rgba(252,209,22,0.30); margin-left: 1.5rem; }
+        .cascade-row.disponible { background: rgba(34,197,94,0.07); border: 2px solid rgba(34,197,94,0.45); margin-left: 3rem; }
+        .cascade-tag { font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--dim); flex-shrink: 0; min-width: 64px; }
+        .cascade-row.disponible .cascade-tag { color: var(--green); }
+        .cascade-name { flex: 1; color: var(--light); font-size: 0.95rem; font-weight: 600; }
+        .cascade-value { font-family: 'Courier New', monospace; font-weight: 800; font-size: 1.15rem; color: var(--primary); flex-shrink: 0; text-align: right; min-width: 110px; }
+        .cascade-row.disponible .cascade-value { color: var(--green); font-size: 1.3rem; }
+        @media (max-width: 540px) {
+            .cascade-row.llega { margin-left: 0.6rem; }
+            .cascade-row.disponible { margin-left: 1.2rem; }
+            .cascade-tag { min-width: 56px; font-size: 0.6rem; }
+            .cascade-value { font-size: 1rem; min-width: 90px; }
         }
-        body::before { content:""; display:block; height:3px; background:linear-gradient(90deg, #FCD116, #003893 50%, #CE1126); }
+
+        /* Calculator */
+        .calc { background: var(--dark2); border: 2px solid rgba(252,209,22,0.2); border-radius: 1rem; padding: 1.75rem; }
+        .calc-title { font-size: 1.15rem; color: var(--primary); margin-bottom: 0.4rem; font-weight: 700; }
+        .calc-desc { color: var(--dim); font-size: 0.9rem; margin-bottom: 1.25rem; line-height: 1.65; }
+        .calc-inputs { display: grid; gap: 1rem; margin-bottom: 1rem; }
+        .calc-field label { display: block; color: var(--light); font-size: 0.92rem; font-weight: 600; margin-bottom: 0.4rem; }
+        .calc-field input { width: 100%; padding: 0.7rem 0.85rem; background: var(--dark); border: 2px solid rgba(252,209,22,0.25); border-radius: 0.55rem; color: var(--light); font-size: 1.05rem; font-family: 'Courier New', monospace; }
+        .calc-field input:focus { outline: none; border-color: var(--primary); }
+        .calc-field .hint { color: var(--dim); font-size: 0.82rem; margin-top: 0.4rem; line-height: 1.55; }
+        .calc-field .hint strong { color: var(--light); }
+
+        .calc-breakdown { margin-top: 1.5rem; padding-top: 1.25rem; border-top: 1px solid rgba(252,209,22,0.15); }
+        .calc-breakdown-label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--dim); margin-bottom: 0.75rem; }
+
+        /* Optional employer-cost accordion */
+        .opt-details { background: var(--dark2); border: 1px solid rgba(252,209,22,0.18); border-radius: 0.875rem; padding: 0; overflow: hidden; margin-top: 1.25rem; }
+        .opt-details summary { padding: 1rem 1.2rem; cursor: pointer; list-style: none; display: flex; justify-content: space-between; align-items: center; gap: 0.75rem; }
+        .opt-details summary::-webkit-details-marker { display: none; }
+        .opt-summary-title { color: var(--primary); font-weight: 700; font-size: 0.95rem; }
+        .opt-summary-copy { display: block; color: var(--dim); font-size: 0.82rem; line-height: 1.55; margin-top: 0.2rem; }
+        .opt-chev { color: var(--dim); font-size: 1rem; transition: transform 0.2s; flex-shrink: 0; }
+        .opt-details[open] .opt-chev { transform: rotate(90deg); }
+        .opt-body { padding: 0 1.2rem 1.2rem; border-top: 1px solid rgba(252,209,22,0.1); padding-top: 1rem; }
+        .opt-row { display: flex; justify-content: space-between; padding: 0.5rem 0; border-bottom: 1px dashed rgba(252,209,22,0.08); font-size: 0.9rem; }
+        .opt-row:last-child { border-bottom: none; }
+        .opt-row .k { color: var(--dim); }
+        .opt-row .v { color: var(--yellow); font-family: 'Courier New', monospace; font-weight: 700; }
+        .opt-row.total { margin-top: 0.5rem; padding-top: 0.75rem; border-top: 2px solid rgba(252,209,22,0.3); border-bottom: none; }
+        .opt-row.total .k { color: var(--light); font-weight: 700; }
+        .opt-row.total .v { color: var(--primary); font-size: 1.05rem; }
+        .opt-note { color: var(--dim); font-size: 0.85rem; line-height: 1.65; margin-top: 0.9rem; padding-top: 0.9rem; border-top: 1px solid rgba(252,209,22,0.08); }
+
+        /* Reflection */
+        .reflect { background: rgba(252,209,22,0.04); border: 2px solid rgba(252,209,22,0.2); border-radius: 1rem; padding: 1.5rem 1.6rem; }
+        .reflect-title { font-size: 1.1rem; color: var(--primary); font-weight: 700; margin-bottom: 0.5rem; }
+        .reflect-q { color: var(--light); font-weight: 600; font-size: 0.97rem; margin-bottom: 0.6rem; line-height: 1.55; }
+        .reflect textarea { width: 100%; padding: 0.7rem; background: var(--dark); border: 2px solid rgba(252,209,22,0.2); border-radius: 0.5rem; color: var(--light); font-family: inherit; font-size: 0.94rem; resize: vertical; min-height: 80px; }
+        .reflect textarea:focus { outline: none; border-color: var(--primary); }
+
+        /* Next week */
+        .next-week { background: var(--dark2); border: 2px solid var(--primary); border-radius: 1rem; padding: 1.5rem 1.6rem; text-align: center; }
+        .next-week h3 { color: var(--primary); margin-bottom: 0.5rem; font-size: 1.1rem; }
+        .next-week p { color: var(--dim); margin-bottom: 1.1rem; font-size: 0.97rem; line-height: 1.7; }
+        .btn { padding: 0.85rem 1.75rem; border: none; border-radius: 0.75rem; font-weight: 700; font-size: 0.94rem; cursor: pointer; transition: all 0.3s; text-decoration: none; display: inline-block; }
+        .btn-primary { background: var(--grad); color: #1a1a1a; }
+        .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(252,209,22,0.4); }
+
+        .footnote { color: var(--dim); font-size: 0.78rem; line-height: 1.55; text-align: center; opacity: 0.7; margin-top: 1.5rem; }
+
+        @media (max-width: 540px) {
+            .week-title { font-size: 1.7rem; }
+            .calc { padding: 1.2rem; }
+        }
     </style>
     <link rel="stylesheet" href="../lesson-structure.css">
     <link rel="stylesheet" href="../programa-colombia-v2.css">
 </head>
 <body>
-    <div class="container">
-        <a href="../" class="back-link">← Volver al Programa</a>
-        
-        <div class="header">
-            <h1 class="week-title">Semana 2: Entender mi pago con claridad</h1>
-            <p class="week-subtitle">Aprende a leer una nómina o un ingreso variable para saber con cuánto dinero cuentas realmente.</p>
-        </div>
+<div class="container">
+    <a href="../" class="back-link">← Volver al Programa</a>
 
-        <div class="intro-section">
-            <p class="intro-text">
-                Llega el pago. Ves el número y sientes alivio. Pero después:<br>
-                ¿Cuánto de esto puedo usar de verdad? ¿Qué parte ya está comprometida? ¿Por qué entra una cantidad y al final queda mucho menos?
-            </p>
-        </div>
-        
-        <div class="tip-box" style="background: rgba(252,209,22,0.15); border: 2px solid var(--yellow); margin: 2rem 0;">
-            <div class="tip-header" style="font-size: 1.1rem; margin-bottom: 0.75rem;">
-                💡 Idea clave de la semana
-            </div>
-            <div style="color: var(--light); font-size: 1rem; font-weight: 600;">
-                No basta con saber cuánto entra. También necesitas saber cuánto queda realmente disponible después de descuentos y compromisos.
-            </div>
-        </div>
-        
-        <div class="comparison-section">
-            <h2 class="comp-title">Empieza por la forma en que te entra el dinero</h2>
-            <p class="comp-description">
-                La idea no es encajarte en una etiqueta. Es elegir la ruta que más se parece a tu realidad para ver dónde se enreda el dinero: en descuentos automáticos o en separaciones que te toca hacer por tu cuenta.
-            </p>
-
-            <div class="employment-types">
-                <button type="button" class="employment-card is-active" id="path-formal" onclick="setIncomeMode('formal')">
-                    <span class="employment-title">🏢 Trabajo formal</span>
-                    <span class="employment-features">
-                        <span class="employment-feature">Sirve si te pagan por nómina o con desprendible</span>
-                        <span class="employment-feature">Salud y pensión suelen salir automáticamente</span>
-                        <span class="employment-feature">El foco es distinguir salario total vs dinero libre</span>
-                    </span>
-                </button>
-                
-                <button type="button" class="employment-card" id="path-informal" onclick="setIncomeMode('informal')">
-                    <span class="employment-title">🚶 Trabajo informal o independiente</span>
-                    <span class="employment-features">
-                        <span class="employment-feature">Sirve si vendes, haces turnos o el ingreso cambia</span>
-                        <span class="employment-feature">El foco es separar primero lo que no conviene gastar</span>
-                        <span class="employment-feature">Ayuda a ver cuánto queda usable en un mes normal</span>
-                    </span>
-                </button>
-            </div>
-            <p class="employment-note" id="employment-note">Ruta activa: nómina formal. Aquí miraremos descuentos automáticos, otros compromisos y el dinero que realmente queda libre.</p>
-        </div>
-
-        <div class="calculator-section">
-            <h2 class="calc-title">🧮 Calculadora de dinero disponible</h2>
-            <p class="calc-description" id="calc-description">Usa esta ruta si quieres mirar un pago de nómina y ver qué parte desaparece antes de que puedas usarla.</p>
-
-            <div class="calc-input-section">
-                <div class="calc-input-group">
-                    <span class="calc-label">Ruta activa</span>
-                    <div class="mode-summary">
-                        <div class="mode-chip" id="employment-type-label">Pago por nómina</div>
-                        <p class="mode-copy" id="employment-type-help">Te mostraremos salud, pensión y otros descuentos que reducen el dinero libre del mes.</p>
-                    </div>
-                    <input type="hidden" id="employment-type" value="formal">
-                </div>
-                
-                <div class="calc-input-group">
-                    <label class="calc-label" for="gross-salary" id="gross-salary-label">Ingreso mensual hipotético:</label>
-                    <input type="number" id="gross-salary" class="calc-input" placeholder="2.000.000" min="0" oninput="calculateTakeHome()">
-                    <small class="calc-preview" id="gross-salary-guidance">Si tienes desprendible, usa el valor antes de descuentos.</small>
-                    <small class="calc-preview" id="gross-salary-preview">$0</small>
-                </div>
-                
-                <div class="calc-input-group" id="formal-options">
-                    <span class="calc-label">Lectura rápida de la nómina</span>
-                    <div class="helper-card">
-                        <div class="helper-card-title" id="salary-range-title">Con este ejemplo, lo más visible suelen ser salud y pensión.</div>
-                        <div class="helper-card-copy" id="salary-range-copy">Si el ingreso sube, también puede empezar a aparecer retención. Aquí la calculadora la estima automáticamente solo como referencia educativa.</div>
-                    </div>
-                </div>
-                
-                <div class="calc-input-group">
-                    <label class="calc-label" for="other-deductions" id="other-deductions-label">Otros descuentos o compromisos mensuales:</label>
-                    <input type="number" id="other-deductions" class="calc-input" placeholder="50.000" min="0" oninput="calculateTakeHome()">
-                    <small class="calc-preview" id="other-deductions-preview">$0</small>
-                    <small style="color:var(--dim); font-size:0.8rem;" id="other-deductions-help">Cooperativa, préstamos, seguros adicionales, etc.</small>
-                </div>
-            </div>
-
-            <div class="paycheck-breakdown" id="breakdown-section" style="display:none;">
-                <h3 class="breakdown-title">💰 Desglose de tu Pago</h3>
-                <div class="breakdown-grid" id="breakdown-grid">
-                    <!-- Se llenará con JavaScript -->
-                </div>
-                
-                <div class="final-result">
-                    <div class="final-amount" id="final-amount">$0</div>
-                    <div class="final-label">Dinero realmente disponible</div>
-                    <div class="final-note">Este es el dinero que realmente puedes gastar o ahorrar cada mes</div>
-                </div>
-            </div>
-            
-            <div id="interpretation-section" style="background: var(--dark2); border: 2px solid rgba(252,209,22,0.15); border-radius: 1rem; padding: 2rem; margin: 2rem 0; display:none;">
-                <h3 style="font-size: 1.5rem; color: var(--primary); margin-bottom: 1rem;" id="interpretation-title">Lo que muestra el ejercicio</h3>
-                <p style="color: var(--dim); font-size: 1.1rem; margin-bottom: 1rem; line-height: 1.7;" id="interpretation-line-1">
-                    El total que entra es solo la mitad de la historia.
-                </p>
-                <p style="color: var(--light); font-size: 1.1rem; font-weight: 600;" id="interpretation-line-3">
-                    Ver el dinero realmente disponible cambia las decisiones del mes.
-                </p>
-            </div>
-        </div>
-
-        <div class="deduction-explanation" id="formal-explanation">
-            <h2 class="explanation-title">¿Qué significa cada descuento?</h2>
-            
-            <div class="deduction-grid">
-                <div class="deduction-item">
-                    <div class="deduction-name">Salud (EPS) - 4%</div>
-                    <div class="deduction-description">
-                        Tu contribución al sistema de salud. Te da derecho a servicios médicos básicos.
-                    </div>
-                </div>
-                
-                <div class="deduction-item">
-                    <div class="deduction-name">Pensión - 4%</div>
-                    <div class="deduction-description">
-                        Ahorro obligatorio para tu jubilación. El empleador aporta 12% adicional.
-                    </div>
-                </div>
-                
-                <div class="deduction-item">
-                    <div class="deduction-name">Retención en la Fuente</div>
-                    <div class="deduction-description">
-                        Anticipo del impuesto de renta. Solo aplica si ganas más de cierto monto.
-                    </div>
-                </div>
-                
-                <div class="deduction-item">
-                    <div class="deduction-name">Prestaciones Sociales</div>
-                    <div class="deduction-description">
-                        Prima, cesantías, vacaciones. No se descuentan del salario - son adicionales.
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="deduction-explanation" id="informal-explanation" style="display:none;">
-            <h2 class="explanation-title">¿Qué suele separarse por cuenta propia?</h2>
-            <p style="color: var(--dim); line-height: 1.7; margin-bottom: 1rem;">
-                Si el dinero llega por ventas, turnos, encargos o trabajos independientes, el reto no suele ser leer un descuento automático. El reto es separar a tiempo lo que no conviene gastar de una.
-            </p>
-            <div class="deduction-grid">
-                <div class="deduction-item">
-                    <div class="deduction-name">Salud, aportes o cuidado básico</div>
-                    <div class="deduction-description">
-                        Algunas personas apartan una parte para salud, seguridad social o gastos básicos que no pueden dejar para después.
-                    </div>
-                </div>
-                <div class="deduction-item">
-                    <div class="deduction-name">Mes flojo o semana lenta</div>
-                    <div class="deduction-description">
-                        Cuando el ingreso cambia, guardar una parte para el siguiente bajón da más estabilidad que esperar a que sobre.
-                    </div>
-                </div>
-                <div class="deduction-item">
-                    <div class="deduction-name">Compromisos que salen apenas entra el dinero</div>
-                    <div class="deduction-description">
-                        Deudas, mercado, arriendo o apoyo a la casa pueden comerse el ingreso rápido aunque no aparezcan como descuento formal.
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="deduction-explanation" id="employer-cost-section" style="border-color: rgba(252,209,22,0.3); margin-top:0;">
-            <details class="optional-details">
-                <summary>
-                    <span class="optional-summary-title">Opcional: ver el costo total del empleo formal</span>
-                    <span class="optional-summary-copy">Esto no es lo principal de la semana. Ábrelo solo si quieres entender lo que no siempre se ve en el recibo.</span>
-                </summary>
-                <div class="optional-body">
-                    <p style="color: var(--dim); margin-bottom: 1rem; line-height: 1.8; font-size: 1rem;">
-                        Cuando una persona trabaja de forma formal, el valor que recibe no siempre muestra toda la compensación asociada a ese trabajo. Los números de este ejercicio siguen siendo hipotéticos.
-                    </p>
-                    <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem; margin-bottom:1.5rem;">
-                        <div>
-                            <label class="calc-label" for="employer-salary">Ingreso mensual hipotético:</label>
-                            <input type="number" id="employer-salary" class="calc-input" value="1500000" oninput="calcEmployerCost()">
-                        </div>
-                        <div style="display:flex; align-items:flex-end; padding-bottom:0.1rem;">
-                            <button type="button" onclick="calcEmployerCost()" style="width:100%; padding:0.75rem; background:#FCD116; color:#1a1a1a; border:none; border-radius:0.5rem; font-weight:700; font-size:1rem; cursor:pointer;">Calcular →</button>
-                        </div>
-                    </div>
-                    <div id="employer-cost-result" style="display:none;">
-                        <div style="background:var(--dark); border:2px solid var(--primary); border-radius:0.75rem; padding:1.5rem; margin-bottom:1rem;">
-                            <div style="display:grid; gap:0.6rem;">
-                            <div style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem; background:var(--dark2); border-radius:0.4rem;">
-                                <span style="color:var(--dim); font-size:0.9rem;">Tu salario (lo que ves)</span>
-                                <span id="ec-salary" style="color:var(--light); font-family:'Courier New',monospace; font-weight:700;"></span>
-                            </div>
-                            <div style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem;">
-                                <span style="color:var(--dim); font-size:0.85rem;">+ Pensión (empleador, 12%)</span>
-                                <span id="ec-pension" style="color:var(--yellow); font-family:'Courier New',monospace;"></span>
-                            </div>
-                            <div style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem;">
-                                <span style="color:var(--dim); font-size:0.85rem;">+ Salud (empleador, 8.5%)</span>
-                                <span id="ec-health" style="color:var(--yellow); font-family:'Courier New',monospace;"></span>
-                            </div>
-                            <div style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem;">
-                                <span style="color:var(--dim); font-size:0.85rem;">+ Parafiscales (SENA+ICBF+Caja, 9%)</span>
-                                <span id="ec-para" style="color:var(--yellow); font-family:'Courier New',monospace;"></span>
-                            </div>
-                            <div style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem;">
-                                <span style="color:var(--dim); font-size:0.85rem;">+ Cesantías (8.33%)</span>
-                                <span id="ec-cesantias" style="color:var(--yellow); font-family:'Courier New',monospace;"></span>
-                            </div>
-                            <div style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem;">
-                                <span style="color:var(--dim); font-size:0.85rem;">+ Prima de servicios (8.33%)</span>
-                                <span id="ec-prima" style="color:var(--yellow); font-family:'Courier New',monospace;"></span>
-                            </div>
-                            <div style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem;">
-                                <span style="color:var(--dim); font-size:0.85rem;">+ Vacaciones (4.17%)</span>
-                                <span id="ec-vac" style="color:var(--yellow); font-family:'Courier New',monospace;"></span>
-                            </div>
-                            <div style="display:flex; justify-content:space-between; align-items:center; padding:0.5rem;">
-                                <span style="color:var(--dim); font-size:0.85rem;">+ ARL (riesgo laboral, ~1.5%)</span>
-                                <span id="ec-arl" style="color:var(--yellow); font-family:'Courier New',monospace;"></span>
-                            </div>
-                            <div style="display:flex; justify-content:space-between; align-items:center; padding:0.75rem; background:rgba(252,209,22,0.1); border-radius:0.4rem; border:1px solid rgba(252,209,22,0.3); margin-top:0.5rem;">
-                                <span style="color:var(--light); font-weight:700;">Costo total para el empleador</span>
-                                <span id="ec-total" style="color:var(--primary); font-family:'Courier New',monospace; font-weight:900; font-size:1.2rem;"></span>
-                            </div>
-                        </div>
-                        </div>
-                        <div style="background:rgba(252,209,22,0.08); border:2px solid rgba(252,209,22,0.35); border-radius:0.75rem; padding:1.25rem;">
-                            <div style="color:var(--yellow); font-weight:700; margin-bottom:0.4rem;">💡 ¿Por qué importa saber esto?</div>
-                            <p id="ec-insight" style="color:var(--dim); font-size:0.9rem; line-height:1.7;"></p>
-                        </div>
-                    </div>
-                </div>
-            </details>
-        </div>
-        
-        <div class="program-lesson-section program-lesson-section--soft">
-            <div class="program-lesson-kicker">Un paso práctico</div>
-            <h3 class="program-lesson-title program-lesson-title--small">Tu próximo pago en tres líneas</h3>
-            <div class="program-lesson-action">
-                <p class="program-lesson-text">
-                    Anota: cuánto entra, qué sale o conviene separar de inmediato, con cuánto quedas disponible. Tres líneas. Eso es todo esta semana.
-                </p>
-            </div>
-        </div>
-
-        <div style="background: var(--dark2); border: 2px solid rgba(252,209,22,0.15); border-radius: 1rem; padding: 2rem; margin: 3rem 0;">
-            <h3 style="font-size: 1.5rem; color: var(--primary); margin-bottom: 1.5rem;">Una pregunta para terminar</h3>
-            <div style="background: var(--dark); border-left: 4px solid var(--primary); padding: 1.5rem; border-radius: 0.25rem;">
-                <p style="color: var(--dim); font-size: 1rem; line-height: 1.6; margin: 0;">
-                    ¿Qué cambiaría en tus decisiones del mes si supieras exactamente cuánto te queda disponible desde el primer día?
-                </p>
-            </div>
-        </div>
-
-        <div class="next-week">
-            <h3 style="color: var(--primary); font-size: 1.5rem; margin-bottom: 1rem;">Semana 3: Deuda sin drama</h3>
-            <p style="color: var(--dim); font-size: 1.1rem; line-height: 1.7; margin-bottom: 1.5rem;">
-                Cuál deuda ayuda, cuál no, y cómo salir sin que la cuota se coma la quincena.
-            </p>
-            <a href="../semana-3/" class="btn btn-primary" style="text-decoration: none; margin-top: 1rem; display: inline-block;">Continuar a Semana 3 →</a>
-        </div>
-
-        <p style="color:var(--dim); font-size:0.78rem; line-height:1.55; text-align:center; opacity:0.7; margin-top:1.5rem;">Los números y ejemplos son ilustrativos. No representan a ninguna persona en particular.</p>
+    <div class="header">
+        <div class="week-badge">Semana 2 de 10</div>
+        <h1 class="week-title">¿Con qué dinero cuento de verdad?</h1>
+        <p class="week-subtitle">Tres números viven dentro de tu salario. Esta semana los separas.</p>
     </div>
 
-    <script>
-        const MODE_COPY = {
-            formal: {
-                note: 'Ruta activa: nómina formal. Aquí miraremos descuentos automáticos, otros compromisos y el dinero que realmente queda libre.',
-                calcDescription: 'Usa esta ruta si quieres mirar un pago de nómina y ver qué parte desaparece antes de que puedas usarla.',
-                chip: 'Pago por nómina',
-                help: 'Te mostraremos salud, pensión y otros descuentos que reducen el dinero libre del mes.',
-                grossLabel: 'Ingreso mensual hipotético:',
-                grossGuidance: 'Si tienes desprendible, usa el valor antes de descuentos.',
-                otherLabel: 'Otros descuentos o compromisos mensuales:',
-                otherHelp: 'Cooperativa, préstamos, seguros adicionales, etc.',
-                interpretationTitle: 'Lo que muestra el ejercicio',
-                interpretationLine1: 'A veces parece que hay suficiente dinero porque miramos solo el total que entra.',
-                interpretationLine2: 'Pero cuando aparecen descuentos, compromisos y gastos que deben separarse, el panorama cambia.',
-                interpretationLine3: 'Ver esto con claridad ayuda a tomar mejores decisiones.'
-            },
-            informal: {
-                note: 'Ruta activa: ingreso variable o independiente. Aquí miraremos cuánto conviene separar apenas entra el dinero para saber qué parte sí queda usable.',
-                calcDescription: 'Usa esta ruta si tus ingresos cambian o si no recibes nómina. El objetivo es separar primero lo que no conviene gastar de una.',
-                chip: 'Ingreso variable',
-                help: 'Aquí no asumimos descuentos automáticos fijos. La clave es apartar compromisos, salud o colchón apenas entra el dinero.',
-                grossLabel: 'Ingreso del mes que quieres revisar:',
-                grossGuidance: 'Si no ganas lo mismo cada mes, usa un promedio reciente o un mes real para practicar.',
-                otherLabel: 'Separaciones y compromisos del mes:',
-                otherHelp: 'Mercado, deuda, ahorro para salud, apoyo a la casa, transporte, etc.',
-                interpretationTitle: 'Lo que muestra esta ruta',
-                interpretationLine1: 'Cuando el ingreso cambia, el primer número tampoco cuenta toda la historia.',
-                interpretationLine2: 'Si no separas rápido lo básico o lo urgente, el dinero parece libre aunque en realidad ya venía comprometido.',
-                interpretationLine3: 'Ver eso a tiempo ayuda a no confundir “entró plata” con “sí puedo gastarla”.'
-            }
-        };
+    <!-- 1. INTRO -->
+    <div class="section">
+        <div class="intro">
+            <p>Llega el aviso del pago. Ves el número grande. Sientes alivio.</p>
+            <p>Pero ese número no es la plata con la que decides — es solo el punto de partida. Antes de que llegue a tu cuenta, salen los descuentos. Y antes de que puedas organizar nada, ya hay compromisos amarrados.</p>
+            <p><strong>El número con el que organizas tu mes vive después de todo eso.</strong></p>
+        </div>
+    </div>
 
-        function formatMoney(amount) {
-            return new Intl.NumberFormat('es-CO', {
-                style: 'currency',
-                currency: 'COP',
-                minimumFractionDigits: 0
-            }).format(amount);
-        }
+    <!-- 2. IDEA CLAVE -->
+    <div class="section">
+        <div class="idea-clave">
+            <div class="idea-clave-label">Idea clave de la semana</div>
+            <div class="idea-clave-text">No organices tu mes con el número grande. Organízalo con el número que realmente te queda.</div>
+        </div>
+    </div>
 
-        function getSalaryRange(grossSalary) {
-            const smmlvReference = 1423500;
+    <!-- 3. THE THREE NUMBERS -->
+    <div class="section">
+        <h2 class="section-heading">Las tres cifras dentro de tu salario</h2>
+        <p class="section-body">No son lo mismo. Confundirlas es una de las razones más comunes por las que un mes parece que iba bien y termina apretado.</p>
+        <div class="cascade">
+            <div class="cascade-row bruto">
+                <span class="cascade-tag">1 · Bruto</span>
+                <span class="cascade-name">Lo que ganas en el contrato</span>
+                <span class="cascade-value" id="cascade-bruto">$0</span>
+            </div>
+            <div class="cascade-row llega">
+                <span class="cascade-tag">2 · Llega</span>
+                <span class="cascade-name">Lo que entra a tu cuenta</span>
+                <span class="cascade-value" id="cascade-llega">$0</span>
+            </div>
+            <div class="cascade-row disponible">
+                <span class="cascade-tag">3 · Disponible</span>
+                <span class="cascade-name">Con lo que de verdad decides</span>
+                <span class="cascade-value" id="cascade-disponible">$0</span>
+            </div>
+        </div>
+        <p class="section-body" style="margin-top:0.9rem; font-size:0.9rem;">Mete tus números abajo y observa cómo se encoge la cifra. Esa diferencia es lo que cambia el plan.</p>
+    </div>
 
-            if (grossSalary < (4 * smmlvReference)) {
-                return 'low';
-            }
-            if (grossSalary < (8 * smmlvReference)) {
-                return 'mid';
-            }
-            return 'high';
-        }
+    <!-- 4. CALCULATOR -->
+    <div class="section">
+        <div class="calc">
+            <h2 class="calc-title">Calcula tus tres números</h2>
+            <p class="calc-desc">Cambia el salario y todo se actualiza en tiempo real — incluyendo el cascada de arriba.</p>
 
-        function updateFormalGuide(grossSalary) {
-            const range = getSalaryRange(grossSalary || 0);
-            const title = document.getElementById('salary-range-title');
-            const copy = document.getElementById('salary-range-copy');
-
-            if (range === 'low') {
-                title.textContent = 'Con este ejemplo, lo más visible suelen ser salud y pensión.';
-                copy.textContent = 'En este rango la calculadora deja la retención aproximada en cero y se concentra en lo que normalmente más pesa en la nómina.';
-            } else if (range === 'mid') {
-                title.textContent = 'Con este ejemplo, la retención ya podría empezar a aparecer.';
-                copy.textContent = 'La calculadora la muestra solo como referencia educativa para recordar que el dinero libre puede bajar más de lo esperado.';
-            } else {
-                title.textContent = 'Con este ejemplo, la retención puede sentirse más clara.';
-                copy.textContent = 'Aquí la calculadora añade una referencia educativa más alta para que veas cómo cambia el dinero realmente usable.';
-            }
-
-            return range;
-        }
-
-        function setIncomeMode(mode) {
-            const nextMode = mode === 'informal' ? 'informal' : 'formal';
-            const copy = MODE_COPY[nextMode];
-
-            document.getElementById('employment-type').value = nextMode;
-            document.getElementById('path-formal').classList.toggle('is-active', nextMode === 'formal');
-            document.getElementById('path-informal').classList.toggle('is-active', nextMode === 'informal');
-            document.getElementById('employment-note').textContent = copy.note;
-            document.getElementById('calc-description').textContent = copy.calcDescription;
-            document.getElementById('employment-type-label').textContent = copy.chip;
-            document.getElementById('employment-type-help').textContent = copy.help;
-            document.getElementById('gross-salary-label').textContent = copy.grossLabel;
-            document.getElementById('gross-salary-guidance').textContent = copy.grossGuidance;
-            document.getElementById('other-deductions-label').textContent = copy.otherLabel;
-            document.getElementById('other-deductions-help').textContent = copy.otherHelp;
-            document.getElementById('formal-options').style.display = nextMode === 'formal' ? 'block' : 'none';
-            document.getElementById('formal-explanation').style.display = nextMode === 'formal' ? 'block' : 'none';
-            document.getElementById('informal-explanation').style.display = nextMode === 'informal' ? 'block' : 'none';
-            document.getElementById('employer-cost-section').style.display = nextMode === 'formal' ? 'block' : 'none';
-
-            calculateTakeHome();
-        }
-
-        function calculateTakeHome() {
-            const employmentType = document.getElementById('employment-type').value;
-            const grossSalary = parseFloat(document.getElementById('gross-salary').value) || 0;
-            const salaryRange = updateFormalGuide(grossSalary);
-            const otherDeductions = parseFloat(document.getElementById('other-deductions').value) || 0;
-            const copy = MODE_COPY[employmentType];
-
-            document.getElementById('gross-salary-preview').textContent = formatMoney(grossSalary);
-            document.getElementById('other-deductions-preview').textContent = formatMoney(otherDeductions);
-            document.getElementById('interpretation-title').textContent = copy.interpretationTitle;
-            document.getElementById('interpretation-line-1').textContent = copy.interpretationLine1;
-            document.getElementById('interpretation-line-2').textContent = copy.interpretationLine2;
-            document.getElementById('interpretation-line-3').textContent = copy.interpretationLine3;
-
-            if (grossSalary === 0) {
-                document.getElementById('breakdown-section').style.display = 'none';
-                document.getElementById('interpretation-section').style.display = 'none';
-                return;
-            }
-
-            let healthContribution = 0;
-            let pensionContribution = 0;
-            let retentionTax = 0;
-            let totalDeductions = otherDeductions;
-
-            if (employmentType === 'formal') {
-                const smmlvReference = 1423500;
-
-                healthContribution = grossSalary * 0.04;
-                pensionContribution = grossSalary * 0.04;
-
-                if (salaryRange === 'mid') {
-                    retentionTax = Math.max(0, (grossSalary - (4 * smmlvReference)) * 0.05);
-                } else if (salaryRange === 'high') {
-                    retentionTax = Math.max(0, (grossSalary - (4 * smmlvReference)) * 0.10);
-                }
-
-                totalDeductions = healthContribution + pensionContribution + retentionTax + otherDeductions;
-            }
-
-            const netSalary = grossSalary - totalDeductions;
-            const breakdownGrid = document.getElementById('breakdown-grid');
-            breakdownGrid.innerHTML = '';
-
-            breakdownGrid.innerHTML += `
-                <div class="breakdown-item">
-                    <div class="breakdown-label">Ingreso total</div>
-                    <div class="breakdown-amount">${formatMoney(grossSalary)}</div>
-                    <div class="breakdown-percentage">100%</div>
+            <div class="calc-inputs">
+                <div class="calc-field">
+                    <label for="salario-bruto">1 · Salario antes de descuentos ($)</label>
+                    <input type="number" id="salario-bruto" min="0" placeholder="2.000.000" value="2000000" inputmode="numeric">
+                    <div class="hint">El número que dice tu contrato, antes de cualquier descuento.</div>
                 </div>
-                <div class="breakdown-item">
-                    <div class="breakdown-label">${employmentType === 'formal' ? 'Descuentos y compromisos' : 'Separaciones y compromisos'}</div>
-                    <div class="breakdown-amount">-${formatMoney(totalDeductions)}</div>
-                    <div class="breakdown-percentage">-${((totalDeductions / grossSalary) * 100).toFixed(1)}%</div>
+
+                <div class="calc-field">
+                    <label for="otros-descuentos">4 · Otros descuentos de nómina ($)</label>
+                    <input type="number" id="otros-descuentos" min="0" placeholder="0" value="0" inputmode="numeric">
+                    <div class="hint">Cosas como <strong>retención en la fuente</strong> (si tu ingreso supera los rangos), <strong>fondo de solidaridad pensional</strong>, <strong>cooperativa, libranza, seguro voluntario, AFP voluntaria</strong>, etc. Si no sabes el total exacto, mira tu desprendible más reciente y suma todos los descuentos que no sean salud (4%) ni pensión (4%).</div>
                 </div>
-            `;
 
-            if (employmentType === 'formal') {
-                breakdownGrid.innerHTML += `
-                    <div class="breakdown-item">
-                        <div class="breakdown-label">Salud (EPS)</div>
-                        <div class="breakdown-amount">-${formatMoney(healthContribution)}</div>
-                        <div class="breakdown-percentage">-4%</div>
-                    </div>
-                    <div class="breakdown-item">
-                        <div class="breakdown-label">Pensión</div>
-                        <div class="breakdown-amount">-${formatMoney(pensionContribution)}</div>
-                        <div class="breakdown-percentage">-4%</div>
-                    </div>
-                `;
+                <div class="calc-field">
+                    <label for="compromisos">6 · Compromisos ya amarrados ($)</label>
+                    <input type="number" id="compromisos" min="0" placeholder="0" value="0" inputmode="numeric">
+                    <div class="hint">Plata que apenas entra ya tiene dueño: <strong>arriendo, cuota fija de un crédito, suscripciones por débito automático, aporte a la casa</strong>. No es plata con la que decidas — ya está decidida.</div>
+                </div>
+            </div>
 
-                if (retentionTax > 0) {
-                    breakdownGrid.innerHTML += `
-                        <div class="breakdown-item">
-                            <div class="breakdown-label">Retención en la Fuente</div>
-                            <div class="breakdown-amount">-${formatMoney(retentionTax)}</div>
-                            <div class="breakdown-percentage">-${((retentionTax / grossSalary) * 100).toFixed(1)}%</div>
-                        </div>
-                    `;
-                }
-            } else {
-                breakdownGrid.innerHTML += `
-                    <div class="breakdown-item" style="grid-column: 1 / -1;">
-                        <div class="breakdown-label">Ingreso variable o independiente</div>
-                        <div class="breakdown-amount">Aquí no asumimos descuentos automáticos fijos</div>
-                        <div class="breakdown-percentage" style="color:var(--yellow);">El ejercicio te ayuda a separar primero lo que no conviene gastar apenas entra el dinero</div>
-                    </div>
-                `;
-            }
+            <div class="calc-breakdown">
+                <div class="calc-breakdown-label">Cómo se descompone tu salario</div>
+                <div class="opt-row">
+                    <span class="k">1 · Salario antes de descuentos</span>
+                    <span class="v" id="out-bruto">$0</span>
+                </div>
+                <div class="opt-row">
+                    <span class="k">2 · Salud (4%)</span>
+                    <span class="v" id="out-salud" style="color:#ff9999;">$0</span>
+                </div>
+                <div class="opt-row">
+                    <span class="k">3 · Pensión (4%)</span>
+                    <span class="v" id="out-pension" style="color:#ff9999;">$0</span>
+                </div>
+                <div class="opt-row">
+                    <span class="k">4 · Otros descuentos de nómina</span>
+                    <span class="v" id="out-otros" style="color:#ff9999;">$0</span>
+                </div>
+                <div class="opt-row total">
+                    <span class="k">5 · Dinero que llega aproximado</span>
+                    <span class="v" id="out-llega">$0</span>
+                </div>
+                <div class="opt-row" style="margin-top:0.5rem;">
+                    <span class="k">6 · Compromisos ya amarrados</span>
+                    <span class="v" id="out-compromisos" style="color:#ff9999;">$0</span>
+                </div>
+                <div class="opt-row total">
+                    <span class="k" style="color:var(--green);">7 · Dinero realmente disponible</span>
+                    <span class="v" id="out-disponible" style="color:var(--green);">$0</span>
+                </div>
+            </div>
+        </div>
+    </div>
 
-            if (otherDeductions > 0) {
-                breakdownGrid.innerHTML += `
-                    <div class="breakdown-item">
-                        <div class="breakdown-label">${employmentType === 'formal' ? 'Otros descuentos' : 'Separaciones que te apartas'}</div>
-                        <div class="breakdown-amount">-${formatMoney(otherDeductions)}</div>
-                        <div class="breakdown-percentage">-${((otherDeductions / grossSalary) * 100).toFixed(1)}%</div>
-                    </div>
-                `;
-            }
+    <!-- 5. OPTIONAL: EMPLOYER COST -->
+    <div class="section">
+        <details class="opt-details">
+            <summary>
+                <div>
+                    <span class="opt-summary-title">Opcional: lo que tu trabajo cuesta completo</span>
+                    <span class="opt-summary-copy">Lo que la empresa paga, no lo que tú recibes. No cambia tu plata disponible — solo da contexto.</span>
+                </div>
+                <span class="opt-chev">›</span>
+            </summary>
+            <div class="opt-body">
+                <p class="section-body" style="margin-bottom:0.9rem; font-size:0.9rem;">El salario bruto es solo una parte. La empresa además paga, por ti, varios aportes y prestaciones. Esto no llega a tu cuenta — pero sí muestra el costo real de tu trabajo.</p>
+                <div class="opt-row"><span class="k">Tu salario bruto</span><span class="v" id="ec-salary">$0</span></div>
+                <div class="opt-row"><span class="k">+ Pensión empleador (12%)</span><span class="v" id="ec-pension">$0</span></div>
+                <div class="opt-row"><span class="k">+ Salud empleador (8.5%)</span><span class="v" id="ec-salud">$0</span></div>
+                <div class="opt-row"><span class="k">+ Parafiscales SENA+ICBF+Caja (9%)</span><span class="v" id="ec-para">$0</span></div>
+                <div class="opt-row"><span class="k">+ Cesantías (8.33%)</span><span class="v" id="ec-cesantias">$0</span></div>
+                <div class="opt-row"><span class="k">+ Prima de servicios (8.33%)</span><span class="v" id="ec-prima">$0</span></div>
+                <div class="opt-row"><span class="k">+ Vacaciones (4.17%)</span><span class="v" id="ec-vacaciones">$0</span></div>
+                <div class="opt-row"><span class="k">+ ARL (~1.5%)</span><span class="v" id="ec-arl">$0</span></div>
+                <div class="opt-row total"><span class="k">Costo total para el empleador</span><span class="v" id="ec-total">$0</span></div>
+                <p class="opt-note">El número de arriba es lo que tu trabajo le cuesta a la empresa. La diferencia con lo que recibes es el aporte que la empresa hace al sistema (salud pública, pensión, capacitación, prestaciones). No es plata que puedas gastar — pero saberlo te ayuda a entender el contexto de una negociación salarial o de un contrato de prestación de servicios.</p>
+            </div>
+        </details>
+    </div>
 
-            document.getElementById('final-amount').textContent = formatMoney(netSalary);
-            document.getElementById('breakdown-section').style.display = 'block';
-            document.getElementById('interpretation-section').style.display = 'block';
+    <!-- 6. REFLECTION -->
+    <div class="section">
+        <div class="reflect">
+            <div class="reflect-title">Una pregunta para terminar</div>
+            <div class="reflect-q">¿Cuánto se reduce tu "número grande" cuando lo conviertes en tu "número disponible"? ¿Te sorprende?</div>
+            <textarea placeholder="Anota la diferencia en pesos o en porcentaje, y cómo se siente verla."></textarea>
+        </div>
+    </div>
 
-            const finalNote = document.querySelector('.final-note');
-            if (employmentType === 'formal') {
-                finalNote.textContent = 'Este es tu dinero disponible. Recuerda que también recibes prestaciones sociales (prima, cesantías) que no aparecen aquí.';
-            } else {
-                finalNote.textContent = 'Aquí el punto no es un descuento automático, sino cuánto apartas a tiempo para salud, emergencias o meses con ingresos más variables.';
-            }
-        }
+    <!-- 7. NEXT WEEK -->
+    <div class="next-week">
+        <h3>Semana 3: ¿Qué pasa cuando una deuda empieza a crecer?</h3>
+        <p>Ahora que sabes con qué número realmente cuentas, la siguiente semana mira qué pasa cuando una propuesta de crédito promete aliviar y termina costando el doble.</p>
+        <a href="../semana-3/" class="btn btn-primary">Continuar a Semana 3 →</a>
+    </div>
 
-        function calcEmployerCost() {
-            const salary = parseFloat(document.getElementById('employer-salary').value) || 0;
+    <p class="footnote">Los porcentajes 4% / 4% son los aportes obligatorios del empleado a salud y pensión en Colombia para un contrato laboral estándar. Los porcentajes del empleador son referenciales. Los números y ejemplos son ilustrativos.</p>
+</div>
 
-            if (salary === 0) {
-                return;
-            }
+<script>
+    const fmt = (n) => {
+        if (!isFinite(n) || isNaN(n)) return '$0';
+        const rounded = Math.round(n);
+        return '$' + rounded.toLocaleString('es-CO');
+    };
 
-            const fmt = (value) => new Intl.NumberFormat('es-CO', {
-                style: 'currency',
-                currency: 'COP',
-                minimumFractionDigits: 0
-            }).format(Math.round(value));
+    const $ = (id) => document.getElementById(id);
 
-            const pension = salary * 0.12;
-            const health = salary * 0.085;
-            const para = salary * 0.09;
-            const ces = salary * 0.0833;
-            const prima = salary * 0.0833;
-            const vac = salary * 0.0417;
-            const arl = salary * 0.015;
-            const extras = pension + health + para + ces + prima + vac + arl;
-            const total = salary + extras;
-            const pct = ((extras / salary) * 100).toFixed(0);
+    const inputs = {
+        bruto: $('salario-bruto'),
+        otros: $('otros-descuentos'),
+        compromisos: $('compromisos')
+    };
 
-            document.getElementById('ec-salary').textContent = fmt(salary);
-            document.getElementById('ec-pension').textContent = fmt(pension);
-            document.getElementById('ec-health').textContent = fmt(health);
-            document.getElementById('ec-para').textContent = fmt(para);
-            document.getElementById('ec-cesantias').textContent = fmt(ces);
-            document.getElementById('ec-prima').textContent = fmt(prima);
-            document.getElementById('ec-vac').textContent = fmt(vac);
-            document.getElementById('ec-arl').textContent = fmt(arl);
-            document.getElementById('ec-total').textContent = fmt(total);
-            document.getElementById('ec-insight').textContent =
-                `Por cada ${fmt(salary)} que recibes, tu empresa paga ${fmt(total)} en total — un ${pct}% adicional que no ves en tu recibo. ` +
-                `Las prestaciones (cesantías, prima, vacaciones) hacen parte de la compensación, aunque no lleguen como dinero libre inmediato. ` +
-                `En trabajos independientes, muchas personas necesitan organizar por su cuenta una parte para salud, descansos o meses más lentos.`;
-            document.getElementById('employer-cost-result').style.display = 'block';
-        }
+    function num(el) {
+        const v = parseFloat(el.value);
+        return isFinite(v) && v > 0 ? v : 0;
+    }
 
-        window.onload = function() {
-            document.getElementById('gross-salary').value = '2000000';
-            document.getElementById('other-deductions').value = '50000';
-            document.getElementById('employer-salary').value = '2000000';
-            setIncomeMode('formal');
-            calcEmployerCost();
-        };
-    </script>
-    <script src="../program-state.js"></script>
+    function update() {
+        const salarioBruto = num(inputs.bruto);
+        const otrosDescuentosNomina = num(inputs.otros);
+        const compromisosAmarrados = num(inputs.compromisos);
+
+        // Employee formulas (per spec)
+        const saludEmpleado = salarioBruto * 0.04;
+        const pensionEmpleado = salarioBruto * 0.04;
+        const descuentosObligatorios = saludEmpleado + pensionEmpleado;
+        const dineroQueLlega = salarioBruto - descuentosObligatorios - otrosDescuentosNomina;
+        const dineroDisponible = dineroQueLlega - compromisosAmarrados;
+
+        // Cascade visualization
+        $('cascade-bruto').textContent = fmt(salarioBruto);
+        $('cascade-llega').textContent = fmt(dineroQueLlega);
+        $('cascade-disponible').textContent = fmt(dineroDisponible);
+
+        // Calculator breakdown
+        $('out-bruto').textContent = fmt(salarioBruto);
+        $('out-salud').textContent = '−' + fmt(saludEmpleado);
+        $('out-pension').textContent = '−' + fmt(pensionEmpleado);
+        $('out-otros').textContent = '−' + fmt(otrosDescuentosNomina);
+        $('out-llega').textContent = fmt(dineroQueLlega);
+        $('out-compromisos').textContent = '−' + fmt(compromisosAmarrados);
+        $('out-disponible').textContent = fmt(dineroDisponible);
+
+        // Optional employer cost — same salarioBruto
+        const pensionEmpleador = salarioBruto * 0.12;
+        const saludEmpleador = salarioBruto * 0.085;
+        const parafiscales = salarioBruto * 0.09;
+        const cesantias = salarioBruto * 0.0833;
+        const prima = salarioBruto * 0.0833;
+        const vacaciones = salarioBruto * 0.0417;
+        const arl = salarioBruto * 0.015;
+        const costoTotalEmpleador = salarioBruto + pensionEmpleador + saludEmpleador + parafiscales + cesantias + prima + vacaciones + arl;
+
+        $('ec-salary').textContent = fmt(salarioBruto);
+        $('ec-pension').textContent = fmt(pensionEmpleador);
+        $('ec-salud').textContent = fmt(saludEmpleador);
+        $('ec-para').textContent = fmt(parafiscales);
+        $('ec-cesantias').textContent = fmt(cesantias);
+        $('ec-prima').textContent = fmt(prima);
+        $('ec-vacaciones').textContent = fmt(vacaciones);
+        $('ec-arl').textContent = fmt(arl);
+        $('ec-total').textContent = fmt(costoTotalEmpleador);
+    }
+
+    // Reactive: any change to any input recomputes everything
+    Object.values(inputs).forEach(el => {
+        el.addEventListener('input', update);
+        el.addEventListener('change', update);
+    });
+
+    update();  // initial render
+</script>
+<script src="../program-state.js"></script>
 </body>
 </html>

--- a/programa-colombia/semana-2/index.html
+++ b/programa-colombia/semana-2/index.html
@@ -246,7 +246,7 @@
                 <div class="opt-row"><span class="k">+ Vacaciones (4.17%)</span><span class="v" id="ec-vacaciones">$0</span></div>
                 <div class="opt-row"><span class="k">+ ARL (~1.5%)</span><span class="v" id="ec-arl">$0</span></div>
                 <div class="opt-row total"><span class="k">Costo total para el empleador</span><span class="v" id="ec-total">$0</span></div>
-                <p class="opt-note">El número de arriba es lo que tu trabajo le cuesta a la empresa. La diferencia con lo que recibes es el aporte que la empresa hace al sistema (salud pública, pensión, capacitación, prestaciones). No es plata que puedas gastar — pero saberlo te ayuda a entender el contexto de una negociación salarial o de un contrato de prestación de servicios.</p>
+                <p class="opt-note">Esto es el costo total que tu trabajo representa para la empresa. Cuando un empleador decide cuánto puede pagar, suma todo — salario, aportes, prestaciones — y lo compara con su presupuesto. Hay un debate económico honesto sobre si estos aportes deben verse como "lo que paga la empresa" (porque firma el cheque) o como "lo que tu salario nominal podría haber sido" (porque sale del mismo presupuesto laboral). Esta semana no toma partido en ese debate — solo te muestra los números completos para que decidas tú.</p>
             </div>
         </details>
     </div>
@@ -267,7 +267,7 @@
         <a href="../semana-3/" class="btn btn-primary">Continuar a Semana 3 →</a>
     </div>
 
-    <p class="footnote">Los porcentajes 4% / 4% son los aportes obligatorios del empleado a salud y pensión en Colombia para un contrato laboral estándar. Los porcentajes del empleador son referenciales. Los números y ejemplos son ilustrativos.</p>
+    <p class="footnote">Los porcentajes 4% / 4% son los aportes obligatorios del empleado a salud y pensión en Colombia para un contrato laboral estándar. Los porcentajes adicionales son los que el empleador gira al sistema desde su presupuesto laboral — aunque hay debate económico legítimo sobre dónde recae realmente el costo final. Los números y ejemplos son ilustrativos.</p>
 </div>
 
 <script>


### PR DESCRIPTION
Sequence:
- Semana 1: ¿Dónde se fue mi dinero?
- Semana 2: ¿Con qué dinero cuento de verdad?
- Semana 3: ¿Qué pasa cuando una deuda empieza a crecer?

Three-number framing (bruto / llega / disponible) shown as a visual
cascade where each box indents and shrinks. Single reactive salary
input drives every output on the page.

Formulas (exactly as specified):
  saludEmpleado = salarioBruto * 0.04
  pensionEmpleado = salarioBruto * 0.04
  descuentosObligatorios = saludEmpleado + pensionEmpleado
  dineroQueLlega = salarioBruto - descuentosObligatorios - otrosDescuentosNomina
  dineroDisponible = dineroQueLlega - compromisosAmarrados

Employer cost fully collapsed in <details>, same salarioBruto, all 8
line items recompute reactively.

Two helper-text bits convert abstract fields into actionable instructions:
- 'Otros descuentos de nómina' lists retención en la fuente, fondo de
  solidaridad pensional, cooperativa, libranza, AFP voluntaria.
- 'Compromisos ya amarrados' lists arriendo, cuota fija de crédito,
  débito automático — quietly bridges to sem-3 and sem-4.

Incidence framing neutralized: the employer-cost accordion and footnote
no longer call parafiscales 'el aporte que la empresa hace.' Instead
they describe the mechanism (employer girates from labor budget) and
name the economic debate honestly without taking a side. Keeps the
program 'sin agenda política' while staying linguistically honest.

Removed: 'Una situación muy común' tic, '¿Por qué pasa esto?' redundant
framing, 'Hagamos un ejercicio' preamble, 'Lo que sigue' preamble.
