### PR TITLE
feat(youth): Phase 4 cheap wins — reflect-widget + family-conversation prompts

### DIFF
--- a/youth-families/week-01/index.html
+++ b/youth-families/week-01/index.html
@@ -459,6 +459,15 @@
             </ul>
         </div>
 
+        <!-- Family Conversation (Phase 4 family-catalyst win) -->
+        <div class="family-conversation" style="background: var(--card-bg, #1a3a2e); border-left: 4px solid var(--primary-orange, #FF7A00); border-radius: 0.5rem; padding: 1.25rem 1.5rem; margin: 2rem 0;">
+            <div style="font-weight: 700; display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">💬 Family Conversation</div>
+            <p style="margin: 0; color: var(--text-secondary, #9ca3af);">Ask a parent or guardian about the first thing they ever saved up to buy. What made it worth the wait?</p>
+        </div>
+
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 1: Understanding Money Basics"></div>
+
         <div class="next-week">
             <h3>🎯 Ready for Week 2?</h3>
             <p>Next week we'll learn how money flows in and out with budgeting basics!</p>
@@ -686,5 +695,6 @@
         // Start the game when page loads
         window.addEventListener('load', startGame);
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>

--- a/youth-families/week-02/index.html
+++ b/youth-families/week-02/index.html
@@ -532,6 +532,9 @@
             </div>
         </div>
 
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 2: How Money Flows"></div>
+
         <div class="next-week">
             <h3>🎯 Ready for Week 3?</h3>
             <p>Next week we'll learn saving strategies and goal setting!</p>
@@ -554,5 +557,6 @@
             link.addEventListener('click', markWeekCompleted);
         });
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>

--- a/youth-families/week-03/index.html
+++ b/youth-families/week-03/index.html
@@ -194,6 +194,15 @@
             </div>
         </div>
 
+        <!-- Family Conversation (Phase 4 family-catalyst win) -->
+        <div class="family-conversation" style="background: var(--card-bg, #1a3a2e); border-left: 4px solid var(--primary-orange, #FF7A00); border-radius: 0.5rem; padding: 1.25rem 1.5rem; margin: 2rem 0;">
+            <div style="font-weight: 700; display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">💬 Family Conversation</div>
+            <p style="margin: 0; color: var(--text-secondary, #9ca3af);">Ask a family member how they decide what to save versus spend. Do they “pay themselves first”?</p>
+        </div>
+
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 3: Saving Strategies"></div>
+
         <div class="next-week">
             <h3>🎯 Ready for Week 4?</h3>
             <p>Next week we'll learn about emergency funds and financial safety nets!</p>
@@ -220,5 +229,6 @@
             }
         });
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>

--- a/youth-families/week-04/index.html
+++ b/youth-families/week-04/index.html
@@ -343,6 +343,15 @@
             </div>
         </div>
 
+        <!-- Family Conversation (Phase 4 family-catalyst win) -->
+        <div class="family-conversation" style="background: var(--card-bg, #1a3a2e); border-left: 4px solid var(--primary-orange, #FF7A00); border-radius: 0.5rem; padding: 1.25rem 1.5rem; margin: 2rem 0;">
+            <div style="font-weight: 700; display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">💬 Family Conversation</div>
+            <p style="margin: 0; color: var(--text-secondary, #9ca3af);">Ask a parent or guardian about a time an unexpected expense hit. How did the family handle it — and what would an emergency fund have changed?</p>
+        </div>
+
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 4: Emergency Fund Basics"></div>
+
         <div class="next-week">
             <h3>🎯 Ready for Week 5?</h3>
             <p>Next week we'll decode your first paycheck and understand taxes!</p>
@@ -374,5 +383,6 @@
             }
         });
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>

--- a/youth-families/week-05/index.html
+++ b/youth-families/week-05/index.html
@@ -520,6 +520,15 @@
             </div>
         </div>
 
+        <!-- Family Conversation (Phase 4 family-catalyst win) -->
+        <div class="family-conversation" style="background: var(--card-bg, #1a3a2e); border-left: 4px solid var(--primary-orange, #FF7A00); border-radius: 0.5rem; padding: 1.25rem 1.5rem; margin: 2rem 0;">
+            <div style="font-weight: 700; display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">💬 Family Conversation</div>
+            <p style="margin: 0; color: var(--text-secondary, #9ca3af);">Ask an adult who works to walk you through a real pay stub. Which deduction was bigger than you expected?</p>
+        </div>
+
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 5: First Paycheck Literacy"></div>
+
         <div class="next-week">
             <h3>🎯 Ready for Week 6?</h3>
             <p>Next week we'll learn smart spending habits and how to avoid money traps!</p>
@@ -625,5 +634,6 @@
         // Calculate on page load
         window.addEventListener('load', calculatePaycheck);
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>

--- a/youth-families/week-06/index.html
+++ b/youth-families/week-06/index.html
@@ -528,6 +528,15 @@
             </div>
         </div>
 
+        <!-- Family Conversation (Phase 4 family-catalyst win) -->
+        <div class="family-conversation" style="background: var(--card-bg, #1a3a2e); border-left: 4px solid var(--primary-orange, #FF7A00); border-radius: 0.5rem; padding: 1.25rem 1.5rem; margin: 2rem 0;">
+            <div style="font-weight: 700; display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">💬 Family Conversation</div>
+            <p style="margin: 0; color: var(--text-secondary, #9ca3af);">Pick one subscription your household pays for and decide together whether it’s worth keeping. Agree to try the 24-hour rule before the next “want” purchase.</p>
+        </div>
+
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 6: Smart Spending Habits"></div>
+
         <div class="next-week" style="margin-top: 2rem;">
             <h3>🎯 Ready for Week 7?</h3>
             <p style="color: var(--text-secondary);">Next week we'll learn about banking, digital payments, and keeping your money safe!</p>
