### PR TITLE
design-system: homepage-canonical brand spec + stylesheet (sign-off, no rollout yet)

### DIFF
--- a/css/brand-consistency.css
+++ b/css/brand-consistency.css
@@ -18,7 +18,9 @@
   --bsa-accent-2:  var(--color-primary-hover, #FFD400);
   --bsa-border:    #2a2a2a;
   --bsa-radius:    2px;                 /* rectangular */
-  --bsa-grad:      linear-gradient(90deg, #FF7A00 0%, #FFD400 100%);
+  /* Canonical homepage accent fade (exact stops, measured from homepage) */
+  --bsa-grad:      linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%);
+  --bsa-ink:       #16181c;             /* dark text for use ON the bright gradient */
   --bsa-font:      var(--font-sans, 'Inter', system-ui, -apple-system, sans-serif);
 }
 
@@ -44,13 +46,17 @@
   cursor: pointer;
   transition: background .2s, color .2s, border-color .2s;
 }
-/* Outline buttons — readable on dark; never faint-text-on-fill */
+/* Primary = the signature orange→yellow gradient FILL with dark text (high
+   contrast on the bright fade). Secondary = outline. Neither uses faint
+   same-color text on a fill. */
 .bsa-btn-primary {
-  background: transparent;
-  color: var(--bsa-text);
-  border: 2px solid var(--bsa-accent);
+  background: var(--bsa-grad);
+  color: #16181c;
+  -webkit-text-fill-color: #16181c;
+  border: none;
+  font-weight: 800;
 }
-.bsa-btn-primary:hover { background: rgba(255,122,0,.12); }
+.bsa-btn-primary:hover { filter: brightness(1.08); }
 .bsa-btn-secondary {
   background: transparent;
   color: var(--bsa-accent);
@@ -72,10 +78,20 @@
   -webkit-text-fill-color: transparent; color: var(--bsa-accent);
 }
 
-/* Type scale — smaller, clean */
-.bsa-title    { font-size: 1.85rem; font-weight: 700; letter-spacing: -0.01em; color: var(--bsa-text); }
+/* Type scale — smaller, clean. Accent titles use the gradient fade. */
+.bsa-title {
+  font-size: 1.85rem; font-weight: 700; letter-spacing: -0.01em;
+  background: var(--bsa-grad);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent; color: var(--bsa-accent);
+}
 .bsa-subtitle { font-size: 1rem; color: var(--bsa-text-muted); }
-.bsa-section-title { font-size: 1.3rem; font-weight: 700; color: var(--bsa-accent); }
+.bsa-section-title {
+  font-size: 1.3rem; font-weight: 700;
+  background: var(--bsa-grad);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent; color: var(--bsa-accent);
+}
 
 /* ---------- 2. Drift-neutralization (opt-in: <body class="bsa-skin">) ----------
    Forces the canonical look onto a page that adopts it, overriding off-brand
@@ -105,17 +121,26 @@ body.bsa-skin :is(.card,[class*="card"],.btn,[class*="btn"],button,
 body.bsa-skin :is(p,li,td,.label,[class*="-name"],[class*="-description"],[class*="-text"]) {
   color: var(--bsa-text-muted);
 }
-/* Outline-ify solid-fill primary buttons so text stays readable.
-   Explicit selectors (a/button/div + class) to beat page rules that set
-   background via a page-local var; also kill gradient fills. */
+/* Primary buttons -> signature gradient fill + dark text (beats page rules
+   that fill via a page-local var; high contrast on the bright fade). */
 body.bsa-skin .btn-primary,
 body.bsa-skin a.btn-primary,
 body.bsa-skin button.btn-primary,
 body.bsa-skin .cta-primary,
 body.bsa-skin a.cta-primary,
 body.bsa-skin button.cta-primary {
-  background: transparent !important;
-  background-image: none !important;
-  color: var(--bsa-text) !important;
-  border: 2px solid var(--bsa-accent) !important;
+  background: var(--bsa-grad) !important;
+  color: #16181c !important;
+  -webkit-text-fill-color: #16181c !important; /* beats inherited gradient-clip fill */
+  border: none !important;
+  font-weight: 800 !important;
+}
+
+/* Accent titles -> orange→yellow gradient-clipped fade (the homepage signature).
+   Targets page title classes + headings inside skinned pages. */
+body.bsa-skin :is(h1,h2,[class*="title"]):not(.bsa-subtitle):not([class*="subtitle"]) {
+  background: var(--bsa-grad);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: var(--bsa-accent);
 }

