### PR TITLE
Kits: card + Lightning only (remove on-chain + money-back), add ✓ checkmarks

### DIFF
--- a/assets/snippets/styles.css
+++ b/assets/snippets/styles.css
@@ -51,6 +51,7 @@ body { background: var(--bsa-bg); color: var(--bsa-text); font-family: var(--bsa
 .bsa-includes ul { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
 .bsa-includes li { background: var(--bsa-surface); border: 1px solid var(--bsa-border); border-radius: var(--bsa-radius); padding: 16px 18px; margin: 0; font-size: .95rem; color: var(--bsa-muted); line-height: 1.5; }
 .bsa-includes li strong { display: block; color: var(--bsa-text); font-weight: 600; font-size: 1.02rem; margin-bottom: .25rem; }
+.bsa-includes li strong::before { content: "✓ "; color: var(--bsa-primary); font-weight: 700; }
 
 /* callout */
 .bsa-callout { background: var(--bsa-surface); border: 1px solid var(--bsa-border); border-left: 4px solid var(--bsa-primary); border-radius: 0 var(--bsa-radius) var(--bsa-radius) 0; padding: 1.3rem 1.4rem; margin: 1.6rem 0; }

--- a/products/advisor-bitcoin-client-kit/index.html
+++ b/products/advisor-bitcoin-client-kit/index.html
@@ -89,17 +89,10 @@
       <p style="margin:0 0 .6em;">Lightning Address: <code>sovereigndwp@getalby.com</code></p>
       <img src="https://api.qrserver.com/v1/create-qr-code/?data=lightning%3Asovereigndwp%40getalby.com&size=300x300&margin=10" alt="Lightning QR: sovereigndwp@getalby.com" width="300" height="300" loading="lazy" />
       <p class="ln-after">Scan with any Lightning wallet and enter <strong>$499</strong>. <strong>After paying:</strong> email <a href="mailto:thesovereign.academy@proton.me?subject=BSA%20order%20%E2%80%94%20Bitcoin%20Continuity%20Operational%20Packet%20%28%24499%29&body=I%20just%20paid%20%24499%20to%20sovereigndwp%40getalby.com%20for%20the%20Bitcoin%20Continuity%20Operational%20Packet.%0APlease%20send%20the%20PDF%20to%20this%20email%20address.%0A%0ALightning%20payment%20preimage%20or%20screenshot%20%28optional%2C%20helps%20us%20match%20fast%29%3A">thesovereign.academy@proton.me</a> from the address you want the deliverables sent to.</p>
-      <details class="bsa-fallback">
-        <summary>Prefer on-chain Bitcoin? (slower, higher fees)</summary>
-        <form method="post" action="https://btcpay0.voltageapp.io/apps/2CtKbtyMg3gsuDsokBYEzfKRvUnq/pos" target="_blank" autocomplete="off">
-          <input type="hidden" name="choiceKey" value="bitcoin-continuity-operational-package" />
-          <button type="submit" class="bsa-btn-secondary">Pay on-chain via BTCPay</button>
-        </form>
-      </details>
     </div>
   </details>
 
-  <p class="kit-reassure">Delivered by email within the hour after payment confirms · refunds before delivery only — the editable .docx bundle is non-refundable once sent.</p>
+  <p class="kit-reassure">Delivered by email within the hour after payment confirms.</p>
   <p class="bsa-meta" style="margin-top:14px;">Founding price; future v2 will go to $799 for new buyers — existing buyers get the upgrade free. Need a USD invoice with sats settlement? Email <a href="mailto:thesovereign.academy@proton.me">thesovereign.academy@proton.me</a>.</p>
 </aside>
 

--- a/products/family-bitcoin-recovery-kit/index.html
+++ b/products/family-bitcoin-recovery-kit/index.html
@@ -93,17 +93,10 @@
       <p style="margin:0 0 .6em;">Lightning Address: <code>sovereigndwp@getalby.com</code></p>
       <img src="https://api.qrserver.com/v1/create-qr-code/?data=lightning%3Asovereigndwp%40getalby.com&size=300x300&margin=10" alt="Lightning QR: sovereigndwp@getalby.com" width="300" height="300" loading="lazy" />
       <p class="ln-after">Scan with any Lightning wallet and enter <strong>$149</strong>. <strong>After paying:</strong> email <a href="mailto:thesovereign.academy@proton.me?subject=BSA%20order%20%E2%80%94%20Family%20Bitcoin%20Recovery%20Kit%20%28%24149%29&body=I%20just%20paid%20%24149%20to%20sovereigndwp%40getalby.com%20for%20the%20Family%20Bitcoin%20Recovery%20Kit.%0APlease%20send%20the%20PDF%20to%20this%20email%20address.%0A%0ALightning%20payment%20preimage%20or%20screenshot%20%28optional%2C%20helps%20us%20match%20fast%29%3A">thesovereign.academy@proton.me</a> from the address you want the PDF delivered to. PDF arrives within the hour.</p>
-      <details class="bsa-fallback">
-        <summary>Prefer on-chain Bitcoin? (slower, higher fees)</summary>
-        <form method="post" action="https://btcpay0.voltageapp.io/apps/2CtKbtyMg3gsuDsokBYEzfKRvUnq/pos" target="_blank" autocomplete="off">
-          <input type="hidden" name="choiceKey" value="family-bitcoin-recovery-kit" />
-          <button type="submit" class="bsa-btn-secondary">Pay on-chain via BTCPay</button>
-        </form>
-      </details>
     </div>
   </details>
 
-  <p class="kit-reassure">Delivered by email within the hour after payment confirms · 7-day full-sats refund if it is not what you expected.</p>
+  <p class="kit-reassure">Delivered by email within the hour after payment confirms.</p>
   <p class="bsa-meta" style="margin-top:14px;">Already bought the Starter Kit? Email <a href="mailto:thesovereign.academy@proton.me">thesovereign.academy@proton.me</a> and we apply your $49 toward this kit.</p>
 </aside>
 

--- a/products/self-custody-starter-kit/index.html
+++ b/products/self-custody-starter-kit/index.html
@@ -89,17 +89,10 @@
       <p style="margin:0 0 .6em;">Lightning Address: <code>sovereigndwp@getalby.com</code></p>
       <img src="https://api.qrserver.com/v1/create-qr-code/?data=lightning%3Asovereigndwp%40getalby.com&size=300x300&margin=10" alt="Lightning QR: sovereigndwp@getalby.com" width="300" height="300" loading="lazy" />
       <p class="ln-after">Scan with any Lightning wallet and enter <strong>$49</strong>. <strong>After paying:</strong> email <a href="mailto:thesovereign.academy@proton.me?subject=BSA%20order%20%E2%80%94%20Self-Custody%20Starter%20Kit%20%28%2449%29&body=I%20just%20paid%20%2449%20to%20sovereigndwp%40getalby.com%20for%20the%20Self-Custody%20Starter%20Kit.%0APlease%20send%20the%20PDF%20to%20this%20email%20address.%0A%0ALightning%20payment%20preimage%20or%20screenshot%20%28optional%2C%20helps%20us%20match%20fast%29%3A">thesovereign.academy@proton.me</a> from the address you want the PDF delivered to. PDF arrives within the hour.</p>
-      <details class="bsa-fallback">
-        <summary>Prefer on-chain Bitcoin? (slower, higher fees)</summary>
-        <form method="post" action="https://btcpay0.voltageapp.io/apps/2CtKbtyMg3gsuDsokBYEzfKRvUnq/pos" target="_blank" autocomplete="off">
-          <input type="hidden" name="choiceKey" value="self-custody-starter-kit" />
-          <button type="submit" class="bsa-btn-secondary">Pay on-chain via BTCPay</button>
-        </form>
-      </details>
     </div>
   </details>
 
-  <p class="kit-reassure">Delivered by email within the hour after payment confirms · 7-day full-sats refund if it is not what you expected.</p>
+  <p class="kit-reassure">Delivered by email within the hour after payment confirms.</p>
 </aside>
 
 </div><!-- /kit-grid -->


### PR DESCRIPTION
Small, surgical change to the 3 `products/*` kit pages — anchored to the merged content (source of truth), design A (the live look).

## Changes (4 files, +4 / −24)
- **Remove the on-chain Bitcoin (BTCPay) option** from all 3 kits → only **fiat card + Lightning** remain.
- **Remove money-back / refund language** from all 3 reassurance lines (now just "Delivered by email within the hour after payment confirms.").
- **Add orange ✓ checkmarks** to the "What you get" cards (one CSS rule).

## Preserved (unchanged from the merges)
2-of-3 TBA "honest alternative" section, "Created by Dalia" footer, card button (`data-kit`) + Stripe wiring, Lightning address + QR, sats-price spans, mailto/order links.

Verified in preview: no on-chain, no refund text, card + Lightning render, ✓ checkmarks present, live sats working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)