### PR TITLE
Semana 5: cut purchasing-power repetition, add 'hay más opciones' bridge to sem 10

### DIFF
--- a/archive/semana-5-options-2026-05/semana-5.previous.html
+++ b/archive/semana-5-options-2026-05/semana-5.previous.html
@@ -202,7 +202,13 @@
             <div class="section-card">
                 <h2 class="section-title">¿Qué significa inflación?</h2>
                 <p class="section-text">
-                    Cuando los precios suben con el tiempo, la misma cantidad de dinero compra menos. Si algo cuesta $100 hoy, con una inflación de 6% costará cerca de $106 el próximo año. Eso es lo que llamamos pérdida de poder de compra: no es que tengas menos pesos — es que cada peso rinde menos.
+                    Inflación es cuando los precios suben con el tiempo. Entonces la misma cantidad de dinero compra menos.
+                </p>
+                <p class="section-text">
+                    Si algo cuesta $100 hoy, con una inflación de 6% costará cerca de $106 el próximo año.
+                </p>
+                <p class="section-text">
+                    Por eso importa el poder de compra. No se trata solo de cuántos pesos tienes, sino de cuántas cosas reales puedes pagar con ellos.
                 </p>
             </div>
         </div>
@@ -278,25 +284,25 @@
         <div class="section">
             <div class="section-card">
                 <h2 class="section-title">Mismo aumento, distinto resultado</h2>
-                <p class="section-text">Dos personas reciben exactamente el mismo aumento de salario. Pero su <em>canasta personal</em> — lo que cada una compra — sube a ritmos distintos. El resultado real cambia.</p>
+                <p class="section-text">Dos personas reciben el mismo aumento. Si el costo de vida sube distinto para cada una, el resultado real es diferente.</p>
 
                 <div class="sim-workers">
                     <div class="sim-worker up">
                         <div class="sim-worker-name">👷 Persona A</div>
                         <div class="sim-stat">Salario sube <strong style="color:var(--yellow);">+10%</strong></div>
-                        <div class="sim-stat">Su canasta sube <strong style="color:var(--yellow);">+7%</strong></div>
+                        <div class="sim-stat">Costo de vida sube <strong style="color:var(--yellow);">+7%</strong></div>
                         <div class="sim-result" id="sim-result-a">
-                            <div class="sim-result-val">✅ Poder adquisitivo real: +2,8%</div>
-                            <div class="sim-result-note">Su salario pasó de $1.500.000 a $1.650.000. Esos $1.650.000 nuevos compran lo mismo que $1.543.000 compraban antes. Ganó terreno real.</div>
+                            <div class="sim-result-val">✅ Poder adquisitivo real: +2.8%</div>
+                            <div class="sim-result-note">Con $1.500.000 antes, ahora puede comprar el equivalente a $1.543.000 de hoy.</div>
                         </div>
                     </div>
                     <div class="sim-worker down">
                         <div class="sim-worker-name">👷 Persona B</div>
                         <div class="sim-stat">Salario sube <strong style="color:var(--yellow);">+10%</strong></div>
-                        <div class="sim-stat">Su canasta sube <strong style="color:var(--red);">+11%</strong></div>
+                        <div class="sim-stat">Costo de vida sube <strong style="color:var(--red);">+12%</strong></div>
                         <div class="sim-result" id="sim-result-b">
-                            <div class="sim-result-val">⚠️ Poder adquisitivo real: −0,9%</div>
-                            <div class="sim-result-note">Su salario también pasó de $1.500.000 a $1.650.000. Pero su canasta — arriendo, mercado, transporte — subió 11%, así que esos $1.650.000 nuevos compran lo mismo que $1.486.000 antes. Perdió terreno real, aunque el papel diga que ganó.</div>
+                            <div class="sim-result-val">⚠️ Poder adquisitivo real: −1.8%</div>
+                            <div class="sim-result-note">Con $1.500.000 antes, ahora puede comprar el equivalente a $1.473.000 de hoy.</div>
                         </div>
                     </div>
                 </div>
@@ -306,8 +312,8 @@
                 </div>
 
                 <div id="workers-explanation" style="display:none; background:rgba(252,209,22,0.05); border:1px solid rgba(252,209,22,0.2); border-left:3px solid var(--primary); border-radius:0.75rem; padding:1.25rem;">
