### PR TITLE
feat(funnel): wire 3 pages as Family Custody lead magnets

### DIFF
--- a/emergency-kit.html
+++ b/emergency-kit.html
@@ -2088,6 +2088,9 @@
                 <strong><span data-icon="lightbulb"></span> Remember:</strong>
                 Most Bitcoin "emergencies" feel worse than they are. Stay calm, research carefully, and never make hasty decisions under pressure. When in doubt, ask the community (r/Bitcoin, BitcoinTalk) before taking action.
             </div>
+
+            <!-- Family Custody funnel: email capture lead magnet -->
+            <div id="email-capture-page" data-email-capture="family-custody-kit" data-title="🔐 For families holding their own keys" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — focused on protecting your family's Bitcoin. No spam, ever." data-button="Keep me updated"></div>
         </div>
     </div>
 
@@ -2180,5 +2183,7 @@
     </script>
 
 
+    <script src="/js/analytics.js" defer></script>
+    <script src="/js/email-capture.js" defer></script>
     <script src="/js/demo-nav.js"></script>
 </body></html>

--- a/interactive-demos/sovereign-vault/index.html
+++ b/interactive-demos/sovereign-vault/index.html
@@ -991,7 +991,13 @@
 
 <!-- Analytics, Email Capture & Tip CTAs -->
 <div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
-    <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
+    <!-- Closing CTA: free vault tool -> paid prevention (Family Bitcoin Recovery Kit). funnel: family-custody -->
+    <div style="margin-bottom:2rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#f7931a);border-radius:8px;background:rgba(247,147,26,0.06);">
+        <h3 style="margin:0 0 .5rem;">Built your vault here? Make it survivable.</h3>
+        <p style="margin:0 0 1.25rem;color:var(--text-dim,#9aa0aa);">A vault only protects your family if they can actually recover it. The <strong>Family Bitcoin Recovery Kit</strong> turns what you just set up into a structured, family-readable recovery plan — tested backups, a clear sequence, and not a single exposed key.</p>
+        <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#f7931a);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
+    </div>
+    <div id="email-capture-page" data-email-capture="family-custody-vault" data-title="🔐 Protect your family's Bitcoin" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
     <div id="tip-page" data-tip-cta="compact"></div>
 </div>
 <script src="/js/analytics.js" defer></script>

--- a/interactive-demos/sovereign-vault/templates/emergency-doc.html
+++ b/interactive-demos/sovereign-vault/templates/emergency-doc.html
@@ -823,7 +823,13 @@
 
 <!-- Analytics, Email Capture & Tip CTAs -->
 <div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
-    <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
+    <!-- Closing CTA: free emergency-access doc -> paid prevention (Family Bitcoin Recovery Kit). funnel: family-custody -->
+    <div style="margin-bottom:2rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#f7931a);border-radius:8px;background:rgba(247,147,26,0.06);">
+        <h3 style="margin:0 0 .5rem;">This document is step one — not the whole plan.</h3>
+        <p style="margin:0 0 1.25rem;color:var(--text-dim,#9aa0aa);">An emergency access document only works inside a tested recovery plan. The <strong>Family Bitcoin Recovery Kit</strong> is that plan: a structured, family-readable recovery sequence your loved ones can actually follow, without ever exposing your keys.</p>
+        <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#f7931a);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
+    </div>
+    <div id="email-capture-page" data-email-capture="family-custody-emergency-doc" data-title="🔐 Keep your family's recovery plan current" data-subtitle="Get our custody &amp; inheritance guides and updates as they ship — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
     <div id="tip-page" data-tip-cta="compact"></div>
 </div>
 <script src="/js/analytics.js" defer></script>


### PR DESCRIPTION
Convert the Sovereign Vault demo, its emergency-doc template, and the emergency-kit page into attributable Family Custody lead-capture surfaces using the existing email-capture component (no backend changes).

- emergency-kit.html: add email-capture widget (had none) + load analytics.js and email-capture.js
- sovereign-vault/index.html: retune generic newsletter widget to the funnel
- sovereign-vault/templates/emergency-doc.html: same retune

Lead source tags (flow to /api/subscribe as 'source'):
  family-custody-vault, family-custody-emergency-doc, family-custody-kit

api/subscribe.ts already accepts {email, source, page}; no API change.