### PR TITLE
fix(api): declare jsonwebtoken in api/package.json to stabilize bundling

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,4 +1,7 @@
 {
   "private": true,
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "jsonwebtoken": "^9.0.2"
+  }
 }


### PR DESCRIPTION
## What
Adds `jsonwebtoken` to `api/package.json` dependencies.

## Why
A cache-reuse **Redeploy** of an unchanged commit (`a6bc370`) produced a function bundle **missing `jsonwebtoken`** → `FUNCTION_INVOCATION_FAILED: Cannot find module 'jsonwebtoken'` on `/api/preview-access` and `/api/verify-access`. A fresh (uncached) build of the same source bundled it fine. Declaring the runtime dep in the functions' own `package.json` gives `@vercel/nft` an explicit manifest signal so the trace is deterministic across cache states.

## Verification
- Preview deploy (`b5ae776`) `/api/preview-access?key=wrong` → **403** (not 500): function + `jsonwebtoken` load correctly. No regression.
- Production already restored via fresh build (`8bf818b3`); full preview-key flow verified live (302 + cookies, open-redirect guard, wrong-key 403).

## Scope / follow-up
`jsonwebtoken` only — the dep that actually failed. `api/` also imports `stripe`, `pg`, `@supabase/supabase-js`, which share the same theoretical fragility but were deliberately left out to avoid pulling unlocked versions into payment/DB code. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)