@@ -680,5 +689,6 @@
         // Init
         simulateLifestyle();
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>

--- a/youth-families/week-07/index.html
+++ b/youth-families/week-07/index.html
@@ -523,6 +523,15 @@
             </div>
         </div>
 
+        <!-- Family Conversation (Phase 4 family-catalyst win) -->
+        <div class="family-conversation" style="background: var(--card-bg, #1a3a2e); border-left: 4px solid var(--primary-orange, #FF7A00); border-radius: 0.5rem; padding: 1.25rem 1.5rem; margin: 2rem 0;">
+            <div style="font-weight: 700; display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">💬 Family Conversation</div>
+            <p style="margin: 0; color: var(--text-secondary, #9ca3af);">Ask a family member whether they’ve ever spotted — or fallen for — a scam or sketchy payment request. What was the warning sign?</p>
+        </div>
+
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 7: Banking & Digital Payments"></div>
+
         <div class="next-week">
             <h3>🎯 Ready for Week 8?</h3>
             <p style="color: var(--text-secondary);">Next week we'll tackle college financial planning — costs, FAFSA, and scholarship strategies!</p>
@@ -609,5 +618,6 @@
             }
         }
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>

--- a/youth-families/week-08/index.html
+++ b/youth-families/week-08/index.html
@@ -282,6 +282,15 @@
             </div>
         </div>
 
+        <!-- Family Conversation (Phase 4 family-catalyst win) -->
+        <div class="family-conversation" style="background: var(--card-bg, #1a3a2e); border-left: 4px solid var(--primary-orange, #FF7A00); border-radius: 0.5rem; padding: 1.25rem 1.5rem; margin: 2rem 0;">
+            <div style="font-weight: 700; display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">💬 Family Conversation</div>
+            <p style="margin: 0; color: var(--text-secondary, #9ca3af);">Ask a parent or guardian what they wish they’d known about paying for education. Talk through one way to lower the cost (FAFSA, scholarships, or the 2+2 transfer path).</p>
+        </div>
+
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 8: College Financial Planning"></div>
+
         <div class="next-week">
             <h3>🎯 Ready for Week 9?</h3>
             <p style="color: var(--text-secondary);">Next week: Teen Independence Preparation — real-world budgeting for your first apartment!</p>
@@ -355,5 +364,6 @@
         // Calculate on load
         calculateCost();
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>

--- a/youth-families/week-09/index.html
+++ b/youth-families/week-09/index.html
@@ -293,6 +293,15 @@
             </div>
         </div>
 
+        <!-- Family Conversation (Phase 4 family-catalyst win) -->
+        <div class="family-conversation" style="background: var(--card-bg, #1a3a2e); border-left: 4px solid var(--primary-orange, #FF7A00); border-radius: 0.5rem; padding: 1.25rem 1.5rem; margin: 2rem 0;">
+            <div style="font-weight: 700; display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem;">💬 Family Conversation</div>
+            <p style="margin: 0; color: var(--text-secondary, #9ca3af);">Ask an adult what their first month living on their own actually cost. Compare it to the budget you just built.</p>
+        </div>
+
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 9: Teen Independence Preparation"></div>
+
         <div class="next-week">
             <h3>🎯 Ready for Week 10?</h3>
             <p style="color: var(--text-secondary);">Final week: Family Financial Planning — bringing it all together with collaborative goal-setting!</p>
@@ -403,5 +412,6 @@
 
         calculateBudget();
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>

--- a/youth-families/week-10/index.html
+++ b/youth-families/week-10/index.html
@@ -298,6 +298,9 @@
             </div>
         </div>
 
+        <!-- Socratic reflection (Phase 4 reflection win) -->
+        <div class="reflect-widget" data-topic="money" data-path="youth-families" data-title="Week 10: Family Financial Planning"></div>
+
         <div class="completion-section">
             <h3>🎉 Congratulations!</h3>
             <p style="color: var(--text-secondary); margin-bottom: 1rem;">You've completed the 10-week Youth & Families Financial Literacy Program.</p>
@@ -351,5 +354,6 @@
             }
         }
     </script>
+    <script src="/js/reflect-widget.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Acts on the two highest-ROI cross-cutting findings from the Phase 4 audit (`reports/pedagogy-youth-audit-2026-06-06.md`, wins A + B) — no page redesign, just the gaps the scorecard flagged.

## What changed (10 youth-families week lessons)
- **Socratic reflection** (criterion 13 scored **1** across the whole track — the reflect-widget was genuinely absent; these pages loaded *no* external scripts): mount `reflect-widget` on **all 10** weeks (`data-topic="money"`, per-week `data-title`).
- **Family-conversation catalyst** (criterion 12 averaged **1.90** on a brand whose identity is *custody & inheritance for families*): add **one** parent/guardian conversation prompt per lesson, tied to that week's topic. Applied to the **8 weeks scoring ≤2**; skipped week-02 (4) and week-10 (5), already strong.

## Verification (in-browser)
- Both blocks render; reflect-widget auto-initializes with its tiered Quick/Deeper/Why-it-matters UI.
- Family-prompt text contrast **≈4.9:1** (passes WCAG AA 4.5:1) on the page's existing green card.
- No console errors.

![rendered](verified locally via preview — Family Conversation block + mounted reflect-widget on week-04)

## Scope notes (deliberate)
- Index/educator hub pages excluded — A targets *lessons* (where Socratic scored 1).
- Reflect seed questions use the generic `money` topic; per-week custom seeds are a small future follow-up (the `data-title` already gives the tutor per-week context).
- Bigger items from the audit (front-door redesign, restate→compute calculators) are separate, spec-first efforts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)