-                    <div style="color:var(--primary); font-weight:700; margin-bottom:0.75rem;">💡 Tu inflación no es el titular del noticiero</div>
-                    <p style="color:var(--dim); font-size:0.92rem; line-height:1.75; margin-bottom:0;">El IPC nacional es un promedio. Pero tu inflación personal depende de lo que <strong style="color:var(--light);">tú</strong> compras: si tu mercado y tu arriendo suben más rápido que el promedio, tu canasta sube más rápido. Por eso dos personas con el mismo aumento pueden terminar en lugares muy distintos.</p>
+                    <div style="color:var(--primary); font-weight:700; margin-bottom:0.75rem;">💡 Poder adquisitivo: lo que realmente importa</div>
+                    <p style="color:var(--dim); font-size:0.92rem; line-height:1.75; margin-bottom:0;">El mismo aumento no siempre deja a dos personas en el mismo punto. Si el costo de vida sube más rápido que el ingreso, un avance en el papel puede sentirse como retroceso en la vida diaria.</p>
                 </div>
             </div>
         </div>
@@ -406,70 +412,63 @@
         <div class="section">
             <div class="section-card">
                 <h2 class="section-title">Dónde guardas tu dinero importa</h2>
-                <p class="section-text">Los lugares más cómodos no siempre son los que mejor protegen lo que tienes.</p>
+                <p class="section-text">No todos los lugares protegen igual el poder de compra. Esta comparación rápida ayuda a ver la diferencia.</p>
                 <div class="scenarios-grid">
                     <div class="scenario-card bad">
                         <div class="scenario-icon">💵</div>
                         <div class="scenario-name">Efectivo en casa</div>
                         <div class="scenario-rate">Rendimiento: 0%</div>
-                        <div class="scenario-result">Útil para lo inmediato. Pierde valor con el tiempo.</div>
+                        <div class="scenario-result">Sigue siendo útil para lo inmediato, pero pierde poder de compra con el tiempo.</div>
                     </div>
                     <div class="scenario-card bad">
                         <div class="scenario-icon">🏦</div>
                         <div class="scenario-name">Cuenta de ahorros</div>
                         <div class="scenario-rate">Rendimiento: ~2% anual</div>
-                        <div class="scenario-result">Cómoda. Casi siempre rinde por debajo de la inflación.</div>
+                        <div class="scenario-result">Puede ser cómoda, pero muchas veces no alcanza a proteger bien frente a la inflación.</div>
                     </div>
                     <div class="scenario-card ok">
                         <div class="scenario-icon">📄</div>
                         <div class="scenario-name">CDT</div>
                         <div class="scenario-rate">Rendimiento: 6–10% anual</div>
-                        <div class="scenario-result">Puede acercarse o superar la inflación. Plazo fijo — no toques mientras dure.</div>
+                        <div class="scenario-result">Puede acercarse o superar la inflación. Sirve mejor para dinero que no necesitas mover de inmediato.</div>
                     </div>
                 </div>
-            </div>
-        </div>
-
-        <div class="section">
-            <div class="section-card" style="border-left:4px solid var(--primary);">
-                <h2 class="section-title">Hay más opciones — y vienen con trade-offs</h2>
-                <p class="section-text">Lo de arriba son las herramientas más seguras y conocidas. Existen otras que pueden proteger mejor frente a la inflación — pero cada una pide algo a cambio: más tiempo, más variación, o más conocimiento. La regla honesta es: <strong>más variación posible, mayor potencial de ganancia <em>o pérdida</em>, casi siempre más tiempo.</strong></p>
-                <div style="display:grid; gap:0.75rem; margin-top:1rem;">
-                    <div style="background:rgba(252,209,22,0.05); border:1px solid rgba(252,209,22,0.2); border-left:3px solid var(--primary); border-radius:0 0.6rem 0.6rem 0; padding:0.9rem 1.1rem;">
-                        <div style="color:var(--light); font-weight:700; font-size:0.95rem; margin-bottom:0.3rem;">📊 Renta variable (acciones, fondos)</div>
-                        <div style="color:var(--dim); font-size:0.88rem; line-height:1.6;">Históricamente le ha ganado a la inflación en plazos largos. Puede bajar 30%+ en un mal año. Requiere paciencia de 5 años o más.</div>
-                    </div>
-                    <div style="background:rgba(252,209,22,0.05); border:1px solid rgba(252,209,22,0.2); border-left:3px solid var(--primary); border-radius:0 0.6rem 0.6rem 0; padding:0.9rem 1.1rem;">
-                        <div style="color:var(--light); font-weight:700; font-size:0.95rem; margin-bottom:0.3rem;">🏠 Activos reales (finca raíz, oro)</div>
-                        <div style="color:var(--dim); font-size:0.88rem; line-height:1.6;">Tangibles, tienden a acompañar la inflación. Requieren mucho capital (finca raíz) o cuidado especial (oro). Liquidez baja — no se venden fácil.</div>
-                    </div>
-                    <div style="background:rgba(252,209,22,0.05); border:1px solid rgba(252,209,22,0.2); border-left:3px solid var(--primary); border-radius:0 0.6rem 0.6rem 0; padding:0.9rem 1.1rem;">
-                        <div style="color:var(--light); font-weight:700; font-size:0.95rem; margin-bottom:0.3rem;">⚠️ Lo que no aplica</div>
-                        <div style="color:var(--dim); font-size:0.88rem; line-height:1.6;">Nada de esto sirve para el fondo de emergencia ni para la plata que necesitas en menos de un año. Esto es para dinero que de verdad puede esperar.</div>
-                    </div>
-                </div>
-                <p class="section-text" style="margin-top:1rem; font-size:0.92rem;">En la <strong>Semana 10</strong> miramos las seis categorías a fondo, con una calculadora honesta que compara qué pasa con tu plata en cada una.</p>
             </div>
         </div>
 
         <div class="section">
             <div class="section-card">