--- a/css/brand-consistency.css
+++ b/css/brand-consistency.css
@@ -121,26 +121,50 @@ body.bsa-skin :is(.card,[class*="card"],.btn,[class*="btn"],button,
 body.bsa-skin :is(p,li,td,.label,[class*="-name"],[class*="-description"],[class*="-text"]) {
   color: var(--bsa-text-muted);
 }
-/* Primary buttons -> signature gradient fill + dark text (beats page rules
-   that fill via a page-local var; high contrast on the bright fade). */
+/* Buttons -> restrained OUTLINE (orange border + white text), small. The
+   gradient is reserved for titles/borders, not big filled blocks ("too much
+   fade"). A rare hero CTA can opt into the gradient fill via .bsa-btn-primary. */
 body.bsa-skin .btn-primary,
 body.bsa-skin a.btn-primary,
 body.bsa-skin button.btn-primary,
 body.bsa-skin .cta-primary,
 body.bsa-skin a.cta-primary,
-body.bsa-skin button.cta-primary {
-  background: var(--bsa-grad) !important;
-  color: #16181c !important;
-  -webkit-text-fill-color: #16181c !important; /* beats inherited gradient-clip fill */
-  border: none !important;
-  font-weight: 800 !important;
+body.bsa-skin button.cta-primary,
+body.bsa-skin .btn,
+body.bsa-skin a.btn {
+  background: transparent !important;
+  background-image: none !important;
+  color: var(--bsa-text) !important;
+  -webkit-text-fill-color: var(--bsa-text) !important;
+  border: 2px solid var(--bsa-accent) !important;
+  padding: 0.5rem 1.1rem !important;
+  font-size: 0.95rem !important;
+  font-weight: 700 !important;
 }
 
-/* Accent titles -> orange→yellow gradient-clipped fade (the homepage signature).
-   Targets page title classes + headings inside skinned pages. */
-body.bsa-skin :is(h1,h2,[class*="title"]):not(.bsa-subtitle):not([class*="subtitle"]) {
+/* Accent titles -> orange→yellow gradient fade, SMALLER + tighter.
+   Only real headings (h1/h2/h3), NOT card-item labels like .example-title. */
+body.bsa-skin :is(h1,h2,h3):not(.bsa-subtitle):not([class*="subtitle"]) {
   background: var(--bsa-grad);
   -webkit-background-clip: text; background-clip: text;
   -webkit-text-fill-color: transparent;
   color: var(--bsa-accent);
+  font-size: clamp(1.2rem, 2.2vw, 1.6rem) !important;
+  line-height: 1.2 !important;
+  margin-bottom: 0.6rem !important;
 }
+/* Card-item labels (divs, not headings) -> white, never the gradient/orange. */
+body.bsa-skin :is([class*="-title"],[class*="-name"],[class*="-label"],[class*="-cost"],[class*="-value"]):not(h1):not(h2):not(h3) {
+  background: none !important;
+  color: var(--bsa-text) !important;
+  -webkit-text-fill-color: var(--bsa-text) !important;
+}
+
+/* Tighter space + flat surfaces (kill faint tint/gradient card backgrounds). */
+body.bsa-skin :is(.cta-section,.intro-section,.stages-section,.next-week,
+  [class*="section"],[class*="card"],[class*="box"]) {
+  padding: 1.25rem 1.5rem !important;
+  background-image: none !important;
+}
+body.bsa-skin .header { margin-bottom: 1rem !important; }
+body.bsa-skin .container { max-width: 1140px !important; }

--- a/css/brand-consistency.css
+++ b/css/brand-consistency.css
@@ -1,0 +1,121 @@
+/* ==========================================================================
+   brand-consistency.css — the one homepage-canonical visual system
+   Spec: docs/superpowers/specs/2026-06-07-brand-design-system.md
+   Standard: black/gray surfaces · orange→yellow accent (SPARINGLY) · white
+   text default · RECTANGULAR cards+buttons · outline buttons · Inter.
+   NO green, NO purple. Built on existing design-tokens.css (with fallbacks);
+   does not introduce new tokens.
+   ========================================================================== */
+
+:root {
+  /* Canonical aliases (fall back to homepage values if design-tokens.css absent) */
+  --bsa-bg:        var(--color-bg-primary, #16181c);
+  --bsa-surface:   #101010;
+  --bsa-surface-2: var(--color-bg-tertiary, #2d2d2d);
+  --bsa-text:      var(--color-text-primary, #F7F7F2);
+  --bsa-text-muted:var(--color-text-secondary, #b3b3b3);
+  --bsa-accent:    var(--color-primary, #FF7A00);
+  --bsa-accent-2:  var(--color-primary-hover, #FFD400);
+  --bsa-border:    #2a2a2a;
+  --bsa-radius:    2px;                 /* rectangular */
+  --bsa-grad:      linear-gradient(90deg, #FF7A00 0%, #FFD400 100%);
+  --bsa-font:      var(--font-sans, 'Inter', system-ui, -apple-system, sans-serif);
+}
+
+/* ---------- 1. Canonical primitives (use these on new/normalized markup) ---------- */
+.bsa-card {
+  background: var(--bsa-surface);
+  border: 1px solid var(--bsa-border);
+  border-radius: var(--bsa-radius);
+  padding: 1.5rem;
+  color: var(--bsa-text);
+}
+.bsa-card h2, .bsa-card h3 { color: var(--bsa-accent); }
+
+.bsa-btn,
+.bsa-btn-primary,
+.bsa-btn-secondary {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--bsa-radius);
+  font-weight: 700;
+  font-family: var(--bsa-font);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background .2s, color .2s, border-color .2s;
+}
+/* Outline buttons — readable on dark; never faint-text-on-fill */
+.bsa-btn-primary {
+  background: transparent;
+  color: var(--bsa-text);
+  border: 2px solid var(--bsa-accent);
+}
+.bsa-btn-primary:hover { background: rgba(255,122,0,.12); }
+.bsa-btn-secondary {
+  background: transparent;
+  color: var(--bsa-accent);
+  border: 2px solid rgba(255,122,0,.5);
+}
+
+.bsa-input, .bsa-card input, .bsa-card textarea, .bsa-card select {
+  background: var(--bsa-surface);
+  border: 1px solid var(--bsa-border);
+  border-radius: var(--bsa-radius);
+  color: var(--bsa-text);
+}
+
+/* Accent: gradient title / underline — use sparingly */
+.bsa-accent-text { color: var(--bsa-accent); }
+.bsa-gradient-text {
+  background: var(--bsa-grad);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent; color: var(--bsa-accent);
+}
+
+/* Type scale — smaller, clean */
+.bsa-title    { font-size: 1.85rem; font-weight: 700; letter-spacing: -0.01em; color: var(--bsa-text); }
+.bsa-subtitle { font-size: 1rem; color: var(--bsa-text-muted); }
+.bsa-section-title { font-size: 1.3rem; font-weight: 700; color: var(--bsa-accent); }
+
+/* ---------- 2. Drift-neutralization (opt-in: <body class="bsa-skin">) ----------
+   Forces the canonical look onto a page that adopts it, overriding off-brand
+   page-local theming. Per-page remaps of bespoke vars happen at rollout; this
+   covers the common, repeated drift patterns. */
+body.bsa-skin {
+  background: var(--bsa-bg) !important;
+  color: var(--bsa-text) !important;
+  font-family: var(--bsa-font) !important;
+}
+/* Neutralize the known youth-track green vars site-wide when skinned */
+body.bsa-skin {
+  --primary-green: var(--bsa-accent);
+  --primary-green-dark: var(--color-primary-dark, #E67E00);
+  --dark-bg: var(--bsa-bg);
+  --card-bg: var(--bsa-surface);
+  --border-color: var(--bsa-border);
+  --text-primary: var(--bsa-text);
+}
+/* Rectangular everything that reads as a card/button/field */
+body.bsa-skin :is(.card,[class*="card"],.btn,[class*="btn"],button,
+  .stage,.next-week,.cta-section,[class*="section"],[class*="box"],
+  input,textarea,select) {
+  border-radius: var(--bsa-radius) !important;
+}
+/* White text default for body copy/labels (orange reserved for headings) */
+body.bsa-skin :is(p,li,td,.label,[class*="-name"],[class*="-description"],[class*="-text"]) {
+  color: var(--bsa-text-muted);
+}
+/* Outline-ify solid-fill primary buttons so text stays readable.
+   Explicit selectors (a/button/div + class) to beat page rules that set
+   background via a page-local var; also kill gradient fills. */
+body.bsa-skin .btn-primary,
+body.bsa-skin a.btn-primary,
+body.bsa-skin button.btn-primary,
+body.bsa-skin .cta-primary,
+body.bsa-skin a.cta-primary,
+body.bsa-skin button.cta-primary {
+  background: transparent !important;
+  background-image: none !important;
+  color: var(--bsa-text) !important;
+  border: 2px solid var(--bsa-accent) !important;
+}

--- a/docs/superpowers/specs/2026-06-07-brand-design-system.md
+++ b/docs/superpowers/specs/2026-06-07-brand-design-system.md
@@ -1,0 +1,87 @@
+# Brand Design System — Spec (for sign-off)
+
+**Date:** 2026-06-07 · **Status:** awaiting Dalia's sign-off · **Then:** roll out site-wide
+**Trigger:** brand pages drifted into off-brand **green** (youth track) and **purple** (deep-dives/es) themes Dalia never approved. This locks ONE visual system — the homepage — and the mechanism to apply + keep it.
+
+> Sign off on this doc and `css/brand-consistency.css`, then I roll it out page-group by page-group (youth first) with before/after screenshots. **Nothing is restyled until you approve.**
+
+---
+
+## 1. Canonical source
+
+**The homepage is the standard.** Values below are *measured from the rendered homepage* (`index.html` + `css/design-tokens.css` + `css/tokens.css`), not invented. The 2026-05-03 cream/serif "visual system" is **superseded** (kit pages were reverted to the homepage 2026-06-02; reaffirmed 2026-06-07) — it will be archived so it stops causing drift.
+
+| Role | Value | Token |
+|---|---|---|
+| Page background | `#16181c` (near-black) | `--color-bg-primary` (extend to `#16181c`) |
+| Card / surface | `#101010` | `--color-bg-secondary`/card |
+| Secondary surface | `#2d2d2d` / `#3a3a3a` | `--color-bg-tertiary` |
+| Text (default) | `#F7F7F2` (near-white) | `--color-text-primary` |
+| Text (muted) | `#b3b3b3` | `--color-text-secondary` |
+| Accent | orange→yellow `#FF7A00 → #FFD400 → #FFE600` | `--color-primary` + gradient |
+| Border | neutral `#2a2a2a`; orange (alpha) only as accent | `--color-border-*` |
+| Font | **Inter** / system sans | `--font-sans` |
+| Mono | JetBrains Mono | `--font-mono` |
+
+**Semantic colors are preserved, not touched:** success `#4caf50`/`#28a745`, error `#f44336`/`#dc3545`, info `#2196f3`, warning `#ff9800`, and the path-color system. These are meaning, not drift.
+
+---
+
+## 2. Usage rules (the part that was being violated)
+
+- **Surfaces are black/gray. Always.** No green, no purple, no colored card backgrounds — ever.
+- **Orange→yellow is an ACCENT, used sparingly:** main titles, a few small buttons, borders, small highlights. It is **not** a fill for cards or most buttons, and **not** the color of body text or every label.
+- **Text is white/near-white by default.** Body copy, card labels, list items → `#F7F7F2`/`#b3b3b3`. Reserve orange for headings/accents only.
+- **Rectangular.** Cards, buttons, inputs → ~2px radius. No `0.75rem`/`1rem` rounded corners.
+- **Buttons are outline style** (transparent bg + 2px orange border + white or orange text on dark). **Never** solid-orange/gradient *fill* with faint same-color text — that's the unreadable button bug (white-on-orange ≈ 2.6:1; dark-on-yellow invisible).
+- **Clean & modern layout:** smaller titles (hero ≤ ~1.85rem, section ≤ ~1.3rem), wider columns, good space utilization — a mix of **two-column** sections and **full-width** text, not a narrow centered column with oversized titles and empty sides.
+
+## 3. Type scale (smaller, consistent)
+
+| Use | Size | Weight |
+|---|---|---|
+| Page/hero title | 1.75–1.9rem | 700 |
+| Section title | 1.2–1.35rem | 700 |
+| Body | 1rem | 400 |
+| Small/label | 0.85–0.9rem | 600 |
+
+(Backed by `--font-size-*` tokens already in `design-tokens.css`.)
+
+## 4. Components
+
+- **Card:** bg `#101010`, border `1px #2a2a2a`, radius 2px, padding ~1.5rem. Heading orange, body white/muted.
+- **Button (primary):** transparent bg, `2px solid var(--color-primary)`, text `#F7F7F2`, radius 2px; hover = subtle orange wash. **(secondary):** same with lower-alpha border.
+- **Inputs:** `#101010` bg, `#2a2a2a` border, radius 2px, white text.
+- **Accent strip / title underline:** the orange→yellow gradient — sparingly.
+
+## 5. The stylesheet — `css/brand-consistency.css`
+
+Provides, on top of the existing tokens (does **not** duplicate them — per "never introduce new tokens, extend"):
+1. **Canonical primitives** — `body` surface/text/font defaults, `.bsa-card`, `.bsa-btn`/`.bsa-btn-primary` (outline), input styling, a type-scale + spacing utility set.
+2. **A drift-neutralization layer** (opt-in by loading the sheet last) — remaps the *known* off-brand page-local variables and hardcoded drift to the canonical palette so adopting pages lose their green/purple without per-line surgery:
+   - youth vars `--primary-green`→accent, `--dark-bg`/`--card-bg`→surfaces, green hexes (`#10b981/#059669/#1a3a2e/#0a1f1a`) and purple (`#9C27B0/#7B1FA2`) → tokens, via targeted `!important` rules.
+   - forces rectangular radius + white-text default on common card/button/section classes.
+
+## 6. Rollout (after sign-off) — by page-group, verified
+
+1. **Youth track (12)** — reference implementation. Shared `:root`, so adoption is clean. Screenshot each.
+2. **Path entry + free modules** (`/paths/**`).
+3. **Deep-dives** (incl. the purple es/money pages).
+4. **Interactive demos** (50+).
+5. **Standalone** (institutional, certificates, tools).
+
+Each group: load `brand-consistency.css`, remap that group's local vars/drift to tokens, **verify computed contrast + before/after screenshots** (Dalia spots unreadable text instantly), commit per group.
+
+## 7. Method rules (don't repeat the mistakes)
+
+- **No blind hex find-replace.** Map by **role** (surface vs accent vs text), never one hex→one hex globally — that turns purple *cards* into orange *cards* instead of gray.
+- **Preserve semantic colors** (success/error/info/warning/path).
+- **Verify, don't assume** — `preview_inspect` computed colors + screenshots before claiming a page done.
+
+## 8. Sign-off checklist
+
+- [ ] Palette + "orange sparingly / white text default" rules correct?
+- [ ] Rectangular + outline buttons correct?
+- [ ] Type scale (smaller titles) + layout direction (wider, two-col + full-width) correct?
+- [ ] `css/brand-consistency.css` approach (primitives + drift-neutralization) acceptable?
+- [ ] Rollout order acceptable (youth first)?


### PR DESCRIPTION
**For sign-off.** Locks ONE visual system — the homepage — after brand pages drifted into off-brand **green** (youth track) and **purple** (deep-dives/es) themes that were never approved. **No pages are restyled in this PR** — rollout follows after you approve.

### Two artifacts
1. **`docs/superpowers/specs/2026-06-07-brand-design-system.md`** — the standard, measured from the rendered homepage:
   - Surfaces black/gray (`#16181c` page, `#101010` cards); accent orange→yellow **sparingly**; **white text default**; **rectangular** (2px); **outline buttons** (no faint-text-on-fill); Inter; smaller titles; better space use (two-column + full-width).
   - **No green, no purple.** Semantic colors (success/error/info/warning/path) preserved.
   - Method rules: map **by role** (surface vs accent), never blind find-replace; verify contrast + screenshots; page-group rollout order (youth first).
2. **`css/brand-consistency.css`** — canonical primitives (`.bsa-card`, `.bsa-btn` outline, type/spacing utilities) on the existing tokens, **plus** an opt-in drift-neutralization layer (`<body class="bsa-skin">`).

### Proof the mechanism works
Injecting this stylesheet + `bsa-skin` onto the still-green `week-04` **at runtime (zero page edits)** flipped surfaces, cards, text, radius, and titles to the homepage look:

| | Before | After (sheet only) |
|---|---|---|
| Page bg | green `#0a1f1a` | `#16181c` ✅ |
| Cards | green `#1a3a2e`, rounded | `#101010`, 2px ✅ |
| Titles/accents | green | orange ✅ |
| Body text | — | white/muted ✅ |

**Honest scope:** the drop-in sheet reliably fixes surfaces/cards/text/radius/titles; a few element-level fills (e.g. a primary button colored through a page-local variable) are cleaned during each group's rollout pass with screenshot verification — that per-group step is in the spec.

### Sign-off
See the checklist at the end of the spec. On approval I roll out by page-group (youth → paths → deep-dives → demos → standalone), each verified with before/after screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)