### PR TITLE
feat(funnel): wire 5 P1 demos to offer CTAs

### DIFF
--- a/interactive-demos/bitcoin-dca-time-machine/index.html
+++ b/interactive-demos/bitcoin-dca-time-machine/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="What dollar-cost averaging actually does to your money — drawdowns, regrets, and all. A truth-telling DCA simulator using real historical Bitcoin prices.">
     <title>DCA Reality Check | Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/demo-cta-footer.css">
 
     <!-- Open Graph -->
     <meta property="og:title" content="DCA Reality Check — what dollar-cost averaging actually does">
@@ -1351,11 +1352,18 @@
 
 <!-- Analytics, Email Capture & Tip CTAs -->
 <div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
+    <div class="demo-cta-footer"
+         data-demo-id="bitcoin-dca-time-machine"
+         data-heading="What to do this week"
+         data-sub="Pick the track that fits you. Each one is a single concrete action."
+         data-tracks='[{"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit — checklists so your stack actually lives in your own custody","href":"/products/self-custody-starter-kit/"},{"audience":"beginner","time":"10 min","action":"See how a real wallet is set up in the Wallet Workshop","href":"/interactive-demos/wallet-workshop/"}]'>
+    </div>
     <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
     <div id="tip-page" data-tip-cta="compact"></div>
 </div>
 <script src="/js/analytics.js" defer></script>
 <script src="/js/email-capture.js" defer></script>
+<script src="/js/demo-cta-footer.js" defer></script>
 <script src="/js/tip-cta.js" defer></script>
 
     <script src="/js/demo-nav.js"></script>

--- a/interactive-demos/index.html
+++ b/interactive-demos/index.html
@@ -4,6 +4,7 @@
     <title>Interactive Demos - Bitcoin Sovereign Academy</title>
     <meta name="description" content="Browse all Bitcoin Sovereign Academy interactive demos - wallets, security, mining, transactions, and more">
     <link rel="stylesheet" href="/css/brand.css">
+    <link rel="stylesheet" href="/css/demo-cta-footer.css">
     <style>
       :root {
         --bg: var(--color-bg);
@@ -996,11 +997,18 @@
 
 <!-- Analytics, Email Capture & Tip CTAs -->
 <div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
+    <div class="demo-cta-footer"
+         data-demo-id="interactive-demos-index"
+         data-heading="Want these for your team?"
+         data-sub="Pick the track that fits you."
+         data-tracks='[{"audience":"advisor","time":"15 min","action":"License these demos for your practice or institution","href":"/institutional"},{"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit — turn the demos into a checklist you actually follow","href":"/products/self-custody-starter-kit/"}]'>
+    </div>
     <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
     <div id="tip-page" data-tip-cta="compact"></div>
 </div>
 <script src="/js/analytics.js" defer></script>
 <script src="/js/email-capture.js" defer></script>
+<script src="/js/demo-cta-footer.js" defer></script>
 <script src="/js/tip-cta.js" defer></script>
 
 </body></html>

--- a/interactive-demos/kyc-best-practices/index.html
+++ b/interactive-demos/kyc-best-practices/index.html
@@ -367,6 +367,7 @@
              data-heading="What to do this week"
              data-sub="Pick the track for your jurisdiction."
              data-tracks='[
+               {"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit — the checklist that turns \"which exchange\" into \"safely off the exchange\"","href":"/products/self-custody-starter-kit/"},
                {"audience":"us-buyer","time":"10 min","action":"Open the On-Ramp Chooser to compare regulated US options","href":"/interactive-demos/onramp-chooser/?region=us"},
                {"audience":"eu-buyer","time":"10 min","action":"Open the On-Ramp Chooser with EU filter","href":"/interactive-demos/onramp-chooser/?region=eu"},
                {"audience":"colombia","time":"15 min","action":"Practice on testnet first, then pick a Colombian exchange","href":"/interactive-demos/testnet-practice-guide/"}

--- a/interactive-demos/onramp-chooser/index.html
+++ b/interactive-demos/onramp-chooser/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitcoin On-Ramp Chooser 2025 | Find Your Perfect Entry Point</title>
     <link rel="stylesheet" href="/css/icons.css">
+    <link rel="stylesheet" href="/css/demo-cta-footer.css">
     <link rel="stylesheet" href="/css/interactive-demos.css">
     <style>
         :root {
@@ -844,11 +845,18 @@
 
 <!-- Analytics, Email Capture & Tip CTAs -->
 <div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
+    <div class="demo-cta-footer"
+         data-demo-id="onramp-chooser"
+         data-heading="What to do this week"
+         data-sub="Pick the track that fits you. Each one is a single concrete action."
+         data-tracks='[{"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit — move from exchange to your own keys with a checklist","href":"/products/self-custody-starter-kit/"},{"audience":"beginner","time":"10 min","action":"Practice a safe first withdrawal on testnet","href":"/interactive-demos/testnet-practice-guide/"}]'>
+    </div>
     <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
     <div id="tip-page" data-tip-cta="compact"></div>
 </div>
 <script src="/js/analytics.js" defer></script>
 <script src="/js/email-capture.js" defer></script>
+<script src="/js/demo-cta-footer.js" defer></script>
 <script src="/js/tip-cta.js" defer></script>
 
     <script src="/js/demo-nav.js"></script>

--- a/multisig-security-demo.html
+++ b/multisig-security-demo.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitcoin Multisig Vault Security Demo</title>
+    <link rel="stylesheet" href="/css/demo-cta-footer.css">
     <style>
         * {
             box-sizing: border-box;
@@ -2839,5 +2840,18 @@
     </script>
 
 
+<!-- Analytics, offer CTA & Email Capture -->
+<div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
+    <div class="demo-cta-footer"
+         data-demo-id="multisig-security-demo"
+         data-heading="What to do this week"
+         data-sub="Pick the track that fits you. Each one is a single concrete action."
+         data-tracks='[{"audience":"family","time":"this week","action":"Get the Family Bitcoin Recovery Kit — a family-readable recovery plan that never exposes your keys","href":"/products/family-bitcoin-recovery-kit/"},{"audience":"holder","time":"15 min","action":"Get single-sig right first in the Wallet Workshop","href":"/interactive-demos/wallet-workshop/"}]'>
+    </div>
+    <div id="email-capture-page" data-email-capture="family-custody-multisig" data-title="🔐 Protect your family's Bitcoin" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
+</div>
+<script src="/js/analytics.js" defer></script>
+<script src="/js/email-capture.js" defer></script>
+<script src="/js/demo-cta-footer.js" defer></script>
     <script src="/js/demo-nav.js"></script>
 </body></html>


### PR DESCRIPTION
Adds offer CTAs to the remaining P1 demo pages using the existing demo-cta-footer pattern.

Changed files:
- interactive-demos/bitcoin-dca-time-machine/index.html
- interactive-demos/index.html
- interactive-demos/kyc-best-practices/index.html
- interactive-demos/onramp-chooser/index.html
- multisig-security-demo.html

Scope:
- Adds offer CTA wiring to 5 demo surfaces.
- Uses existing funnel infrastructure.
- Does not introduce a new lead-gate system.
- Does not modify product pages.
- Does not include youth/audit work or unrelated WIP.

Validation:
- Secret scan passed before push.
- Branch contains one commit: 8c1ea55c.