-                <h2 class="section-title">Tu paso esta semana</h2>
-                <p class="section-text">Elige una sola.</p>
+                <h2 class="section-title">Qué idea conviene llevarte</h2>
+                <p class="section-text">La inflaci&#243;n no se siente primero en una gr&#225;fica. Se siente cuando el mismo dinero compra menos.</p>
+                <p class="section-text">Por eso, antes de pensar en decisiones m&#225;s largas, conviene tener clara una pregunta simple: <strong>si este dinero va a esperar, &#191;c&#243;mo vas a evitar que pierda tanto poder de compra?</strong></p>
+            </div>
+        </div>
+
+        <div class="section">
+            <div class="section-card">
+                <h2 class="section-title">Un pequeño paso práctico</h2>
+                <p class="section-text">No necesitas hacer grandes cambios de una vez. Elige una sola de estas acciones y úsala como punto de partida.</p>
 
                 <div class="actions-grid">
                     <div class="action-item">
-                        <div class="action-num">Opción 1</div>
-                        <div class="action-title">Identifica plata quieta</div>
+                        <div class="action-num">Acción 1</div>
+                        <div class="action-title">No dejar efectivo guardado más de lo necesario</div>
                         <div class="action-desc">
-                            Mira tu cuenta y separa mentalmente: ¿cuánto necesitas en los próximos 30 días? El resto es "plata quieta" — el principal candidato a perder valor por inflación.
+                            Guarda en efectivo lo que sí necesitas usar pronto. Lo demás vale la pena revisarlo para que no pierda tanto poder de compra.
                         </div>
                     </div>
                     <div class="action-item">
-                        <div class="action-num">Opción 2</div>
-                        <div class="action-title">Compara tu ingreso con tus gastos</div>
+                        <div class="action-num">Acción 2</div>
+                        <div class="action-title">Revisar si parte del ahorro puede estar en un instrumento que rinda más</div>
                         <div class="action-desc">
-                            Pregunta concreta: ¿subió tu salario igual o más que tus gastos en los últimos dos años? Si no, ya sabes en qué dirección estás caminando.
+                            Si tienes dinero que no vas a usar en el corto plazo, compara opciones como cuentas con mejor rendimiento o CDTs.
+                        </div>
+                    </div>
+                    <div class="action-item">
+                        <div class="action-num">Acción 3</div>
+                        <div class="action-title">Comparar si tus ingresos están creciendo al ritmo del costo de vida</div>
+                        <div class="action-desc">
+                            Mirar solo el aumento en pesos no siempre alcanza. También conviene compararlo con cuánto han subido tus gastos principales.
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Repetition removed:
- '¿Qué significa inflación?' merged 3 paragraphs into 1.
- 'Qué idea conviene llevarte' section deleted (restated the idea clave).
- 'Un pequeño paso práctico' trimmed from 3 actions to 2.

New section — 'Hay más opciones — y vienen con trade-offs':
- Names 3 categories (renta variable, activos reales, what-doesn't-apply
  warning) with one honest line each. Does NOT teach the alternatives
  in depth — that's sem 10's job.
- Honest framing: 'más variación posible, mayor potencial de ganancia
  o pérdida, casi siempre más tiempo.' Avoids the lazy 'más riesgo,
  más rentabilidad' shorthand that gets people in trouble.
- Bitcoin and gold deliberately not named individually here.
- Explicit pointer to sem 10 for the deep dive with the matrix and
  calculator. Gives emotional release ('there ARE options') without
  stealing sem 10's depth.

Persona B example refined:
- Cost-of-living: 12% → 11% (more realistic for recent Colombian CPI;
  not extreme).
- Both personas now show explicit peso amounts before and after, so
  the math is verifiable and concrete instead of abstract %.
- Reframed 'costo de vida' to 'tu canasta personal' to set up the
  key insight: inflation is personal, not the headline IPC.
- Reveal-box insight is now sharper: 'Tu inflación no es el titular
  del noticiero.'

All interactivity unchanged (chart, year selector, savings erosion
simulator, reveal button JS preserved byte-for-byte).
