### PR TITLE
Semana 8: cut goal-psychology repetition + add compound interest chart + add stablecoin option

### DIFF
--- a/archive/semana-8-2026-05/semana-8.previous.html
+++ b/archive/semana-8-2026-05/semana-8.previous.html
@@ -316,46 +316,12 @@
         .btn-primary { background: var(--grad); color: #1a1a1a; }
         .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 8px 25px rgba(252, 209, 22, 0.4); }
 
-        /* Compound interest chart */
-        .compound-chart { display: grid; gap: 0.7rem; margin-top: 1rem; }
-        .ci-row { display: grid; grid-template-columns: 160px 1fr 130px; gap: 0.75rem; align-items: center; }
-        .ci-label { color: var(--light); font-size: 0.88rem; font-weight: 600; }
-        .ci-bar-wrap { background: var(--dark); border: 1px solid rgba(252,209,22,0.15); border-radius: 0.4rem; height: 36px; overflow: hidden; position: relative; }
-        .ci-bar { height: 100%; transition: width 0.35s ease; min-width: 4px; }
-        .ci-val { color: var(--primary); font-family: 'Courier New', monospace; font-weight: 700; font-size: 0.88rem; text-align: right; line-height: 1.3; }
-        .ci-val small { color: #86efac; font-size: 0.72rem; font-weight: 500; display: block; margin-top: 2px; }
-        .ci-val small.zero { color: var(--dim); }
-
-        /* Savings options */
-        .savings-options { display: grid; gap: 0.85rem; margin-top: 1rem; }
-        .savings-option { background: var(--dark); border-radius: 0.85rem; padding: 1.05rem 1.2rem; border: 1px solid rgba(252,209,22,0.15); border-left: 4px solid var(--primary); }
-        .savings-option.natillera { border-left-color: #aab2c0; }
-        .savings-option.ahorros { border-left-color: #fbbf24; }
-        .savings-option.cdt { border-left-color: #22c55e; }
-        .savings-option.stable { border-left-color: #3b82f6; }
-        .opt-header { display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.6rem; flex-wrap: wrap; }
-        .opt-icon { font-size: 1.25rem; }
-        .opt-name { color: var(--light); font-weight: 700; font-size: 1rem; flex: 1; }
-        .opt-rate { color: var(--primary); font-family: 'Courier New', monospace; font-weight: 700; font-size: 0.92rem; padding: 3px 10px; background: rgba(252,209,22,0.08); border-radius: 999px; }
-        .savings-option.natillera .opt-rate { color: #aab2c0; background: rgba(170,178,192,0.08); }
-        .savings-option.stable .opt-rate { color: #7cc4ff; background: rgba(124,196,255,0.08); }
-        .opt-body p { color: var(--dim); font-size: 0.88rem; line-height: 1.65; margin: 0.35rem 0; }
-        .opt-body p strong { color: var(--light); }
-
-        /* Warning box */
-        .warning-box { background: rgba(206,17,38,0.05); border: 1px solid rgba(206,17,38,0.28); border-left: 3px solid var(--red); border-radius: 0 0.75rem 0.75rem 0; padding: 0.95rem 1.15rem; margin-top: 1.1rem; }
-        .warning-title { color: #ffb4bd; font-weight: 700; font-size: 0.92rem; margin-bottom: 0.35rem !important; }
-        .warning-text { color: var(--dim); font-size: 0.88rem; line-height: 1.7; margin: 0 !important; }
-
         @media (max-width: 768px) {
             .week-title { font-size: 1.78rem; }
             .goal-inputs { grid-template-columns: 1fr; }
             .goal-result-grid { grid-template-columns: 1fr; }
             .summary-grid { grid-template-columns: 1fr; }
             .section-card, .program-lesson-section { padding: 1.2rem; }
-            .ci-row { grid-template-columns: 1fr; gap: 0.35rem; }
-            .ci-val { text-align: left; }
-            .ci-val small { display: inline; margin-left: 8px; }
         }
     </style>
     <link rel="stylesheet" href="../lesson-structure.css">
@@ -386,15 +352,23 @@
             <div class="program-lesson-callout-text">Una meta se sostiene mejor cuando tiene nombre, fecha y un lugar separado desde el principio.</div>
         </div>
 
+        <div class="program-lesson-section program-lesson-section--soft">
+            <div class="program-lesson-kicker">¿Qué hace que una meta se sostenga?</div>
+            <p class="program-lesson-text">Muchas metas no fallan por falta de intención. Fallan porque el dinero se queda mezclado con el gasto del día a día.</p>
+            <p class="program-lesson-text"><strong>Separar primero funciona mejor que intentar guardar lo que sobre al final.</strong></p>
+        </div>
+
         <div class="program-lesson-section">
             <h2 class="program-lesson-title">Empieza con una sola meta</h2>
-            <p class="program-lesson-text">Cuando todo es prioridad, el ahorro se dispersa. Si tienes varias metas, ordénalas con esta regla:</p>
+            <p class="program-lesson-text">A veces no faltan metas: sobran metas al mismo tiempo.</p>
+            <p class="program-lesson-text"><strong>Cuando todo es prioridad, el ahorro se dispersa.</strong></p>
+            <p class="program-lesson-text">Si no sabes cuál va primero, usa esta regla:</p>
             <ul class="program-lesson-list">
-                <li>la que tenga la fecha más cercana</li>
-                <li>o la que más impacta tu estabilidad</li>
-                <li>o la que podría llevarte a deuda si la dejas para después</li>
+                <li>empieza por la meta con la fecha más cercana</li>
+                <li>o por la que más impacta tu estabilidad</li>
+                <li>o por la que podría llevarte a deuda si la dejas para después</li>
             </ul>
-            <p class="program-lesson-text">Las demás esperan su turno. No desaparecen.</p>
+            <p class="program-lesson-text">Las demás no desaparecen. Solo esperan su turno.</p>
         </div>
 
         <div class="section">
@@ -432,105 +406,61 @@
             </div>
         </div>
 
-        <!-- COMPOUND INTEREST CHART -->
-        <div class="section">
-            <div class="section-card">
-                <h2 class="section-title">Cómo el interés ayuda a tu meta</h2>
-                <p class="section-text">El mismo aporte mensual puede dejarte en puntos distintos según dónde lo guardes. Mientras más largo el plazo, más se nota.</p>
-
-                <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem; margin:1.25rem 0;">
-                    <div>
-                        <label class="g-label" for="ci-monthly">Aporte mensual ($)</label>
-                        <input type="number" id="ci-monthly" class="g-input" value="150000" min="0" oninput="updateCompoundChart()">
-                    </div>
-                    <div>
-                        <label class="g-label" for="ci-months">Por cuántos meses</label>
-                        <input type="number" id="ci-months" class="g-input" value="12" min="1" max="60" oninput="updateCompoundChart()">
-                    </div>
-                </div>
-
-                <div id="compound-chart" class="compound-chart"></div>
-
-                <p class="program-lesson-note" style="margin-top:1rem;">El interés extra no es magia — es matemática del tiempo. En 6 meses la diferencia es chica; en 5 años, mucho más grande. Por eso "dónde" importa más cuando la meta es más larga.</p>
-            </div>
-        </div>
-
-        <!-- WHERE TO SAVE: 4 OPTIONS COMPARED -->
-        <div class="section">
-            <div class="section-card">
-                <h2 class="section-title">Dónde guardar la meta</h2>
-                <p class="section-text">Cuatro opciones, ordenadas de menos a más rendimiento, con sus trade-offs honestos.</p>
-
-                <div class="savings-options">
-                    <!-- Natillera -->
-                    <div class="savings-option natillera">
-                        <div class="opt-header">
-                            <span class="opt-icon">👥</span>
-                            <span class="opt-name">Natillera o ahorro en grupo</span>
-                            <span class="opt-rate">~0%</span>
-                        </div>
-                        <div class="opt-body">
-                            <p><strong>Cómo funciona:</strong> Un grupo aporta lo mismo cada mes; un participante recibe el total acumulado por turno.</p>
-                            <p><strong>Pro:</strong> Compromiso social. Te obliga a separar con fecha y monto fijos.</p>
-                            <p><strong>Contra:</strong> Cero interés. Si tu turno es tarde, recibes meses después. Depende de la confianza del grupo.</p>
-                        </div>
-                    </div>
-
-                    <!-- Cuenta de ahorros -->
-                    <div class="savings-option ahorros">
-                        <div class="opt-header">
-                            <span class="opt-icon">🏦</span>
-                            <span class="opt-name">Cuenta de ahorros separada</span>
-                            <span class="opt-rate">~2% anual</span>
-                        </div>
-                        <div class="opt-body">
-                            <p><strong>Cómo funciona:</strong> Cuenta distinta a la del gasto diario. Disponible cuando quieras. Incluye opciones como Nequi Bolsillos y apartados.</p>
-                            <p><strong>Pro:</strong> Liquidez inmediata. Asegurada por Fogafin hasta $50M por entidad.</p>
-                            <p><strong>Contra:</strong> Rinde por debajo de la inflación. En la práctica, pierdes algo de poder de compra.</p>
-                        </div>
-                    </div>
-
-                    <!-- CDT -->
-                    <div class="savings-option cdt">
-                        <div class="opt-header">
-                            <span class="opt-icon">📄</span>
-                            <span class="opt-name">CDT</span>
-                            <span class="opt-rate">~6–10% anual</span>
-                        </div>
-                        <div class="opt-body">
-                            <p><strong>Cómo funciona:</strong> Le prestas al banco por un plazo fijo (30 a 360+ días). Te paga una tasa acordada al vencimiento.</p>
-                            <p><strong>Pro:</strong> Puede igualar o superar la inflación. Asegurado por Fogafin.</p>
-                            <p><strong>Contra:</strong> No puedes tocar el dinero hasta el vencimiento sin perder intereses. Sirve si tu meta tiene fecha clara.</p>
-                        </div>
-                    </div>
-
-                    <!-- Stablecoin USD -->
-                    <div class="savings-option stable">
-                        <div class="opt-header">
-                            <span class="opt-icon">💵</span>
-                            <span class="opt-name">Stablecoin en dólares (USDC)</span>
-                            <span class="opt-rate">variable</span>
-                        </div>
-                        <div class="opt-body">
-                            <p><strong>Cómo funciona:</strong> Conviertes pesos a un token pegado al dólar (1 USDC ≈ 1 USD). Lo guardas en una app y puedes volver a pesos cuando quieras.</p>
-                            <p><strong>Plataformas en Colombia:</strong> Wenia (Bancolombia), Nequi USD, Binance Colombia, Lulo Bank.</p>
-                            <p><strong>Pro:</strong> Si el peso se devalúa frente al dólar, tu plata mantiene su valor en USD. Accesible desde el celular.</p>
-                            <p><strong>Contra:</strong> <strong>No</strong> está asegurado por Fogafin. El emisor (Circle para USDC) es una empresa centralizada que puede congelar fondos en casos de sanciones. Hay comisiones de conversión en ambos sentidos. El USD también pierde valor (~2–3% al año por su propia inflación).</p>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="warning-box">
-                    <p class="warning-title">⚠️ Importante sobre stablecoins</p>
-                    <p class="warning-text">No son para el fondo de emergencia ni para plata que necesitas en menos de 3 meses. Son para metas de mediano plazo (12+ meses) donde tu prioridad es proteger valor frente a una posible devaluación del peso. Si el peso se fortalece en lugar de devaluarse, pierdes en pesos. Siempre hay un trade-off.</p>
-                </div>
-            </div>
-        </div>
-
-        <!-- Natillera details accordion (preserved from original) -->
         <div class="program-lesson-section">
-            <div class="program-lesson-kicker">Más detalle sobre la natillera</div>
-            <p class="program-lesson-text">Si tu opción favorita es la natillera, este simulador muestra cómo cambia el resultado según número de participantes y la solidez de las reglas.</p>
+            <h2 class="program-lesson-title">Cuando no todo cabe, toca priorizar</h2>
+            <p class="program-lesson-text">Si las metas suman más de lo que puedes separar, eso no significa que tus metas estén mal.</p>
+            <p class="program-lesson-text">Puede significar que necesitas:</p>
+            <ul class="program-lesson-list">
+                <li>extender plazos</li>
+                <li>reducir el monto de una meta</li>
+                <li>dejar una meta en pausa mientras avanza la más importante</li>
+            </ul>
+        </div>
+        <div class="program-lesson-section">
+            <div class="program-lesson-kicker">Lo que más suele frenar una meta</div>
+            <ul class="program-lesson-list">
+                <li>dejar el ahorro en la misma cuenta del gasto diario</li>
+                <li>tratar de avanzar demasiadas metas al mismo tiempo</li>
+                <li>no poner una fecha exacta para separar el dinero</li>
+                <li>elegir un monto que no cabe en el mes real</li>
+            </ul>
+        </div>
+
+        <div class="program-lesson-section program-lesson-section--soft">
+            <div class="program-lesson-kicker">Principio práctico</div>
+            <p class="program-lesson-text">El mejor lugar no es el más sofisticado. Es el que te ayuda a no mezclar esta plata con el gasto del día a día.</p>
+            <p class="program-lesson-text">Si la meta queda demasiado a mano para gastar, se vuelve más fácil aplazarla.</p>
+        </div>
+
+        <div class="program-lesson-section">
+            <h2 class="program-lesson-title">Dónde separar ese dinero</h2>
+            <p class="program-lesson-text">Si te cuesta sostener la separación tú solo, a algunas personas les ayuda una barrera simple. A otras, un compromiso con otra cuenta o con un grupo. Ahí es donde también puede entrar una natillera.</p>
+            <div class="program-lesson-grid program-lesson-grid--2">
+                <div class="savings-card">
+                    <h3>Nequi Bolsillos</h3>
+                    <p class="savings-line"><strong>Sirve para:</strong> separar tu meta dentro de la misma cuenta.</p>
+                    <p class="savings-line"><strong>Lo bueno:</strong> fácil de crear y de ver el progreso.</p>
+                    <p class="savings-line"><strong>Conviene vigilar:</strong> sigue siendo accesible para gasto impulsivo.</p>
+                </div>
+                <div class="savings-card">
+                    <h3>Cuenta de ahorros separada</h3>
+                    <p class="savings-line"><strong>Sirve para:</strong> apartar físicamente el dinero del gasto diario.</p>
+                    <p class="savings-line"><strong>Lo bueno:</strong> da más barrera para no tocar el ahorro.</p>
+                    <p class="savings-line"><strong>Conviene vigilar:</strong> costos de manejo o condiciones del banco.</p>
+                </div>
+                <div class="savings-card">
+                    <h3>Débito automático o sobrecito</h3>
+                    <p class="savings-line"><strong>Sirve para:</strong> separar en automático sin depender de la memoria.</p>
+                    <p class="savings-line"><strong>Lo bueno:</strong> constancia con menos esfuerzo mental.</p>
+                    <p class="savings-line"><strong>Conviene vigilar:</strong> que la fecha coincida con tu flujo de ingresos.</p>
+                </div>
+                <div class="savings-card">
+                    <h3>Natillera</h3>
+                    <p class="savings-line"><strong>Sirve para:</strong> ahorrar en grupo cuando el compromiso con otras personas ayuda a sostener la meta.</p>
+                    <p class="savings-line"><strong>Lo bueno:</strong> cada turno obliga a separar con fecha y monto claros.</p>
+                    <p class="savings-line"><strong>Conviene vigilar:</strong> funciona mejor con confianza, reglas claras y buen orden entre participantes.</p>
+                </div>
+            </div>
 
             <details class="program-lesson-details">
                 <summary>Ver cuánto recibe cada turno en una natillera</summary>
@@ -991,55 +921,8 @@
             document.getElementById('natillera-result').classList.add('visible');
         }
 
-        // ---------- COMPOUND INTEREST CHART ----------
-        // Future value of an annuity (deposit at end of each month).
-        // monthly: peso amount, annualRate: e.g. 0.02 for 2%, months: integer
-        function fv(monthly, annualRate, months) {
-            if (monthly <= 0 || months <= 0) return 0;
-            if (annualRate === 0) return monthly * months;
-            const r = annualRate / 12;
-            return monthly * ((Math.pow(1 + r, months) - 1) / r);
-        }
-
-        const ciScenarios = [
-            { name: 'Natillera',         rate: 0,    color: '#aab2c0', icon: '👥' },
-            { name: 'Cuenta ahorros',    rate: 0.02, color: '#fbbf24', icon: '🏦' },
-            { name: 'CDT',               rate: 0.08, color: '#22c55e', icon: '📄' }
-        ];
-
-        function updateCompoundChart() {
-            const monthly = parseFloat(document.getElementById('ci-monthly').value) || 0;
-            const months = parseFloat(document.getElementById('ci-months').value) || 0;
-            const contributed = monthly * months;
-
-            const values = ciScenarios.map(s => ({
-                ...s,
-                total: fv(monthly, s.rate, months)
-            }));
-            const maxVal = Math.max(...values.map(v => v.total), 1);
-
-            const html = values.map(v => {
-                const widthPct = Math.max(2, (v.total / maxVal) * 100);
-                const extra = v.total - contributed;
-                const extraClass = extra > 0 ? '' : 'zero';
-                const extraText = extra > 0
-                    ? '+' + fmt(extra) + ' de interés'
-                    : 'sin interés';
-                return `
-                    <div class="ci-row">
-                        <div class="ci-label">${v.icon} ${v.name} <span style="color:var(--dim); font-size:0.78rem;">(${(v.rate*100).toFixed(0)}%)</span></div>
-                        <div class="ci-bar-wrap"><div class="ci-bar" style="width:${widthPct}%; background:${v.color};"></div></div>
-                        <div class="ci-val">${fmt(v.total)}<small class="${extraClass}">${extraText}</small></div>
-                    </div>
-                `;
-            }).join('');
-
-            document.getElementById('compound-chart').innerHTML = html;
-        }
-
         buildGoals();
         calcNatillera();
-        updateCompoundChart();
     </script>
     <script src="../program-state.js"></script>
 </body>


### PR DESCRIPTION
Repetition removed (4 sections):
- '¿Qué hace que una meta se sostenga?' (duplicated idea clave)
- 'Cuando no todo cabe, toca priorizar' (overlapping)
- 'Lo que más suele frenar una meta' (redundant list)
- 'Principio práctico' (restated the point a third time)

New: compound interest chart
- Two inputs (aporte mensual + meses) drive 3 reactive bars.
- Compares Natillera (0%), Cuenta ahorros (2%), CDT (8%) with bar
  widths proportional to highest value. Final amount + interés ganado
  shown next to each bar.
- Shows that interest gap widens dramatically with longer plazos
  (~67k extra at 12 months vs ~2M extra at 60 months for the same
  150k monthly aporte). Makes 'el tiempo importa' tangible.

New: 'Dónde guardar la meta' — 4 honest options
- Replaces the previous 4-card section that conflated where (vehicle)
  with how (mechanism).
- Each option shows cómo funciona / pro / contra.
- Natillera (~0%), Cuenta ahorros (~2%), CDT (~6-10%), Stablecoin USDC.
- Stablecoin section names 4 Colombian platforms as fact (Wenia,
  Nequi USD, Binance Colombia, Lulo Bank) — not endorsement.
- Honest cons explicitly stated: not Fogafin-insured, Circle as
  centralized issuer with freeze power, conversion fees in both
  directions, USD's own ~2-3% inflation. Avoids the common error
  of teaching stablecoins as 'free money in dollars'.

New: warning box for stablecoins
- Explicit: not for emergency fund, not for <3 month plata.
- For mediano plazo (12+ months) protecting against peso devaluation.
- Names the trade-off honestly: if peso strengthens, you lose in pesos.

Preserved: goals planner with 3 goals + income + summary panel.
Natillera simulator preserved (reframed as 'Más detalle sobre la
natillera' accordion). All JS untouched except 2 new functions
(fv() annuity formula, updateCompoundChart() chart renderer).
