### PR TITLE
design: paths group brand rollout — bsa-skin + QA fixes + rendered verification

### DIFF
--- a/css/brand-consistency.css
+++ b/css/brand-consistency.css
@@ -154,6 +154,9 @@ body.bsa-skin {
   --sovereign-gold: var(--bsa-accent); --builder-purple: var(--bsa-accent);
   --corporate-purple: var(--bsa-accent); --fedimint-purple: var(--bsa-accent);
   --primary-gold: var(--bsa-accent);
+  --pragmatist-cyan: var(--bsa-accent); --pragmatist-teal: var(--bsa-accent);
+  --accent-skeptic: var(--bsa-accent); --accent-skeptic-dark: var(--bsa-surface-2);
+  --accent-skeptic-light: var(--bsa-accent-2);
 }
 /* Rectangular everything that reads as a card/button/field */
 body.bsa-skin :is(.card,[class*="card"],.btn,[class*="btn"],button,
@@ -173,6 +176,7 @@ body.bsa-skin :is(p,li,td,.label,[class*="-name"],[class*="-description"],[class
 body.bsa-skin :is(.btn-primary,a.btn-primary,button.btn-primary,
   .cta-primary,a.cta-primary,button.cta-primary,
   .start-button,a.start-button,button.start-button,
+  .stage-btn,a.stage-btn,
   .btn,a.btn):not(.btn-danger):not(.btn-warning):not(.btn-success):not(.btn-error) {
   background: transparent !important;
   background-image: none !important;
@@ -188,9 +192,23 @@ body.bsa-skin :is(.btn-primary,a.btn-primary,button.btn-primary,
 body.bsa-skin :is(.btn-primary,a.btn-primary,button.btn-primary,
   .cta-primary,a.cta-primary,button.cta-primary,
   .start-button,a.start-button,button.start-button,
+  .stage-btn,a.stage-btn,
   .btn,a.btn):not(.btn-danger):not(.btn-warning):not(.btn-success):not(.btn-error):hover {
   background: rgba(255,122,0,.12) !important;
   border-color: var(--bsa-accent) !important;
+}
+/* Skip-link focus chip: dark text on the orange chip (white was 2.6:1) */
+body.bsa-skin .skip-link:focus {
+  color: #101010 !important;
+  -webkit-text-fill-color: #101010 !important;
+}
+/* Locked/disabled stage CTAs -> muted, clearly inactive (never orange-on-gray).
+   Repeated class bumps specificity past the restrained rule's :not() chain. */
+body.bsa-skin.bsa-skin.bsa-skin.bsa-skin :is(.stage-card.locked,.locked,[aria-disabled="true"]) :is(.stage-btn,a.stage-btn) {
+  background: transparent !important;
+  border-color: var(--bsa-border) !important;
+  color: var(--bsa-text-muted) !important;
+  -webkit-text-fill-color: var(--bsa-text-muted) !important;
 }
 
 /* Accent titles -> orange→yellow gradient fade, SMALLER + tighter.

--- a/css/brand-consistency.css
+++ b/css/brand-consistency.css
@@ -150,6 +150,10 @@ body.bsa-skin {
   --primary-dark: var(--bsa-bg); --secondary-dark: var(--bsa-surface);
   --text-light: var(--bsa-text); --text-dim: var(--bsa-text-muted);
   --serif: var(--bsa-font); --sans: var(--bsa-font);
+  /* bespoke per-page identity vars found in paths (2026-06-10 sweep) */
+  --sovereign-gold: var(--bsa-accent); --builder-purple: var(--bsa-accent);
+  --corporate-purple: var(--bsa-accent); --fedimint-purple: var(--bsa-accent);
+  --primary-gold: var(--bsa-accent);
 }
 /* Rectangular everything that reads as a card/button/field */
 body.bsa-skin :is(.card,[class*="card"],.btn,[class*="btn"],button,

--- a/css/homepage-bsa-brand-fix.css
+++ b/css/homepage-bsa-brand-fix.css
@@ -280,8 +280,7 @@ em,
 .persona-badge,
 .btn-continue,
 .help-bubble,
-.progress-fill,
-.skip-link {
+.progress-fill {
   background: var(--brand-gradient) !important;
   color: #000000 !important;
   border-color: #FF7A00 !important;

--- a/css/path-bsa-brand-fix.css
+++ b/css/path-bsa-brand-fix.css
@@ -87,7 +87,7 @@ h3,
 .back-link,
 .nav-link,
 .content-section h3,
-a:not(.module-card):not(.gate-link) {
+:is(p, li, td, .breadcrumb, .footer-links, footer) a:not(.module-card):not(.gate-link):not(.stage-btn):not(.skip-link):not([class*="btn"]):not([class*="cta"]):not([style*="background"]) {
   color: #FF7A00 !important;
 }
 

--- a/js/bitcoin-context.js
+++ b/js/bitcoin-context.js
@@ -228,7 +228,7 @@
 .ctx-fee-low strong  { color: #4ade80; }
 .ctx-fee-mid strong  { color: #facc15; }
 .ctx-fee-high strong { color: #f87171; }
-.ctx-halving strong  { color: #c084fc; }
+.ctx-halving strong  { color: #FF7A00; }
 /* WCAG 1.4.3: was #666 (2.85:1) → #a0a0a0 (~5:1) */
 .ctx-loading { color: #a0a0a0; font-style: italic; }
 .ctx-err     { color: #f87171; }

--- a/js/monetary-systems-details.js
+++ b/js/monetary-systems-details.js
@@ -180,7 +180,7 @@ const MonetarySystems = {
         name: "Corporate Coins",
         icon: "🏢",
         tagline: "Platform-based value systems",
-        color: "#8b5cf6", // Purple
+        color: "#2dd4bf", // Teal (category palette)
 
         overview: {
             definition: "Digital currencies or point systems created by tech platforms and corporations for use within their ecosystems.",

--- a/js/subdomain-access-control.js
+++ b/js/subdomain-access-control.js
@@ -296,7 +296,7 @@
                 `;
             } else if (accessLevel === CONFIG.accessLevels.DEV) {
                 bannerHTML = `
-                    <div id="subdomain-access-banner" style="background: linear-gradient(135deg, #8b5cf6, #6366f1); color: white; padding: 0.75rem 1.5rem; text-align: center; font-weight: 600; position: fixed; top: 0; left: 0; right: 0; z-index: 10000; box-shadow: 0 2px 10px rgba(0,0,0,0.3);">
+                    <div id="subdomain-access-banner" style="background: #16181C; border-bottom: 2px solid #FF7A00; color: #F7F7F2; padding: 0.75rem 1.5rem; text-align: center; font-weight: 600; position: fixed; top: 0; left: 0; right: 0; z-index: 10000; box-shadow: 0 2px 10px rgba(0,0,0,0.3);">
                         <span style="font-size: 1.1rem;">🔧 Development Mode</span>
                         <span style="margin: 0 1rem; opacity: 0.7;">|</span>
                         <span style="font-size: 0.9rem;">Full access enabled</span>

--- a/paths/builder/index.html
+++ b/paths/builder/index.html
@@ -12,7 +12,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --text-light: #e0e0e0;
             --text-dim: #b3b3b3;
@@ -508,7 +508,7 @@
         .demo-button {
             padding: 0.6rem 1.2rem;
             background: linear-gradient(135deg, var(--primary-orange), #FFD400);
-            color: white;
+            color: #101010;
             border: none;
             border-radius: 0.5rem;
             font-weight: 600;

--- a/paths/builder/index.html
+++ b/paths/builder/index.html
@@ -863,8 +863,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Hero -->
     <section class="hero">

--- a/paths/builder/stage-1/index.html
+++ b/paths/builder/stage-1/index.html
@@ -361,8 +361,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Stage Header -->
     <header class="stage-header">

--- a/paths/builder/stage-1/index.html
+++ b/paths/builder/stage-1/index.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --text-light: #e0e0e0;
             --text-dim: #999;
@@ -226,7 +226,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1));
+            background: #101010;
             border: 3px solid var(--accent-green);
             border-radius: 1rem;
             padding: 2.5rem;

--- a/paths/builder/stage-1/module-1.html
+++ b/paths/builder/stage-1/module-1.html
@@ -270,8 +270,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/builder/stage-1/module-1.html
+++ b/paths/builder/stage-1/module-1.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --text-light: #e0e0e0;
             --text-dim: #b3b3b3;
@@ -651,7 +651,7 @@
             </section>
 
             <!-- Bitcoin Script (Optional Deep Dive) -->
-            <section class="content-section" style="background: rgba(156, 39, 176, 0.05); border-left: 4px solid var(--builder-purple); border-radius: 0.5rem; padding: 2rem;">
+            <section class="content-section" style="background: #101010; border-left: 4px solid var(--builder-purple); border-radius: 0.5rem; padding: 2rem;">
                 <h2 style="color: var(--builder-purple);">🔬 Optional Deep Dive: Bitcoin Script</h2>
 
                 <p style="background: rgba(255, 193, 7, 0.15); border-left: 4px solid #ffc107; padding: 1rem 1.5rem; margin-bottom: 1.5rem;">

--- a/paths/builder/stage-1/module-2.html
+++ b/paths/builder/stage-1/module-2.html
@@ -263,8 +263,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/builder/stage-1/module-2.html
+++ b/paths/builder/stage-1/module-2.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --text-light: #e0e0e0;
             --text-dim: #b3b3b3;
@@ -654,16 +654,16 @@ SHA-256: b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9</code>
                         <!-- Step 4: Address -->
                         <div class="key-step" style="background: var(--primary-dark); border: 2px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem; opacity: 0.3; transition: all 0.3s ease;">
                             <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
-                                <div style="width: 40px; height: 40px; background: #9c27b0; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: white; font-weight: 700; font-size: 1.2rem;">4</div>
+                                <div style="width: 40px; height: 40px; background: #dc3545; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: white; font-weight: 700; font-size: 1.2rem;">4</div>
                                 <div>
-                                    <h4 style="color: #9c27b0; margin: 0;">Bitcoin Address</h4>
+                                    <h4 style="color: #dc3545; margin: 0;">Bitcoin Address</h4>
                                     <p style="color: var(--text-dim); margin: 0; font-size: 0.9rem;">Hash160 + Base58Check encoding</p>
                                 </div>
                             </div>
-                            <div style="background: var(--secondary-dark); border-radius: 0.5rem; padding: 0.75rem; font-family: 'Courier New', monospace; font-size: 0.95rem; word-break: break-all; color: #9c27b0; font-weight: 600;" id="address-output">
+                            <div style="background: var(--secondary-dark); border-radius: 0.5rem; padding: 0.75rem; font-family: 'Courier New', monospace; font-size: 0.95rem; word-break: break-all; color: #dc3545; font-weight: 600;" id="address-output">
                                 Waiting for public key...
                             </div>
-                            <div style="margin-top: 0.75rem; padding: 0.75rem; background: rgba(156, 39, 176, 0.1); border-radius: 0.5rem; font-size: 0.9rem; color: var(--text-dim);">
+                            <div style="margin-top: 0.75rem; padding: 0.75rem; background: #2D2D2D; border-radius: 0.5rem; font-size: 0.9rem; color: var(--text-dim);">
                                 🏦 Process: SHA-256(Public Key) → RIPEMD-160 → Add version byte → Add checksum → Base58 encode
                             </div>
                         </div>

--- a/paths/builder/stage-1/module-3.html
+++ b/paths/builder/stage-1/module-3.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --text-light: #e0e0e0;
             --text-dim: #b3b3b3;
@@ -162,7 +162,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1));
+            background: #101010;
             border: 3px solid var(--accent-green);
             border-radius: 1rem;
             padding: 2.5rem;
@@ -500,7 +500,7 @@ Eve sends 1.2 BTC to Frank</textarea>
                     </div>
 
                     <!-- Success Animation -->
-                    <div id="successAnimation" style="display: none; background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1)); border: 3px solid var(--accent-green); border-radius: 1rem; padding: 2rem; margin-bottom: 2rem; text-align: center;">
+                    <div id="successAnimation" style="display: none; background: #101010; border: 3px solid var(--accent-green); border-radius: 1rem; padding: 2rem; margin-bottom: 2rem; text-align: center;">
                         <div style="font-size: 4rem; margin-bottom: 1rem;">🎉</div>
                         <h4 style="color: var(--accent-green); font-size: 1.5rem; margin-bottom: 0.5rem;">Block Found!</h4>
                         <div id="successMessage" style="color: var(--text-light); margin-bottom: 1rem;"></div>

--- a/paths/builder/stage-1/module-3.html
+++ b/paths/builder/stage-1/module-3.html
@@ -287,8 +287,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/builder/stage-2/index.html
+++ b/paths/builder/stage-2/index.html
@@ -362,8 +362,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Stage Header -->
     <header class="stage-header">

--- a/paths/builder/stage-2/index.html
+++ b/paths/builder/stage-2/index.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --lightning-yellow: #FFC107;
             --text-light: #e0e0e0;
@@ -227,7 +227,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(255, 193, 7, 0.3), rgba(255, 193, 7, 0.1));
+            background: #101010;
             border: 3px solid var(--lightning-yellow);
             border-radius: 1rem;
             padding: 2.5rem;

--- a/paths/builder/stage-2/module-1.html
+++ b/paths/builder/stage-2/module-1.html
@@ -323,8 +323,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/builder/stage-2/module-1.html
+++ b/paths/builder/stage-2/module-1.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --lightning-yellow: #FFC107;
             --text-light: #e0e0e0;
@@ -941,7 +941,7 @@ Bob uses revocation key to claim ALL 0.8 BTC
                         }
 
                         .sim-btn-alice {
-                            background: #9c27b0;
+                            background: #ec4899;
                             color: white;
                         }
 
@@ -1116,7 +1116,7 @@ Bob uses revocation key to claim ALL 0.8 BTC
                         }
 
                         .alice-bar {
-                            background: linear-gradient(90deg, #9c27b0, #ba68c8);
+                            background: linear-gradient(90deg, #ec4899, #f472b6);
                         }
 
                         .bob-bar {
@@ -1607,7 +1607,7 @@ Bob uses revocation key to claim ALL 0.8 BTC
                             const stepWidth = chartWidth / Math.max(channelState.history.length - 1, 1);
 
                             // Alice's line
-                            ctx.strokeStyle = '#9c27b0';
+                            ctx.strokeStyle = '#ec4899';
                             ctx.lineWidth = 3;
                             ctx.beginPath();
                             channelState.history.forEach((point, i) => {
@@ -1636,7 +1636,7 @@ Bob uses revocation key to claim ALL 0.8 BTC
 
                                 // Alice point
                                 const yAlice = height - padding - (point.alice / channelState.totalCapacity) * chartHeight;
-                                ctx.fillStyle = '#9c27b0';
+                                ctx.fillStyle = '#ec4899';
                                 ctx.beginPath();
                                 ctx.arc(x, yAlice, 4, 0, Math.PI * 2);
                                 ctx.fill();
@@ -1660,7 +1660,7 @@ Bob uses revocation key to claim ALL 0.8 BTC
                             ctx.restore();
 
                             // Legend
-                            ctx.fillStyle = '#9c27b0';
+                            ctx.fillStyle = '#ec4899';
                             ctx.fillRect(width - 150, 20, 20, 10);
                             ctx.fillStyle = '#e0e0e0';
                             ctx.fillText('Alice', width - 125, 29);

--- a/paths/builder/stage-2/module-2.html
+++ b/paths/builder/stage-2/module-2.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --lightning-yellow: #FFC107;
             --text-light: #e0e0e0;

--- a/paths/builder/stage-2/module-2.html
+++ b/paths/builder/stage-2/module-2.html
@@ -337,8 +337,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/builder/stage-2/module-3.html
+++ b/paths/builder/stage-2/module-3.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --lightning-yellow: #FFC107;
             --text-light: #e0e0e0;

--- a/paths/builder/stage-2/module-3.html
+++ b/paths/builder/stage-2/module-3.html
@@ -313,8 +313,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/builder/stage-2/module-4.html
+++ b/paths/builder/stage-2/module-4.html
@@ -515,8 +515,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/builder/stage-2/module-4.html
+++ b/paths/builder/stage-2/module-4.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --lightning-yellow: #FFC107;
             --liquid-teal: #00C9BF;

--- a/paths/builder/stage-3/index.html
+++ b/paths/builder/stage-3/index.html
@@ -213,7 +213,7 @@
         }
 
         .module-cta:hover {
-            background: #7B1FA2;
+            background: #E85F00;
             transform: translateX(5px);
         }
 
@@ -259,7 +259,7 @@
         }
 
         .next-stage-btn:hover {
-            background: #7B1FA2;
+            background: #E85F00;
         }
 
         /* Responsive */
@@ -361,8 +361,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Stage Header -->
     <header class="stage-header">

--- a/paths/builder/stage-3/index.html
+++ b/paths/builder/stage-3/index.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --builder-purple: #9C27B0;
             --text-light: #e0e0e0;
@@ -226,7 +226,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(156, 39, 176, 0.3), rgba(156, 39, 176, 0.1));
+            background: #101010;
             border: 3px solid var(--builder-purple);
             border-radius: 1rem;
             padding: 2.5rem;
@@ -536,7 +536,7 @@
                     const card = document.querySelector(`[data-module="${moduleId}"]`);
                     if (card) {
                         card.style.borderColor = 'var(--builder-purple)';
-                        card.style.background = 'rgba(156, 39, 176, 0.05)';
+                        card.style.background = '#101010';
                     }
                 }
             });

--- a/paths/builder/stage-3/module-1.html
+++ b/paths/builder/stage-3/module-1.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --builder-purple: #9C27B0;
             --text-light: #e0e0e0;
@@ -96,7 +96,7 @@
         }
 
         code {
-            background: rgba(156, 39, 176, 0.1);
+            background: #2D2D2D;
             padding: 0.2rem 0.4rem;
             border-radius: 0.25rem;
             font-family: 'Courier New', monospace;

--- a/paths/builder/stage-3/module-1.html
+++ b/paths/builder/stage-3/module-1.html
@@ -241,7 +241,7 @@
         }
 
         .nav-btn:hover {
-            background: #7B1FA2;
+            background: #E85F00;
         }
 
         .nav-btn-secondary {
@@ -345,8 +345,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/builder/stage-3/module-2.html
+++ b/paths/builder/stage-3/module-2.html
@@ -223,7 +223,7 @@
         }
 
         .nav-btn:hover {
-            background: #7B1FA2;
+            background: #E85F00;
         }
 
         .nav-btn-secondary {
@@ -330,8 +330,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/builder/stage-3/module-2.html
+++ b/paths/builder/stage-3/module-2.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --builder-purple: #9C27B0;
             --text-light: #e0e0e0;
@@ -94,7 +94,7 @@
         }
 
         code {
-            background: rgba(156, 39, 176, 0.1);
+            background: #2D2D2D;
             padding: 0.2rem 0.4rem;
             border-radius: 0.25rem;
             font-family: 'Courier New', monospace;
@@ -117,7 +117,7 @@
         }
 
         .project-box {
-            background: linear-gradient(135deg, rgba(156, 39, 176, 0.15), rgba(156, 39, 176, 0.05));
+            background: #101010;
             border: 2px solid var(--builder-purple);
             border-radius: 1rem;
             padding: 2rem;
@@ -364,7 +364,7 @@
                     In this module, you'll create a functional Bitcoin wallet from scratch. You'll generate HD wallets using industry
                     standards (BIP32/39/44), manage UTXOs, construct and sign transactions, estimate fees, and broadcast to the network.
                 </p>
-                <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(156, 39, 176, 0.1); border-radius: 0.5rem;">
+                <p style="margin-top: 1.5rem; padding: 1rem; background: #2D2D2D; border-radius: 0.5rem;">
                     <strong style="color: var(--builder-purple);">This is the most hands-on module yet.</strong> By the end,
                     you'll have built software that creates real Bitcoin transactions. This is what separates Bitcoin enthusiasts
                     from Bitcoin developers.
@@ -980,7 +980,7 @@ print(f"Transaction broadcast: {txid}")
                         <li>Implement PSBT (Partially Signed Bitcoin Transactions)</li>
                     </ul>
 
-                    <p style="background: rgba(156, 39, 176, 0.1); border-left: 3px solid #9c27b0; padding: 0.75rem 1rem; margin-top: 1.5rem; font-size: 0.95rem;">
+                    <p style="background: #2D2D2D; border-left: 3px solid #dc3545; padding: 0.75rem 1rem; margin-top: 1.5rem; font-size: 0.95rem;">
                         🛠️ <strong>About the starter code below:</strong> the <code># TODO</code> comments are <strong>intentional gaps for you to implement</strong>. Each maps to one of the project requirements above. Treat each <code>pass</code> as "fill me in."
                     </p>
                     <details style="margin-top: 1rem;">

--- a/paths/builder/stage-3/module-3.html
+++ b/paths/builder/stage-3/module-3.html
@@ -272,7 +272,7 @@
         }
 
         .nav-btn:hover {
-            background: #7B1FA2;
+            background: #E85F00;
         }
 
         .nav-btn-secondary {
@@ -361,8 +361,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/builder/stage-3/module-3.html
+++ b/paths/builder/stage-3/module-3.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --builder-purple: #9C27B0;
             --text-light: #e0e0e0;
@@ -95,7 +95,7 @@
         }
 
         code {
-            background: rgba(156, 39, 176, 0.1);
+            background: #2D2D2D;
             padding: 0.2rem 0.4rem;
             border-radius: 0.25rem;
             font-family: 'Courier New', monospace;
@@ -397,7 +397,7 @@
                     and users who expect bank-level security. A single bug can cost thousands of dollars. A poor design choice
                     can leak user privacy. An unhandled edge case can freeze funds.
                 </p>
-                <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(156, 39, 176, 0.1); border-radius: 0.5rem;">
+                <p style="margin-top: 1.5rem; padding: 1rem; background: #2D2D2D; border-radius: 0.5rem;">
                     <strong style="color: var(--builder-purple);">This module teaches you the discipline and practices</strong>
                     that professional Bitcoin developers use to ship reliable, secure software.
                 </p>
@@ -1253,7 +1253,7 @@ class Config:
                     But building applications is just the beginning. The next stage takes you deeper: contributing to Bitcoin Core
                     itself, understanding consensus rules, and becoming part of the protocol development community.
                 </p>
-                <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(156, 39, 176, 0.1); border-radius: 0.5rem;">
+                <p style="margin-top: 1.5rem; padding: 1rem; background: #2D2D2D; border-radius: 0.5rem;">
                     <strong style="color: var(--builder-purple);">You're now a Bitcoin Builder.</strong>
                     You can create applications that handle real value, secure user funds, and contribute to Bitcoin's ecosystem.
                     That's a significant achievement—wear it with pride and responsibility.

--- a/paths/builder/stage-4/index.html
+++ b/paths/builder/stage-4/index.html
@@ -384,8 +384,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Stage Header -->
     <header class="stage-header">

--- a/paths/builder/stage-4/index.html
+++ b/paths/builder/stage-4/index.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --contributor-red: #E53935;
             --text-light: #e0e0e0;
@@ -98,7 +98,7 @@
 
         /* Highlight Box */
         .highlight-box {
-            background: linear-gradient(135deg, rgba(229, 57, 53, 0.2), rgba(229, 57, 53, 0.05));
+            background: #101010;
             border: 2px solid var(--contributor-red);
             border-radius: 1rem;
             padding: 2rem;
@@ -249,7 +249,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(229, 57, 53, 0.3), rgba(229, 57, 53, 0.1));
+            background: #101010;
             border: 3px solid var(--contributor-red);
             border-radius: 1rem;
             padding: 2.5rem;

--- a/paths/builder/stage-4/module-1.html
+++ b/paths/builder/stage-4/module-1.html
@@ -384,8 +384,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/builder/stage-4/module-1.html
+++ b/paths/builder/stage-4/module-1.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --contributor-red: #E53935;
             --text-light: #e0e0e0;

--- a/paths/builder/stage-4/module-2.html
+++ b/paths/builder/stage-4/module-2.html
@@ -429,8 +429,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/builder/stage-4/module-2.html
+++ b/paths/builder/stage-4/module-2.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --contributor-red: #E53935;
             --text-light: #e0e0e0;

--- a/paths/builder/stage-4/module-3.html
+++ b/paths/builder/stage-4/module-3.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #B8B5B0;
+            --accent-green: #28a745;
             --accent-blue: #2196f3;
             --contributor-red: #E53935;
             --text-light: #e0e0e0;

--- a/paths/builder/stage-4/module-3.html
+++ b/paths/builder/stage-4/module-3.html
@@ -470,8 +470,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/index.html
+++ b/paths/curious/index.html
@@ -478,8 +478,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Path Header -->
     <header class="path-header">

--- a/paths/curious/index.html
+++ b/paths/curious/index.html
@@ -90,7 +90,7 @@
         }
 
         .stat-card {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border: 2px solid var(--accent-green);
             border-radius: 0.75rem;
             padding: 1.5rem;
@@ -112,7 +112,7 @@
         .progress-bar {
             width: 100%;
             height: 10px;
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-radius: 5px;
             overflow: hidden;
             margin-top: 2rem;
@@ -120,7 +120,7 @@
 
         .progress-fill {
             height: 100%;
-            background: var(--accent-green);
+            background: #FF7A00;
             transition: width 0.3s ease;
         }
 
@@ -165,7 +165,7 @@
 
         .stage-card.completed {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.05);
+            background: #101010;
         }
 
         .stage-card.current {
@@ -209,7 +209,7 @@
         }
 
         .stage-badge {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
             padding: 0.5rem 1rem;
             border-radius: 2rem;
@@ -219,7 +219,7 @@
         }
 
         .stage-card.locked .stage-badge {
-            background: rgba(153, 153, 153, 0.2);
+            background: #101010;
             color: var(--text-dim);
         }
 
@@ -253,7 +253,7 @@
         }
 
         .stage-card.completed .module-item {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left-color: var(--accent-green);
         }
 
@@ -298,7 +298,7 @@
 
         /* Completion Section */
         .completion-section {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1));
+            background: #101010;
             border: 3px solid var(--accent-green);
             border-radius: 1rem;
             padding: 3rem 2rem;
@@ -813,7 +813,7 @@
                 document.getElementById('stage-2').classList.remove('locked');
                 document.getElementById('stage-2').classList.add('current');
                 document.querySelector('#stage-2 .stage-badge').textContent = 'Continue';
-                document.querySelector('#stage-2 .stage-badge').style.background = 'rgba(255, 122, 0, 0.2)';
+                document.querySelector('#stage-2 .stage-badge').style.background = '#101010';
                 document.querySelector('#stage-2 .stage-badge').style.color = 'var(--primary-orange)';
             }
 
@@ -827,7 +827,7 @@
                 document.getElementById('stage-3').classList.remove('locked');
                 document.getElementById('stage-3').classList.add('current');
                 document.querySelector('#stage-3 .stage-badge').textContent = 'Continue';
-                document.querySelector('#stage-3 .stage-badge').style.background = 'rgba(255, 122, 0, 0.2)';
+                document.querySelector('#stage-3 .stage-badge').style.background = '#101010';
                 document.querySelector('#stage-3 .stage-badge').style.color = 'var(--primary-orange)';
             }
 
@@ -841,7 +841,7 @@
                 document.getElementById('stage-4').classList.remove('locked');
                 document.getElementById('stage-4').classList.add('current');
                 document.querySelector('#stage-4 .stage-badge').textContent = 'Continue';
-                document.querySelector('#stage-4 .stage-badge').style.background = 'rgba(255, 122, 0, 0.2)';
+                document.querySelector('#stage-4 .stage-badge').style.background = '#101010';
                 document.querySelector('#stage-4 .stage-badge').style.color = 'var(--primary-orange)';
             }
 
@@ -902,7 +902,7 @@
                 const badge = stageCard.querySelector('.stage-badge');
                 if (badge) {
                     badge.textContent = '🔒 Preview Locked';
-                    badge.style.background = 'rgba(244, 67, 54, 0.2)';
+                    badge.style.background = '#101010';
                     badge.style.color = '#F44336';
                 }
 
@@ -930,7 +930,7 @@
                 // Add visual lock indicator
                 const lockBadge = document.createElement('div');
                 lockBadge.style.cssText = `
-                    position: absolute; top: 20px; right: 20px; background: rgba(244, 67, 54, 0.9);
+                    position: absolute; top: 20px; right: 20px; background: #dc3545;
                     color: white; padding: 6px 14px; border-radius: 20px; font-size: 12px;
                     font-weight: 700; z-index: 100; box-shadow: 0 2px 8px rgba(0,0,0,0.3);
                 `;

--- a/paths/curious/stage-1/deep-dives/fractional-reserve.html
+++ b/paths/curious/stage-1/deep-dives/fractional-reserve.html
@@ -160,8 +160,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Deep Dive Header -->
     <header class="deep-dive-header">

--- a/paths/curious/stage-1/deep-dives/fractional-reserve.html
+++ b/paths/curious/stage-1/deep-dives/fractional-reserve.html
@@ -15,8 +15,6 @@
             --text-light: #e0e0e0;
             --text-dim: #999;
             --border-color: rgba(255, 122, 0, 0.2);
-            --purple-primary: #9C27B0;
-            --purple-dark: #7B1FA2;
         }
 
         * {
@@ -40,10 +38,10 @@
 
         /* Deep Dive Header */
         .deep-dive-header {
-            background: linear-gradient(135deg, var(--purple-primary), var(--purple-dark));
+            background: #16181C;
             padding: 2rem 0;
             margin-bottom: 3rem;
-            border-bottom: 3px solid var(--purple-primary);
+            border-bottom: 3px solid #dc3545;
         }
 
         .deep-dive-badge {
@@ -187,8 +185,8 @@
         <div class="container">
             <!-- Guiding Question -->
             <section class="content-section">
-                <div style="background: rgba(156, 39, 176, 0.15); border: 2px solid #9C27B0; border-radius: 1rem; padding: 2.5rem; margin-bottom: 3rem; text-align: center;">
-                    <h2 style="color: #9C27B0; margin-bottom: 1rem; font-size: 1.5rem;">🤔 Guiding Question for This Lab</h2>
+                <div style="background: #101010; border: 2px solid #dc3545; border-radius: 1rem; padding: 2.5rem; margin-bottom: 3rem; text-align: center;">
+                    <h2 style="color: #dc3545; margin-bottom: 1rem; font-size: 1.5rem;">🤔 Guiding Question for This Lab</h2>
                     <p style="font-size: 1.2rem; line-height: 1.8; color: var(--text-light); font-weight: 600; font-style: italic;">
                         "If banks can multiply your deposit into many loans,<br>
                         how fragile does that make your savings?"
@@ -210,7 +208,7 @@
             </section>
 
             <!-- Interactive Demo: How Banks Create Money -->
-            <div style="background: linear-gradient(135deg, rgba(33, 150, 243, 0.15), rgba(156, 39, 176, 0.15)); border: 2px solid #2196F3; border-radius: 1rem; padding: 2rem; margin: 2rem 0;">
+            <div style="background: #101010; border: 2px solid #2196F3; border-radius: 1rem; padding: 2rem; margin: 2rem 0;">
                 <div style="text-align: center; margin-bottom: 2rem;">
                     <h2 style="color: #2196F3; font-size: 2rem; margin-bottom: 0.5rem;"><span data-icon="game"></span> Interactive Demo: How Banks Multiply Money</h2>
                     <p style="color: var(--text-dim); font-size: 1.05rem;">
@@ -230,18 +228,18 @@
                     </p>
 
                     <!-- Reserve Ratio Slider -->
-                    <div style="background: rgba(33, 150, 243, 0.1); border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem; margin-bottom: 2rem;">
+                    <div style="background: #101010; border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem; margin-bottom: 2rem;">
                         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
                             <strong style="color: #2196F3;">Reserve Ratio: <span id="reserve-ratio">10</span>%</strong>
                         </div>
                         <input type="range" id="reserve-slider" min="5" max="25" value="10" step="5" style="width: 100%; height: 8px; border-radius: 5px; background: linear-gradient(to right, #F44336, #FFC107, #4CAF50); outline: none; cursor: pointer;">
 
                         <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1.5rem;">
-                            <div style="background: rgba(76, 175, 80, 0.2); border: 2px solid var(--accent-green); border-radius: 0.5rem; padding: 1rem; text-align: center;">
+                            <div style="background: #101010; border: 2px solid var(--accent-green); border-radius: 0.5rem; padding: 1rem; text-align: center;">
                                 <div style="font-size: 0.85rem; color: var(--text-dim); margin-bottom: 0.5rem;">Loaned Out</div>
                                 <div style="font-size: 2rem; font-weight: 700; color: var(--accent-green);">$<span id="loaned-amount">90</span></div>
                             </div>
-                            <div style="background: rgba(255, 122, 0, 0.2); border: 2px solid var(--primary-orange); border-radius: 0.5rem; padding: 1rem; text-align: center;">
+                            <div style="background: #101010; border: 2px solid var(--primary-orange); border-radius: 0.5rem; padding: 1rem; text-align: center;">
                                 <div style="font-size: 0.85rem; color: var(--text-dim); margin-bottom: 0.5rem;">Reserve Kept</div>
                                 <div style="font-size: 2rem; font-weight: 700; color: var(--primary-orange);">$<span id="reserve-amount">10</span></div>
                             </div>
@@ -249,9 +247,9 @@
                     </div>
 
                     <!-- Question -->
-                    <div style="background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; padding: 1.5rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                    <div style="background: #101010; border-left: 4px solid #dc3545; padding: 1.5rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                         <p style="margin: 0; color: var(--text-light); font-size: 1.05rem;">
-                            <strong style="color: #9C27B0;"><span data-icon="chat"></span> Question:</strong><br>
+                            <strong style="color: #dc3545;"><span data-icon="chat"></span> Question:</strong><br>
                             "If the bank just lent out $<span id="question-amount">90</span> of your deposit, how much money exists now — $100 or $<span id="total-question">190</span>?"
                         </p>
                     </div>
@@ -262,7 +260,7 @@
                     </button>
 
                     <!-- Hidden Reveal -->
-                    <div id="reveal-1" style="display: none; margin-top: 1.5rem; background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem;">
+                    <div id="reveal-1" style="display: none; margin-top: 1.5rem; background: #101010; border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem;">
                         <strong style="color: var(--accent-green); font-size: 1.1rem;">✅ Both.</strong>
                         <p style="margin: 1rem 0 0 0; line-height: 1.8;">
                             Your $100 still appears in your account, and someone else now has $<span id="reveal-amount">90</span> to spend.<br>
@@ -292,7 +290,7 @@
                     </button>
 
                     <!-- Result Panel -->
-                    <div style="background: rgba(244, 67, 54, 0.1); border: 2px solid var(--accent-red); border-radius: 0.75rem; padding: 1.5rem;">
+                    <div style="background: #101010; border: 2px solid var(--accent-red); border-radius: 0.75rem; padding: 1.5rem;">
                         <h4 style="color: var(--accent-red); margin-bottom: 1rem; text-align: center;"><span data-icon="chart"></span> Money Multiplication Result</h4>
                         <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; text-align: center;">
                             <div>
@@ -340,9 +338,9 @@
                 </div>
 
                 <!-- Socratic Reflection -->
-                <div style="background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; padding: 1.5rem; border-radius: 0.5rem; margin-bottom: 2rem;">
+                <div style="background: #101010; border-left: 4px solid #dc3545; padding: 1.5rem; border-radius: 0.5rem; margin-bottom: 2rem;">
                     <p style="margin: 0 0 1rem 0; color: var(--text-light); font-size: 1.05rem;">
-                        <strong style="color: #9C27B0;"><span data-icon="chat"></span> Socratic Reflection:</strong><br>
+                        <strong style="color: #dc3545;"><span data-icon="chat"></span> Socratic Reflection:</strong><br>
                         "If your $100 deposit can multiply into $<span id="socratic-total">1,000</span> of loans, who really creates money — the government or private banks?"
                     </p>
                     <p style="margin: 0; color: var(--text-dim); font-style: italic;"><span data-icon="brain"></span> Hint: Over 90% of the money supply comes from commercial bank lending, not from printing presses.
@@ -357,7 +355,7 @@
                     </p>
 
                     <!-- Bank Run Visualization -->
-                    <div id="bank-status" style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 2rem; margin-bottom: 1.5rem; text-align: center; transition: all 0.5s;">
+                    <div id="bank-status" style="background: #101010; border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 2rem; margin-bottom: 1.5rem; text-align: center; transition: all 0.5s;">
                         <div style="font-size: 3rem; margin-bottom: 1rem;">🏦</div>
                         <div style="font-size: 1.25rem; font-weight: 600; color: var(--accent-green);">Bank Status: <span id="bank-status-text">Stable</span></div>
                         <div style="margin-top: 1rem; color: var(--text-dim);">Reserves: <strong style="color: var(--accent-green);">$<span id="bank-reserves">10</span></strong></div>
@@ -368,7 +366,7 @@
                         ⚠️ Trigger Bank Run
                     </button>
 
-                    <div id="bank-run-result" style="display: none; background: rgba(244, 67, 54, 0.1); border: 2px solid var(--accent-red); border-radius: 0.75rem; padding: 1.5rem;">
+                    <div id="bank-run-result" style="display: none; background: #101010; border: 2px solid var(--accent-red); border-radius: 0.75rem; padding: 1.5rem;">
                         <p style="margin: 0; line-height: 1.8;">
                             <strong style="color: var(--accent-red);"><span data-icon="alert"></span> Bank Run Detected!</strong><br><br>
                             "When withdrawals exceed reserves, banks fail — and governments bail them out by creating even more money."<br><br>
@@ -377,9 +375,9 @@
                     </div>
 
                     <!-- Key Insight -->
-                    <div style="background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; padding: 1.5rem; border-radius: 0.5rem; margin-top: 1.5rem;">
+                    <div style="background: #101010; border-left: 4px solid #dc3545; padding: 1.5rem; border-radius: 0.5rem; margin-top: 1.5rem;">
                         <p style="margin: 0; color: var(--text-light); font-size: 1.05rem; line-height: 1.8;">
-                            <strong style="color: #9C27B0;"><span data-icon="lightbulb"></span> Key Insight:</strong><br>
+                            <strong style="color: #dc3545;"><span data-icon="lightbulb"></span> Key Insight:</strong><br>
                             Fractional-reserve banking turns deposits into promises backed by confidence.<br>
                             When too many people withdraw at once, confidence breaks — and so does the system.
                         </p>
@@ -511,7 +509,7 @@
                 withdrawalAmount.textContent = withdrawn;
 
                 if (withdrawn >= 20) {
-                    bankStatus.style.background = 'rgba(244, 67, 54, 0.1)';
+                    bankStatus.style.background = '#101010';
                     bankStatus.style.borderColor = 'var(--accent-red)';
                     statusText.textContent = 'Crisis!';
                     statusText.style.color = 'var(--accent-red)';

--- a/paths/curious/stage-1/deep-dives/money-creation.html
+++ b/paths/curious/stage-1/deep-dives/money-creation.html
@@ -387,8 +387,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Deep Dive Header -->
     <header class="deep-dive-header">
@@ -714,7 +715,7 @@
                     <div style="background: rgba(0,0,0,0.3); border-radius: 0.75rem; padding: 1.5rem; margin-bottom: 2rem;">
                         <h4 style="text-align: center; font-weight: 700; margin-bottom: 1rem; color: var(--primary-orange);">💧 Global Liquidity Meter</h4>
                         <div style="width: 100%; height: 30px; background: #e5e7eb; border-radius: 15px; overflow: hidden; position: relative;">
-                            <div id="liquidity-fill" style="height: 100%; background: linear-gradient(90deg, #ff6b00, #ffd700, #00ff00); border-radius: 15px; transition: width 0.5s ease; width: 50%;"></div>
+                            <div id="liquidity-fill" style="height: 100%; background: linear-gradient(90deg, #FF7A00, #f59e0b, #28a745); border-radius: 15px; transition: width 0.5s ease; width: 50%;"></div>
                         </div>
                         <div style="display: flex; justify-content: space-between; margin-top: 0.5rem; font-size: 0.85rem; color: var(--text-dim);">
                             <span>Tight</span>

--- a/paths/curious/stage-1/deep-dives/money-creation.html
+++ b/paths/curious/stage-1/deep-dives/money-creation.html
@@ -37,8 +37,8 @@
 
         /* Deep Dive Header */
         .deep-dive-header {
-            background: linear-gradient(135deg, #9C27B0, #7B1FA2);
-            border-bottom: 3px solid #9C27B0;
+            background: #dc3545;
+            border-bottom: 3px solid #dc3545;
             padding: 2rem 0;
             position: sticky;
             top: 0;
@@ -91,7 +91,7 @@
             margin-top: 1.5rem;
             padding: 0.75rem 1.5rem;
             background: white;
-            color: #9C27B0;
+            color: #dc3545;
             text-decoration: none;
             border-radius: 0.5rem;
             font-weight: 600;
@@ -413,8 +413,8 @@
             <!-- Lab Introduction -->
             <section class="content-section">
                 <!-- Guiding Question -->
-                <div style="background: rgba(156, 39, 176, 0.15); border: 2px solid #9C27B0; border-radius: 1rem; padding: 2.5rem; margin-bottom: 3rem; text-align: center;">
-                    <h2 style="color: #9C27B0; margin-bottom: 1rem; font-size: 1.5rem;">🤔 Guiding Question for This Lab</h2>
+                <div style="background: #101010; border: 2px solid #dc3545; border-radius: 1rem; padding: 2.5rem; margin-bottom: 3rem; text-align: center;">
+                    <h2 style="color: #dc3545; margin-bottom: 1rem; font-size: 1.5rem;">🤔 Guiding Question for This Lab</h2>
                     <p style="font-size: 1.2rem; line-height: 1.8; color: var(--text-light); font-weight: 600; font-style: italic;">
                         "If new money always enters at specific points,<br>
                         who gets the advantage and who pays the price?"
@@ -435,7 +435,7 @@
                         Both layers create money. They just do it in different ways.
                     </p>
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1rem; margin-top: 2rem;">
-                        <div style="background: rgba(33, 150, 243, 0.1); border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem;">
+                        <div style="background: #101010; border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem;">
                             <div style="font-size: 2rem; margin-bottom: 0.5rem;">🏛️</div>
                             <div style="font-weight: 700; color: #2196F3; margin-bottom: 0.5rem;">Step 1</div>
                             <div style="font-size: 0.95rem;">Where money is born</div>
@@ -445,7 +445,7 @@
                             <div style="font-weight: 700; color: var(--primary-orange); margin-bottom: 0.5rem;">Step 2</div>
                             <div style="font-size: 0.95rem;">How the Fed moves the levers</div>
                         </div>
-                        <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem;">
+                        <div style="background: #101010; border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem;">
                             <div style="font-size: 2rem; margin-bottom: 0.5rem;">🌍</div>
                             <div style="font-weight: 700; color: var(--accent-green); margin-bottom: 0.5rem;">Step 3</div>
                             <div style="font-size: 0.95rem;">What the rest of the world feels</div>
@@ -459,7 +459,7 @@
                     Most people think governments "print" all the money. In reality, <strong style="color: var(--primary-orange);">modern money flows from two connected layers</strong> — the government &amp; central bank (Layer 1), and the banking system (Layer 2).
                 </p>
 
-                <div style="background: rgba(33, 150, 243, 0.1); border-left: 4px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem; margin: 2rem 0;">
+                <div style="background: #101010; border-left: 4px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem; margin: 2rem 0;">
                     <h3 style="color: #2196F3; margin-bottom: 1rem; font-size: 1.1rem;"><span data-icon="water-drop"></span> Layer 1: Base Money (Government + Central Bank)</h3>
                     <ul style="margin: 0; padding-left: 1.5rem; line-height: 1.8;">
                         <li>When the government spends more than it collects in taxes, it borrows by issuing Treasury bonds.</li>
@@ -469,7 +469,7 @@
                     <p style="margin-top: 1rem; font-weight: 600; color: #2196F3;"><span data-icon="lightbulb"></span> Base money = physical cash + bank reserves at the Fed.</p>
                 </div>
 
-                <div style="background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem; margin: 2rem 0;">
+                <div style="background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem; margin: 2rem 0;">
                     <h3 style="color: var(--accent-green); margin-bottom: 1rem; font-size: 1.1rem;"><span data-icon="water-drop"></span> Layer 2: Credit Money (Commercial Banks)</h3>
                     <ul style="margin: 0; padding-left: 1.5rem; line-height: 1.8;">
                         <li>Commercial banks use those reserves as a foundation to make loans.</li>
@@ -491,18 +491,18 @@
                 </div>
 
                 <!-- Nudge to Fractional Reserve Lab -->
-                <div style="background: rgba(156, 39, 176, 0.1); border: 2px solid #9C27B0; border-radius: 1rem; padding: 2rem; margin: 3rem 0; text-align: center;">
+                <div style="background: #101010; border: 2px solid #dc3545; border-radius: 1rem; padding: 2rem; margin: 3rem 0; text-align: center;">
                     <p style="font-size: 1.05rem; line-height: 1.8; color: var(--text-light); margin-bottom: 0.5rem;">
                         When you see this, a simple question appears:
                     </p>
-                    <p style="font-size: 1.15rem; line-height: 1.7; color: #9C27B0; font-weight: 600; margin: 1rem 0 1.5rem 0;">
+                    <p style="font-size: 1.15rem; line-height: 1.7; color: #dc3545; font-weight: 600; margin: 1rem 0 1.5rem 0;">
                         If every dollar starts as someone's promise to repay,<br>
                         what happens when too many promises are made at once?
                     </p>
                     <p style="font-size: 0.95rem; color: var(--text-dim); margin-bottom: 1.5rem;">
                         Want to see the full chain from one deposit to many loans?
                     </p>
-                    <a href="./fractional-reserve.html" style="display: inline-block; padding: 1rem 2rem; background: #9C27B0; color: white; text-decoration: none; border-radius: 0.75rem; font-weight: 700; transition: all 0.3s ease;" onmouseover="this.style.background='#7B1FA2'" onmouseout="this.style.background='#9C27B0'">
+                    <a href="./fractional-reserve.html" style="display: inline-block; padding: 1rem 2rem; background: #dc3545; color: white; text-decoration: none; border-radius: 0.75rem; font-weight: 700; transition: all 0.3s ease;" onmouseover="this.style.background='#c0392b'" onmouseout="this.style.background='#dc3545'">
                         🔬 Open the Fractional Reserve Lab →
                     </a>
                 </div>
@@ -571,7 +571,7 @@
                             </div>
                         </div>
 
-                        <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(156, 39, 176, 0.1); border-left: 3px solid #9C27B0; border-radius: 0.5rem; font-size: 0.95rem; line-height: 1.6;"><span data-icon="brain"></span> <strong>Key Insight:</strong> Over 90% of the money supply comes from commercial bank lending, not from central banks. Central banks create the base, but commercial banks multiply it through the lending process.
+                        <p style="margin-top: 1.5rem; padding: 1rem; background: #101010; border-left: 3px solid #dc3545; border-radius: 0.5rem; font-size: 0.95rem; line-height: 1.6;"><span data-icon="brain"></span> <strong>Key Insight:</strong> Over 90% of the money supply comes from commercial bank lending, not from central banks. Central banks create the base, but commercial banks multiply it through the lending process.
                         </p>
                     </div>
 
@@ -637,7 +637,7 @@
                     
                     <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-bottom: 2rem;">
                         <!-- Assets -->
-                        <div style="background: rgba(33, 150, 243, 0.1); border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem;">
+                        <div style="background: #101010; border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem;">
                             <h4 style="color: #2196F3; text-align: center; margin-bottom: 1.5rem; font-size: 1.1rem;">📊 Assets ($T)</h4>
                             
                             <div style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(0,0,0,0.2); border-radius: 0.5rem;">
@@ -669,7 +669,7 @@
                         </div>
 
                         <!-- Liabilities -->
-                        <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem;">
+                        <div style="background: #101010; border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem;">
                             <h4 style="color: var(--accent-green); text-align: center; margin-bottom: 1.5rem; font-size: 1.1rem;">💰 Liabilities ($T)</h4>
                             
                             <div style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(0,0,0,0.2); border-radius: 0.5rem;">
@@ -740,8 +740,8 @@
                     </div>
 
                     <!-- What Each Button Does -->
-                    <div style="background: rgba(156, 39, 176, 0.1); border: 2px solid #9C27B0; border-radius: 0.75rem; padding: 1.5rem;">
-                        <h4 style="color: #9C27B0; margin-bottom: 1rem; font-size: 1.1rem;">🎯 What Each Lever Does</h4>
+                    <div style="background: #101010; border: 2px solid #dc3545; border-radius: 0.75rem; padding: 1.5rem;">
+                        <h4 style="color: #dc3545; margin-bottom: 1rem; font-size: 1.1rem;">🎯 What Each Lever Does</h4>
                         <div style="display: grid; gap: 1rem;">
                             <div>
                                 <strong style="color: var(--primary-orange);">Quantitative Easing:</strong> The Fed buys more Treasuries or mortgage bonds → Assets go up → Reserves of banks go up → The fountain has more base money
@@ -856,7 +856,7 @@
                         </div>
                     </div>
 
-                    <div id="interest-impact" style="padding: 1.5rem; background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 0.75rem; margin-top: 2rem; text-align: center;">
+                    <div id="interest-impact" style="padding: 1.5rem; background: #101010; border: 2px solid var(--accent-green); border-radius: 0.75rem; margin-top: 2rem; text-align: center;">
                         <div style="font-weight: 600; font-size: 1.1rem; margin-bottom: 0.5rem; color: var(--accent-green);">⚖️ Moderate Credit Flow</div>
                         <div style="font-size: 0.95rem; color: var(--text-light);">Borrowing is affordable. Lending is steady. Economy balanced.</div>
                     </div>
@@ -930,7 +930,7 @@
                     })();
                     </script>
 
-                    <div style="margin-top: 2rem; padding: 1rem; background: rgba(156, 39, 176, 0.1); border-left: 3px solid #9C27B0; border-radius: 0.5rem; font-size: 0.95rem; line-height: 1.6;">
+                    <div style="margin-top: 2rem; padding: 1rem; background: #101010; border-left: 3px solid #dc3545; border-radius: 0.5rem; font-size: 0.95rem; line-height: 1.6;">
                         💭 <strong>Reflection:</strong> How powerful should one small committee be if it can expand or shrink the money supply for everyone?
                     </div>
                 </div>
@@ -964,7 +964,7 @@
                     <h3 style="color: var(--primary-orange); text-align: center; margin-bottom: 1.5rem;">🎯 Interactive Missions</h3>
                     
                     <div style="display: grid; gap: 1.5rem;">
-                        <div style="background: rgba(33, 150, 243, 0.1); border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem;">
+                        <div style="background: #101010; border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem;">
                             <h4 style="color: #2196F3; margin-bottom: 0.75rem;">Mission 1: Spot the Fountain</h4>
                             <p style="margin-bottom: 0.5rem; font-size: 0.95rem;">
                                 Go back to Step 1. You start with $100B in base money and a 10% reserve requirement.
@@ -980,7 +980,7 @@
                             </p>
                         </div>
 
-                        <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem;">
+                        <div style="background: #101010; border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem;">
                             <h4 style="color: var(--accent-green); margin-bottom: 0.75rem;">Mission 2: Extreme Easing</h4>
                             <p style="margin-bottom: 0.5rem; font-size: 0.95rem;">
                                 Go back to Step 2. In the Fed Control Room:
@@ -1065,7 +1065,7 @@
                         </div>
 
                         <!-- Status Message -->
-                        <div id="seesaw-status" style="padding: 1.5rem; background: rgba(76, 175, 80, 0.1); border: 2px solid rgba(76, 175, 80, 0.3); border-radius: 0.75rem; max-width: 500px; margin: 0 auto;">
+                        <div id="seesaw-status" style="padding: 1.5rem; background: #101010; border: 2px solid rgba(76, 175, 80, 0.3); border-radius: 0.75rem; max-width: 500px; margin: 0 auto;">
                             <div style="font-weight: 600; font-size: 1.1rem; margin-bottom: 0.5rem; color: var(--accent-green);">✅ Balanced System</div>
                             <div style="font-size: 0.95rem; color: var(--text-light);">Moderate inflation keeps economy stable. Trust remains high.</div>
                         </div>
@@ -1127,28 +1127,28 @@
                                         <div style="font-weight: 600; font-size: 1.1rem; margin-bottom: 0.5rem; color: #ff9800;">⚠️ Deflation Risk</div>
                                         <div style="font-size: 0.95rem; color: var(--text-light);">Too little money creation. Credit freezes, economy stalls, unemployment rises.</div>
                                     `;
-                                    statusDiv.style.background = 'rgba(255, 152, 0, 0.1)';
+                                    statusDiv.style.background = '#101010';
                                     statusDiv.style.border = '2px solid rgba(255, 152, 0, 0.3)';
                                 } else if (rate <= 8) {
                                     status = `
                                         <div style="font-weight: 600; font-size: 1.1rem; margin-bottom: 0.5rem; color: var(--accent-green);">✅ Balanced System</div>
                                         <div style="font-size: 0.95rem; color: var(--text-light);">Moderate inflation keeps economy stable. Trust remains high.</div>
                                     `;
-                                    statusDiv.style.background = 'rgba(76, 175, 80, 0.1)';
+                                    statusDiv.style.background = '#101010';
                                     statusDiv.style.border = '2px solid rgba(76, 175, 80, 0.3)';
                                 } else if (rate <= 15) {
                                     status = `
                                         <div style="font-weight: 600; font-size: 1.1rem; margin-bottom: 0.5rem; color: #ff9800;">⚠️ Trust Eroding</div>
                                         <div style="font-size: 0.95rem; color: var(--text-light);">High inflation. People lose confidence. Currency weakens. Savings erode.</div>
                                     `;
-                                    statusDiv.style.background = 'rgba(255, 152, 0, 0.1)';
+                                    statusDiv.style.background = '#101010';
                                     statusDiv.style.border = '2px solid rgba(255, 152, 0, 0.3)';
                                 } else {
                                     status = `
                                         <div style="font-weight: 600; font-size: 1.1rem; margin-bottom: 0.5rem; color: #ff6b6b;">❌ Crisis Mode</div>
                                         <div style="font-size: 0.95rem; color: var(--text-light);">Hyperinflation. Trust collapses. People flee to foreign currencies or assets.</div>
                                     `;
-                                    statusDiv.style.background = 'rgba(244, 67, 54, 0.1)';
+                                    statusDiv.style.background = '#101010';
                                     statusDiv.style.border = '2px solid rgba(244, 67, 54, 0.3)';
                                 }
 
@@ -1158,9 +1158,9 @@
                     </script>
                 </div>
 
-                <div style="background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; border-radius: 0.75rem; padding: 1.5rem; margin: 2rem 0;">
+                <div style="background: #101010; border-left: 4px solid #dc3545; border-radius: 0.75rem; padding: 1.5rem; margin: 2rem 0;">
                     <p style="margin: 0; font-size: 1.05rem; line-height: 1.8; color: var(--text-light); text-align: center;">
-                        <strong style="color: #9C27B0;">💭 If trust breaks… the fountain stops flowing.</strong>
+                        <strong style="color: #dc3545;">💭 If trust breaks… the fountain stops flowing.</strong>
                     </p>
                 </div>
 
@@ -1177,8 +1177,8 @@
 
             <!-- Final Reflection -->
             <section class="content-section">
-                <div style="background: linear-gradient(135deg, rgba(156, 39, 176, 0.2), rgba(156, 39, 176, 0.1)); border: 2px solid #9C27B0; border-radius: 1rem; padding: 2.5rem; text-align: center;">
-                    <h2 style="color: #9C27B0; margin-bottom: 1.5rem; font-size: 1.5rem;">💡 Key Takeaway</h2>
+                <div style="background: #101010; border: 2px solid #dc3545; border-radius: 1rem; padding: 2.5rem; text-align: center;">
+                    <h2 style="color: #dc3545; margin-bottom: 1.5rem; font-size: 1.5rem;">💡 Key Takeaway</h2>
                     <p style="font-size: 1.1rem; line-height: 1.9; margin-bottom: 1rem;">
                         When rules are set by a small group, the fountain can grow or shrink in ways most people do not see.
                     </p>

--- a/paths/curious/stage-1/deep-dives/money-creation.html
+++ b/paths/curious/stage-1/deep-dives/money-creation.html
@@ -37,8 +37,8 @@
 
         /* Deep Dive Header */
         .deep-dive-header {
-            background: #dc3545;
-            border-bottom: 3px solid #dc3545;
+            background: #101010;
+            border-bottom: 3px solid #FF7A00;
             padding: 2rem 0;
             position: sticky;
             top: 0;
@@ -90,8 +90,9 @@
             display: inline-block;
             margin-top: 1.5rem;
             padding: 0.75rem 1.5rem;
-            background: white;
-            color: #dc3545;
+            background: transparent;
+            border: 2px solid #FF7A00;
+            color: #FF7A00;
             text-decoration: none;
             border-radius: 0.5rem;
             font-weight: 600;
@@ -147,8 +148,8 @@
         }
 
         .cb-source {
-            background: linear-gradient(135deg, #2196F3, #1976D2);
-            border: 3px solid #1565C0;
+            background: linear-gradient(135deg, #1565C0, #0D47A1);
+            border: 3px solid #0D47A1;
             border-radius: 12px 12px 0 0;
             padding: 1rem 2rem;
             box-shadow: 0 4px 12px rgba(33, 150, 243, 0.3);
@@ -404,7 +405,7 @@
             <h1 class="deep-dive-title">Money Creation Lab</h1>
             <p class="deep-dive-subtitle">Interactive exploration of how modern money is created, controlled, and impacts global markets</p>
             <a href="/deep-dives/money-banking/" class="return-button">← Money &amp; Banking Hub</a>
-            <a href="../module-2.html" class="return-button" style="margin-left: 1rem; background: rgba(255,255,255,0.2); color: white;">Return to Module 2</a>
+            <a href="../module-2.html" class="return-button" style="margin-left: 1rem; background: transparent; border: 2px solid #FF7A00; color: #FF7A00;">Return to Module 2</a>
         </div>
     </header>
 
@@ -415,7 +416,7 @@
             <section class="content-section">
                 <!-- Guiding Question -->
                 <div style="background: #101010; border: 2px solid #dc3545; border-radius: 1rem; padding: 2.5rem; margin-bottom: 3rem; text-align: center;">
-                    <h2 style="color: #dc3545; margin-bottom: 1rem; font-size: 1.5rem;">🤔 Guiding Question for This Lab</h2>
+                    <h2 style="color: #e4606d; margin-bottom: 1rem; font-size: 1.5rem;">🤔 Guiding Question for This Lab</h2>
                     <p style="font-size: 1.2rem; line-height: 1.8; color: var(--text-light); font-weight: 600; font-style: italic;">
                         "If new money always enters at specific points,<br>
                         who gets the advantage and who pays the price?"
@@ -496,7 +497,7 @@
                     <p style="font-size: 1.05rem; line-height: 1.8; color: var(--text-light); margin-bottom: 0.5rem;">
                         When you see this, a simple question appears:
                     </p>
-                    <p style="font-size: 1.15rem; line-height: 1.7; color: #dc3545; font-weight: 600; margin: 1rem 0 1.5rem 0;">
+                    <p style="font-size: 1.15rem; line-height: 1.7; color: #e4606d; font-weight: 600; margin: 1rem 0 1.5rem 0;">
                         If every dollar starts as someone's promise to repay,<br>
                         what happens when too many promises are made at once?
                     </p>
@@ -726,23 +727,23 @@
 
                     <!-- Policy Action Buttons -->
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem;">
-                        <button onclick="simulateQE()" style="background: linear-gradient(135deg, #4caf50, #45a049); color: white; border: none; padding: 1rem; border-radius: 0.75rem; font-weight: 600; cursor: pointer; transition: all 0.3s ease;">
+                        <button onclick="simulateQE()" style="background: linear-gradient(135deg, #2e7d32, #1b5e20); color: white; border: none; padding: 1rem; border-radius: 0.75rem; font-weight: 600; cursor: pointer; transition: all 0.3s ease;">
                             🚀 Quantitative Easing
                         </button>
-                        <button onclick="simulateQT()" style="background: linear-gradient(135deg, #ff6b6b, #ee5a52); color: white; border: none; padding: 1rem; border-radius: 0.75rem; font-weight: 600; cursor: pointer; transition: all 0.3s ease;">
+                        <button onclick="simulateQT()" style="background: linear-gradient(135deg, #d32f2f, #b71c1c); color: white; border: none; padding: 1rem; border-radius: 0.75rem; font-weight: 600; cursor: pointer; transition: all 0.3s ease;">
                             📉 Quantitative Tightening
                         </button>
-                        <button onclick="simulateRateCut()" style="background: linear-gradient(135deg, #2196F3, #1976D2); color: white; border: none; padding: 1rem; border-radius: 0.75rem; font-weight: 600; cursor: pointer; transition: all 0.3s ease;">
+                        <button onclick="simulateRateCut()" style="background: linear-gradient(135deg, #1565C0, #0D47A1); color: white; border: none; padding: 1rem; border-radius: 0.75rem; font-weight: 600; cursor: pointer; transition: all 0.3s ease;">
                             📉 Cut Rates
                         </button>
-                        <button onclick="simulateRateHike()" style="background: linear-gradient(135deg, #ff9800, #f57c00); color: white; border: none; padding: 1rem; border-radius: 0.75rem; font-weight: 600; cursor: pointer; transition: all 0.3s ease;">
+                        <button onclick="simulateRateHike()" style="background: linear-gradient(135deg, #bf360c, #9f2c08); color: white; border: none; padding: 1rem; border-radius: 0.75rem; font-weight: 600; cursor: pointer; transition: all 0.3s ease;">
                             📈 Raise Rates
                         </button>
                     </div>
 
                     <!-- What Each Button Does -->
                     <div style="background: #101010; border: 2px solid #dc3545; border-radius: 0.75rem; padding: 1.5rem;">
-                        <h4 style="color: #dc3545; margin-bottom: 1rem; font-size: 1.1rem;">🎯 What Each Lever Does</h4>
+                        <h4 style="color: #e4606d; margin-bottom: 1rem; font-size: 1.1rem;">🎯 What Each Lever Does</h4>
                         <div style="display: grid; gap: 1rem;">
                             <div>
                                 <strong style="color: var(--primary-orange);">Quantitative Easing:</strong> The Fed buys more Treasuries or mortgage bonds → Assets go up → Reserves of banks go up → The fountain has more base money
@@ -1161,7 +1162,7 @@
 
                 <div style="background: #101010; border-left: 4px solid #dc3545; border-radius: 0.75rem; padding: 1.5rem; margin: 2rem 0;">
                     <p style="margin: 0; font-size: 1.05rem; line-height: 1.8; color: var(--text-light); text-align: center;">
-                        <strong style="color: #dc3545;">💭 If trust breaks… the fountain stops flowing.</strong>
+                        <strong style="color: #e4606d;">💭 If trust breaks… the fountain stops flowing.</strong>
                     </p>
                 </div>
 
@@ -1179,7 +1180,7 @@
             <!-- Final Reflection -->
             <section class="content-section">
                 <div style="background: #101010; border: 2px solid #dc3545; border-radius: 1rem; padding: 2.5rem; text-align: center;">
-                    <h2 style="color: #dc3545; margin-bottom: 1.5rem; font-size: 1.5rem;">💡 Key Takeaway</h2>
+                    <h2 style="color: #e4606d; margin-bottom: 1.5rem; font-size: 1.5rem;">💡 Key Takeaway</h2>
                     <p style="font-size: 1.1rem; line-height: 1.9; margin-bottom: 1rem;">
                         When rules are set by a small group, the fountain can grow or shrink in ways most people do not see.
                     </p>
@@ -1197,7 +1198,7 @@
                 <p style="font-size: 1.1rem; margin-bottom: 1.5rem; color: var(--text-dim);">
                     Ready to continue your journey?
                 </p>
-                <a href="../module-2.html" class="return-button" style="display: inline-block; padding: 1rem 2rem; background: var(--primary-orange); color: white; text-decoration: none; border-radius: 0.75rem; font-weight: 700; transition: all 0.3s ease;">
+                <a href="../module-2.html" class="return-button" style="display: inline-block; padding: 1rem 2rem; background: var(--primary-orange); color: #101010; text-decoration: none; border-radius: 0.75rem; font-weight: 700; transition: all 0.3s ease;">
                     ← Return to Module 2
                 </a>
             </section>

--- a/paths/curious/stage-1/es/module-1.html
+++ b/paths/curious/stage-1/es/module-1.html
@@ -214,7 +214,7 @@
         }
 
         .rating-dot.filled {
-            background: var(--accent-green);
+            background: #28a745;
         }
 
         /* Quiz Section */
@@ -262,22 +262,22 @@
 
         .quiz-option:hover {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.selected {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .quiz-option.incorrect {
             border-color: #f44336;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .quiz-feedback {
@@ -292,12 +292,12 @@
         }
 
         .quiz-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
         .quiz-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #ff6b6b;
         }
 
@@ -368,7 +368,7 @@
 
         /* Key Takeaways */
         .takeaways {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1rem;
@@ -653,7 +653,7 @@
                               text-align: center;
                               margin-top: 2rem;
                               padding: 1.5rem;
-                              background: rgba(76, 175, 80, 0.1);
+                              background: #101010;
                               border-radius: 8px;
                               line-height: 1.7;">
                         Acabas de descubrir el problema al que se ha enfrentado toda civilización humana:<br>
@@ -771,7 +771,7 @@
                     }
 
                     .demo-frame.completed .frame-number-demo {
-                        background: var(--accent-green);
+                        background: #28a745;
                         color: #fff;
                     }
 
@@ -1093,7 +1093,7 @@
                                     </div>
                                 </div>
 
-                                <div style="text-align: center; padding: 0.5rem; background: rgba(76, 175, 80, 0.1); border-radius: 6px;">
+                                <div style="text-align: center; padding: 0.5rem; background: #101010; border-radius: 6px;">
                                     <p style="color: var(--accent-green); font-size: 0.75rem; margin: 0;">Tu saldo: <span id="balanceDisplay" style="font-weight: bold;">$500</span></p>
                                 </div>
                             </div>
@@ -1407,7 +1407,7 @@
                     .qualities-section {
                         margin: 1rem 0;
                         padding: 1rem;
-                        background: rgba(76, 175, 80, 0.05);
+                        background: #101010;
                         border-left: 3px solid var(--accent-green);
                         border-radius: 0.5rem;
                     }
@@ -1442,7 +1442,7 @@
                     .challenges-section {
                         margin: 1rem 0;
                         padding: 1rem;
-                        background: rgba(244, 67, 54, 0.05);
+                        background: #101010;
                         border-left: 3px solid #ff6b6b;
                         border-radius: 0.5rem;
                     }
@@ -1848,7 +1848,7 @@
 
                     .property-tile.active {
                         border-color: var(--accent-green);
-                        background: rgba(76, 175, 80, 0.05);
+                        background: #101010;
                     }
 
                     .property-tile-header {
@@ -1981,7 +1981,7 @@
                     </p>
                 </div>
 
-                <div style="background: rgba(244, 67, 54, 0.05); border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 1rem; padding: 2.5rem; text-align: center; position: relative; overflow: hidden;">
+                <div style="background: #101010; border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 1rem; padding: 2.5rem; text-align: center; position: relative; overflow: hidden;">
                     <!-- Subtle leak visualization -->
                     <div style="position: absolute; top: 0; left: 50%; transform: translateX(-50%); width: 2px; height: 100%; background: linear-gradient(to bottom, transparent, rgba(244, 67, 54, 0.4), transparent); opacity: 0.6;"></div>
 
@@ -2248,7 +2248,7 @@
                 // Show completion message
                 if (!localStorage.getItem('retention.s1m1.completed')) {
                     const msg = document.createElement('div');
-                    msg.style.cssText = 'background: rgba(76, 175, 80, 0.15); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 2rem 0; text-align: center;';
+                    msg.style.cssText = 'background: #101010; border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 2rem 0; text-align: center;';
                     msg.innerHTML = '<h4 style="color: var(--accent-green); margin-bottom: 0.5rem;">🎉 ¡Todas las Actividades Completadas!</h4><p>Excelente trabajo. Ya puedes continuar al Módulo 2.</p>';
                     document.querySelector('.retention-section').appendChild(msg);
                     localStorage.setItem('retention.s1m1.completed', 'true');
@@ -2275,7 +2275,7 @@
                 document.getElementById('next-module').classList.remove('disabled');
 
                 const notice = document.createElement('div');
-                notice.style.background = 'rgba(76, 175, 80, 0.2)';
+                notice.style.background = '#101010';
                 notice.style.padding = '1rem';
                 notice.style.borderRadius = '0.5rem';
                 notice.style.color = 'var(--accent-green)';

--- a/paths/curious/stage-1/es/module-1.html
+++ b/paths/curious/stage-1/es/module-1.html
@@ -548,8 +548,9 @@
     "@type": "Audience",
     "audienceType": "Estudiantes interesados en Bitcoin y criptomonedas"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
 <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Ir al contenido principal</a>
     
     <!-- Skip Link for Accessibility (WCAG 2.4.1) -->

--- a/paths/curious/stage-1/es/module-2.html
+++ b/paths/curious/stage-1/es/module-2.html
@@ -177,7 +177,7 @@
         .calculator-result {
             margin-top: 1.5rem;
             padding: 1.5rem;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             border-left: 4px solid var(--accent-red);
             border-radius: 0.5rem;
             display: none;
@@ -249,7 +249,7 @@
             gap: 1rem;
             margin: 1rem 0;
             padding: 1rem;
-            background: rgba(244, 67, 54, 0.1);
+            background: #101010;
             border-radius: 0.5rem;
         }
 
@@ -336,7 +336,7 @@
 
         /* Key Takeaways */
         .takeaways {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -412,22 +412,22 @@
 
         .quiz-option:hover {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.selected {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .quiz-option.incorrect {
             border-color: #f44336;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .quiz-feedback {
@@ -442,12 +442,12 @@
         }
 
         .quiz-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
         .quiz-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #ff6b6b;
         }
 
@@ -635,7 +635,7 @@
         .deep-dive-link {
             display: inline-block;
             padding: 1rem 2rem;
-            background: #9C27B0;
+            background: #dc3545;
             color: white;
             text-decoration: none;
             border-radius: 0.75rem;
@@ -644,7 +644,7 @@
         }
 
         .deep-dive-link:hover {
-            background: #7B1FA2;
+            background: #dc3545;
         }
 
         /* Collapsible Details Animation */
@@ -1021,7 +1021,7 @@
                     }
 
                     .leak-explanation {
-                        background: rgba(244, 67, 54, 0.1);
+                        background: #101010;
                         border: 2px solid var(--accent-red);
                         border-radius: 1rem;
                         padding: 2rem;
@@ -1099,14 +1099,14 @@
                 </p>
 
                 <!-- Money Creation Deep Dive -->
-                <div style="background: rgba(156, 39, 176, 0.1); border: 2px solid #9C27B0; border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
+                <div style="background: #101010; border: 2px solid #dc3545; border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
                     <p style="font-size: 1.05rem; line-height: 1.8; color: var(--text-light); margin: 0 0 0.75rem 0;">
                         Viste cuándo se eliminó el respaldo en oro.<br>
                         Ahora aparece una pregunta justa.
                     </p>
                     <p style="font-size: 1.15rem; line-height: 1.7; color: var(--text-light); margin: 0.75rem 0;">
-                        <strong style="color: #9C27B0;">Si el dinero ya no está atado al metal, ¿quién decide cuántas unidades existen?</strong><br>
-                        <strong style="color: #9C27B0;">¿Y quién recibe primero las nuevas unidades?</strong>
+                        <strong style="color: #dc3545;">Si el dinero ya no está atado al metal, ¿quién decide cuántas unidades existen?</strong><br>
+                        <strong style="color: #dc3545;">¿Y quién recibe primero las nuevas unidades?</strong>
                     </p>
                     <p style="font-size: 0.95rem; color: var(--text-dim); margin: 1rem 0 1.5rem 0;">
                         Hora de abrir el capó y ver el sistema de dos capas que mueve el show.
@@ -1147,7 +1147,7 @@
                 <!-- 1) Hook (replaces pizza block) -->
                 <section id="inflation-lab" style="background: var(--secondary-dark); border-radius: 1.5rem; padding: 2.5rem; margin-bottom: 3rem; border: 2px solid var(--border-color);">
                     <!-- Hook -->
-                    <div style="background: rgba(244, 67, 54, 0.1); border-left: 4px solid var(--accent-red); border-radius: 0.75rem; padding: 2rem; margin-bottom: 2rem; text-align: center;">
+                    <div style="background: #101010; border-left: 4px solid var(--accent-red); border-radius: 0.75rem; padding: 2rem; margin-bottom: 2rem; text-align: center;">
                         <p style="font-size: 1.2rem; line-height: 1.8; color: var(--text-light); margin: 0;">
                             Este mes tu sueldo es el mismo. Los alimentos cuestan un poco más. El arriendo también.<br>
                             <strong style="color: var(--accent-red);">¿Cambió el pan, cambió tu trabajo, o cambió el dinero?</strong>
@@ -1185,7 +1185,7 @@
                             }
 
                             .price-tag.increased {
-                                background: rgba(244, 67, 54, 0.1);
+                                background: #101010;
                                 border-color: var(--accent-red);
                             }
 
@@ -1246,8 +1246,8 @@
                             }
 
                             .socratic-prompt {
-                                background: rgba(156, 39, 176, 0.1);
-                                border-left: 4px solid #9C27B0;
+                                background: #101010;
+                                border-left: 4px solid #dc3545;
                                 border-radius: 0.5rem;
                                 padding: 1.5rem;
                                 margin: 1.5rem 0;
@@ -1289,7 +1289,7 @@
                                 </div>
                             </div>
 
-                            <div style="text-align: center; padding: 1rem; background: rgba(76, 175, 80, 0.1); border-radius: 0.5rem; margin-top: 1.5rem;">
+                            <div style="text-align: center; padding: 1rem; background: #101010; border-radius: 0.5rem; margin-top: 1.5rem;">
                                 <p style="margin: 0; color: var(--text-light);">
                                     Puedes cubrir lo básico y aún ahorrar dinero. La vida se siente manejable.
                                 </p>
@@ -1335,7 +1335,7 @@
                                 </div>
                             </div>
 
-                            <div style="text-align: center; padding: 1rem; background: rgba(244, 67, 54, 0.1); border-radius: 0.5rem; margin: 1.5rem 0;">
+                            <div style="text-align: center; padding: 1rem; background: #101010; border-radius: 0.5rem; margin: 1.5rem 0;">
                                 <p style="margin: 0; color: var(--text-light); font-weight: 600;">
                                     ⚠️ Tu salario: sigue en $10/día. Tus ahorros: siguen en $100. Pero ahora solo alcanzan para la mitad.
                                 </p>
@@ -1354,37 +1354,37 @@
 
                             <!-- Socratic Prompts -->
                             <div id="prompt-raise" class="socratic-prompt">
-                                <strong style="color: #9C27B0;">💭 Reflexión:</strong><br>
+                                <strong style="color: #dc3545;">💭 Reflexión:</strong><br>
                                 Tu jefe dice que los aumentos son una vez al año. Todos los demás también necesitan uno. Los salarios se rezagan frente a los precios. Siempre.
                             </div>
                             <div id="prompt-borrow" class="socratic-prompt">
-                                <strong style="color: #9C27B0;">💭 Reflexión:</strong><br>
+                                <strong style="color: #dc3545;">💭 Reflexión:</strong><br>
                                 <p style="margin: 1rem 0; line-height: 1.8;">
                                     Pediste prestado para seguirle el ritmo a los precios que suben.<br>
                                     El mes que viene, los mismos bienes cuestan aún más, pero tu deuda también creció.
                                 </p>
-                                <p style="margin: 1.5rem 0 1rem 0; font-weight: 600; font-size: 1.05rem; color: #9C27B0;">
+                                <p style="margin: 1.5rem 0 1rem 0; font-weight: 600; font-size: 1.05rem; color: #dc3545;">
                                     ¿Quién se benefició realmente del nuevo dinero? ¿El prestatario, el prestamista o quien lo creó?
                                 </p>
                                 <div style="display: grid; gap: 0.75rem; margin-top: 1.5rem;">
-                                    <button onclick="showBorrowBranch('borrower')" style="background: rgba(156, 39, 176, 0.15); border: 2px solid rgba(156, 39, 176, 0.3); border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
+                                    <button onclick="showBorrowBranch('borrower')" style="background: #101010; border: 2px solid #dc3545; border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
                                         El Prestatario (yo)
                                     </button>
-                                    <button onclick="showBorrowBranch('lender')" style="background: rgba(156, 39, 176, 0.15); border: 2px solid rgba(156, 39, 176, 0.3); border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
+                                    <button onclick="showBorrowBranch('lender')" style="background: #101010; border: 2px solid #dc3545; border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
                                         El Prestamista (banco)
                                     </button>
-                                    <button onclick="showBorrowBranch('creator')" style="background: rgba(156, 39, 176, 0.15); border: 2px solid rgba(156, 39, 176, 0.3); border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
+                                    <button onclick="showBorrowBranch('creator')" style="background: #101010; border: 2px solid #dc3545; border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
                                         El Creador del Dinero
                                     </button>
                                 </div>
-                                <div id="borrow-branch" style="display: none; margin-top: 1.5rem; padding: 1.5rem; background: rgba(26, 26, 26, 0.6); border-radius: 0.5rem; border-left: 4px solid #9C27B0;"></div>
+                                <div id="borrow-branch" style="display: none; margin-top: 1.5rem; padding: 1.5rem; background: rgba(26, 26, 26, 0.6); border-radius: 0.5rem; border-left: 4px solid #dc3545;"></div>
                             </div>
                             <div id="prompt-cut" class="socratic-prompt">
-                                <strong style="color: #9C27B0;">💭 Reflexión:</strong><br>
+                                <strong style="color: #dc3545;">💭 Reflexión:</strong><br>
                                 Sobrevives gastando menos. Pero si los precios siguen subiendo, ¿cuánto tiempo puedes seguir recortando?
                             </div>
                             <div id="prompt-hard" class="socratic-prompt">
-                                <strong style="color: #9C27B0;">💭 Reflexión:</strong><br>
+                                <strong style="color: #dc3545;">💭 Reflexión:</strong><br>
                                 El dinero duro no pierde valor cuando la oferta se mantiene fija. Tus ahorros aún comprarían lo mismo el mes que viene.
                             </div>
                         </div>
@@ -1447,7 +1447,7 @@
                     </div>
 
                     <!-- 3) Debrief (merge explanations) -->
-                    <div id="debrief-section" style="display: none; background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
+                    <div id="debrief-section" style="display: none; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
                         <h4 style="color: var(--accent-green); margin-bottom: 1.5rem;"><span data-icon="target"></span> Lo que Descubriste</h4>
                         <div style="line-height: 2;">
                             <p style="margin: 0 0 1rem 0;">
@@ -1494,7 +1494,7 @@
                         </div>
 
                         <!-- Unlock Button -->
-                        <button id="unlock-replay" style="display: none; width: 100%; padding: 1.5rem; background: var(--accent-green); color: white; border: none; border-radius: 0.75rem; font-size: 1.15rem; font-weight: 700; cursor: pointer; margin-top: 1.5rem;" onclick="document.getElementById('sound-money-replay').style.display='block'; this.style.display='none';">
+                        <button id="unlock-replay" style="display: none; width: 100%; padding: 1.5rem; background: #FF7A00; color: white; border: none; border-radius: 0.75rem; font-size: 1.15rem; font-weight: 700; cursor: pointer; margin-top: 1.5rem;" onclick="document.getElementById('sound-money-replay').style.display='block'; this.style.display='none';">
                             🔓 Desbloquear "Repetición con Dinero Sólido"
                         </button>
 
@@ -1513,7 +1513,7 @@
 
                             .quiz-option:hover {
                                 border-color: var(--primary-orange);
-                                background: rgba(255, 122, 0, 0.2);
+                                background: #101010;
                             }
                         </style>
 
@@ -1525,7 +1525,7 @@
                             feedback.style.display = 'block';
 
                             if (isCorrect) {
-                                feedback.style.background = 'rgba(76, 175, 80, 0.2)';
+                                feedback.style.background = '#101010';
                                 feedback.style.color = 'var(--accent-green)';
                                 feedback.textContent = '✅ ¡Correcto!';
                                 correctAnswers++;
@@ -1538,7 +1538,7 @@
                                     document.getElementById('unlock-replay').style.display = 'block';
                                 }
                             } else {
-                                feedback.style.background = 'rgba(244, 67, 54, 0.2)';
+                                feedback.style.background = '#101010';
                                 feedback.style.color = '#ff6b6b';
                                 feedback.textContent = '❌ Intenta de nuevo';
                                 setTimeout(() => feedback.style.display = 'none', 2000);
@@ -1552,26 +1552,26 @@
                         <h4 style="color: var(--accent-green); margin-bottom: 1.5rem; text-align: center; font-size: 1.4rem;"><span data-icon="shield"></span> Repetición con Dinero Sólido</h4>
 
                         <div style="text-align: center; margin: 2rem 0;">
-                            <div style="display: inline-block; background: rgba(76, 175, 80, 0.2); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem 2rem;">
+                            <div style="display: inline-block; background: #101010; border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem 2rem;">
                                 <div style="font-size: 0.9rem; color: var(--text-dim); margin-bottom: 0.5rem;">Oferta Monetaria</div>
                                 <div style="font-size: 2rem; font-weight: 700; color: var(--accent-green);">FIJA</div>
                             </div>
                         </div>
 
                         <div class="budget-grid">
-                            <div class="price-tag" style="border-color: var(--accent-green); background: rgba(76, 175, 80, 0.1);">
+                            <div class="price-tag" style="border-color: var(--accent-green); background: #101010;">
                                 <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🍞</div>
                                 <div style="font-weight: 600;">Pan</div>
                                 <div style="font-size: 1.3rem; color: var(--accent-green); font-weight: 700;">$2</div>
                                 <div style="font-size: 0.75rem; color: var(--text-dim); margin-top: 0.25rem;">Estable ✓</div>
                             </div>
-                            <div class="price-tag" style="border-color: var(--accent-green); background: rgba(76, 175, 80, 0.1);">
+                            <div class="price-tag" style="border-color: var(--accent-green); background: #101010;">
                                 <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🥛</div>
                                 <div style="font-weight: 600;">Leche</div>
                                 <div style="font-size: 1.3rem; color: var(--accent-green); font-weight: 700;">$3</div>
                                 <div style="font-size: 0.75rem; color: var(--text-dim); margin-top: 0.25rem;">Estable ✓</div>
                             </div>
-                            <div class="price-tag" style="border-color: var(--accent-green); background: rgba(76, 175, 80, 0.1);">
+                            <div class="price-tag" style="border-color: var(--accent-green); background: #101010;">
                                 <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🏠</div>
                                 <div style="font-weight: 600;">Arriendo</div>
                                 <div style="font-size: 1.3rem; color: var(--accent-green); font-weight: 700;">$25</div>
@@ -1579,7 +1579,7 @@
                             </div>
                         </div>
 
-                        <div style="background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem; margin: 2rem 0;">
+                        <div style="background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem; margin: 2rem 0;">
                             <p style="margin: 0; font-size: 1.1rem; line-height: 1.8; color: var(--text-light); font-style: italic; text-align: center;">
                                 <strong style="color: var(--accent-green);">Si el dinero conservara su valor, ¿cómo cambiaría tu plan?</strong>
                             </p>
@@ -1630,7 +1630,7 @@
                         </p>
 
                         <!-- Interactive Simulator -->
-                        <div style="background: rgba(33, 150, 243, 0.1); border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem; margin: 1.5rem 0;">
+                        <div style="background: #101010; border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem; margin: 1.5rem 0;">
                             <h4 style="color: #2196F3; margin-bottom: 1rem;"><span data-icon="game"></span> Pruébalo: Ajusta la Economía</h4>
                             <p style="color: var(--text-dim); font-size: 0.95rem; margin-bottom: 1.5rem;">Mueve los controles deslizantes para ver cómo distintas condiciones afectan los precios.</p>
 
@@ -1665,7 +1665,7 @@
                             </div>
 
                             <!-- COVID Example -->
-                            <div style="padding: 1rem; background: rgba(244, 67, 54, 0.1); border-left: 3px solid #F44336; border-radius: 0.5rem; margin-bottom: 1.5rem;">
+                            <div style="padding: 1rem; background: #101010; border-left: 3px solid #F44336; border-radius: 0.5rem; margin-bottom: 1.5rem;">
                                 <p style="color: var(--text-light); font-size: 0.95rem; margin: 0;">
                                     <strong style="color: #F44336;"><span data-icon="lightbulb"></span> Ejemplo:</strong>
                                     Durante el COVID, los gobiernos inyectaron billones en la economía mientras las cadenas de suministro se congelaban.
@@ -1674,9 +1674,9 @@
                             </div>
 
                             <!-- Cause and Effect -->
-                            <div style="padding: 1rem; background: rgba(156, 39, 176, 0.1); border-left: 3px solid #9C27B0; border-radius: 0.5rem;">
+                            <div style="padding: 1rem; background: #101010; border-left: 3px solid #dc3545; border-radius: 0.5rem;">
                                 <p style="color: #b0b0b0; font-size: 0.95rem; margin: 0;">
-                                    <strong style="color: #9C27B0;"><span data-icon="lightbulb"></span> Causa → Efecto:</strong>
+                                    <strong style="color: #dc3545;"><span data-icon="lightbulb"></span> Causa → Efecto:</strong>
                                     La escasez de bienes magnifica la inflación cuando la creación de dinero se mantiene alta.
                                 </p>
                             </div>
@@ -1699,9 +1699,9 @@
                         </div>
 
                         <!-- Socratic Question -->
-                        <div style="background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; padding: 1rem; border-radius: 0.5rem; margin-top: 1.5rem;">
+                        <div style="background: #101010; border-left: 4px solid #dc3545; padding: 1rem; border-radius: 0.5rem; margin-top: 1.5rem;">
                             <p style="margin: 0; color: #b0b0b0; font-style: italic;">
-                                <strong style="color: #9C27B0;"><span data-icon="chat"></span> Pregunta Socrática:</strong>
+                                <strong style="color: #dc3545;"><span data-icon="chat"></span> Pregunta Socrática:</strong>
                                 Si la economía de tu país puede oscilar por un puñado de decisiones, ¿qué tan descentralizado es tu dinero, realmente?
                             </p>
                         </div>
@@ -1776,15 +1776,15 @@
                             Cuando la confianza se rompe, la gente corre a sacar su dinero y toda la cadena se vuelve frágil.
                         </p>
 
-                        <div style="background: rgba(156, 39, 176, 0.1); border: 2px solid #9C27B0; border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
+                        <div style="background: #101010; border: 2px solid #dc3545; border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
                             <p style="font-size: 1.05rem; line-height: 1.8; color: var(--text-light); margin: 0 0 0.5rem 0;">
-                                <strong style="color: #9C27B0;">¿Quieres repetir esa reacción en cadena?</strong>
+                                <strong style="color: #dc3545;">¿Quieres repetir esa reacción en cadena?</strong>
                             </p>
                             <p style="font-size: 0.95rem; color: var(--text-dim); margin: 0.5rem 0 1.5rem 0;">
                                 Abre el Laboratorio de Reserva Fraccionaria y dispara una corrida bancaria.
                             </p>
                             <div style="text-align: center;">
-                                <a href="../deep-dives/fractional-reserve.html" style="display: inline-block; padding: 1rem 2rem; background: #9C27B0; color: white; text-decoration: none; border-radius: 0.75rem; font-weight: 700; transition: all 0.3s ease;" onmouseover="this.style.background='#7B1FA2'" onmouseout="this.style.background='#9C27B0'">
+                                <a href="../deep-dives/fractional-reserve.html" style="display: inline-block; padding: 1rem 2rem; background: #dc3545; color: white; text-decoration: none; border-radius: 0.75rem; font-weight: 700; transition: all 0.3s ease;" onmouseover="this.style.background='#c0392b'" onmouseout="this.style.background='#dc3545'">
                                     🔬 Sigue un depósito mientras se multiplica en muchos préstamos →
                                 </a>
                             </div>
@@ -1822,9 +1822,9 @@
                         </ul>
                     </div>
 
-                    <div style="background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; padding: 1rem; border-radius: 0.5rem; margin-top: 1.5rem;">
+                    <div style="background: #101010; border-left: 4px solid #dc3545; padding: 1rem; border-radius: 0.5rem; margin-top: 1.5rem;">
                         <p style="margin: 0; color: #b0b0b0; font-style: italic;">
-                            <strong style="color: #9C27B0;"><span data-icon="chat"></span> Pregunta Socrática:</strong>
+                            <strong style="color: #dc3545;"><span data-icon="chat"></span> Pregunta Socrática:</strong>
                             Si alguien más puede detener tu transacción, ¿es realmente tu dinero?
                         </p>
                     </div>
@@ -1888,7 +1888,7 @@
                                 <div style="font-size: 1.25rem; font-weight: 700; color: var(--accent-red);">2008</div>
                                 <div style="font-size: 0.85rem; color: var(--text-dim);">🇿🇼 Zimbabue</div>
                             </div>
-                            <div style="background: rgba(244, 67, 54, 0.1); border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
+                            <div style="background: #101010; border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
                                 <p style="margin: 0; font-size: 0.95rem;">
                                     <strong style="color: var(--accent-red);">Hiperinflación: 79.600.000.000% por mes</strong><br>
                                     Billetes de $100 billones impresos. El dinero se volvió inservible de un día para otro. Ahorros borrados.
@@ -1916,7 +1916,7 @@
                                 <div style="font-size: 1.25rem; font-weight: 700; color: var(--accent-red);">2016–2019</div>
                                 <div style="font-size: 0.85rem; color: var(--text-dim);">🇻🇪 Venezuela</div>
                             </div>
-                            <div style="background: rgba(244, 67, 54, 0.1); border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
+                            <div style="background: #101010; border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
                                 <p style="margin: 0; font-size: 0.95rem;">
                                     <strong style="color: var(--accent-red);">Hiperinflación: 10.000.000%</strong><br>
                                     Carretillas de efectivo por un pan. Éxodo masivo. La adopción de Bitcoin se dispara como ruta de escape.
@@ -1930,7 +1930,7 @@
                                 <div style="font-size: 1.25rem; font-weight: 700; color: var(--accent-red);">2019–Hoy</div>
                                 <div style="font-size: 0.85rem; color: var(--text-dim);">🇱🇧 Líbano</div>
                             </div>
-                            <div style="background: rgba(244, 67, 54, 0.1); border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
+                            <div style="background: #101010; border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
                                 <p style="margin: 0; font-size: 0.95rem;">
                                     <strong style="color: var(--accent-red);">Retiros bancarios: límite de $200/mes</strong><br>
                                     Ahorros congelados. Familias arruinadas. "Tu dinero", pero no puedes acceder a él.
@@ -1982,8 +1982,8 @@
                     </div>
 
                     <!-- Pattern Recognition Box -->
-                    <div style="background: rgba(156, 39, 176, 0.1); border: 2px solid #9C27B0; border-radius: 0.75rem; padding: 1.5rem; margin-top: 2rem;">
-                        <h4 style="color: #9C27B0; margin-bottom: 1rem;">💭 El Patrón Universal</h4>
+                    <div style="background: #101010; border: 2px solid #dc3545; border-radius: 0.75rem; padding: 1.5rem; margin-top: 2rem;">
+                        <h4 style="color: #dc3545; margin-bottom: 1rem;">💭 El Patrón Universal</h4>
                         <p style="margin: 0; line-height: 1.8;">
                             Nota la progresión: <strong>Zimbabue → Venezuela → Líbano → ?</strong><br><br>
                             "Aquí no puede pasar" es lo que dijo cada país. Hasta que pasó.<br><br>
@@ -2033,7 +2033,7 @@
                 <div class="quiz-container">
                     <h3>📝 Pon a Prueba lo que Aprendiste</h3>
 
-                    <div class="takeaways" style="margin-bottom: 2rem; background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem;">
+                    <div class="takeaways" style="margin-bottom: 2rem; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem;">
                         <h4 style="color: var(--accent-green); margin-bottom: 1rem;"><span data-icon="target"></span> Ideas Clave</h4>
                         <ul style="list-style: none; padding-left: 0;">
                             <li style="padding-left: 1.5rem; margin-bottom: 0.5rem; position: relative;">
@@ -2294,7 +2294,7 @@
                 transitionFooter.style.textAlign = 'center';
                 transitionFooter.style.marginTop = '1.5rem';
                 transitionFooter.style.padding = '1rem';
-                transitionFooter.style.background = 'rgba(76, 175, 80, 0.1)';
+                transitionFooter.style.background = '#101010';
                 transitionFooter.style.borderRadius = '0.5rem';
                 transitionFooter.style.fontStyle = 'italic';
                 transitionFooter.textContent = '🔧 Ya viste la fuga. El Módulo 3 revela cómo sellar el balde. De forma permanente.';
@@ -2327,7 +2327,7 @@
                 document.getElementById('next-module').classList.remove('disabled');
 
                 const notice = document.createElement('div');
-                notice.style.background = 'rgba(76, 175, 80, 0.2)';
+                notice.style.background = '#101010';
                 notice.style.padding = '1rem';
                 notice.style.borderRadius = '0.5rem';
                 notice.style.color = 'var(--accent-green)';

--- a/paths/curious/stage-1/es/module-2.html
+++ b/paths/curious/stage-1/es/module-2.html
@@ -757,8 +757,9 @@
     "audienceType": "Estudiantes interesados en Bitcoin y criptomonedas"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Ir al contenido principal</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-1/es/module-3.html
+++ b/paths/curious/stage-1/es/module-3.html
@@ -158,12 +158,12 @@
         }
 
         .comparison-header > div:nth-child(2) {
-            background: linear-gradient(135deg, rgba(244, 67, 54, 0.25), rgba(244, 67, 54, 0.1));
+            background: #101010; border-left: 4px solid #dc3545;
             color: #ff6b6b;
         }
 
         .comparison-header > div:nth-child(3) {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.25), rgba(76, 175, 80, 0.1));
+            background: #101010;
             color: var(--accent-green);
         }
 
@@ -329,7 +329,7 @@
 
         /* Takeaways */
         .takeaways {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -405,22 +405,22 @@
 
         .quiz-option:hover {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.selected {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .quiz-option.incorrect {
             border-color: #f44336;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .quiz-feedback {
@@ -435,12 +435,12 @@
         }
 
         .quiz-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
         .quiz-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #ff6b6b;
         }
 
@@ -468,7 +468,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1));
+            background: #101010;
             border: 3px solid var(--accent-green);
             border-radius: 1rem;
             padding: 2.5rem;
@@ -728,7 +728,7 @@
                     <strong>Pero una y otra vez, lo hicieron.</strong>
                 </p>
 
-                <div style="margin: 2rem 0; padding: 2rem; background: linear-gradient(135deg, rgba(255, 122, 0, 0.1), rgba(156, 39, 176, 0.1)); border: 2px solid var(--primary-orange); border-radius: 1rem; text-align: center;">
+                <div style="margin: 2rem 0; padding: 2rem; background: #101010; border: 2px solid var(--primary-orange); border-radius: 1rem; text-align: center;">
                     <p style="font-size: 1.2rem; line-height: 1.9; margin: 0;">
                         <strong style="color: var(--primary-orange);">Así el mundo se enfrentó a una pregunta más profunda:</strong><br><br>
                         <span style="font-size: 1.3rem;">¿Puede existir el dinero sin necesidad de confiar en nadie en absoluto?</span>
@@ -750,7 +750,7 @@
                     Durante décadas, ese problema sin resolver (conocido como el <strong style="color: var(--primary-orange);">problema del doble gasto</strong>) frenó cada intento de crear dinero digital.
                 </p>
 
-                <div style="margin: 2rem 0; padding: 1.5rem; background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.75rem;">
+                <div style="margin: 2rem 0; padding: 1.5rem; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.75rem;">
                     <p style="font-size: 1.1rem; line-height: 1.8; margin: 0;">
                         <strong style="color: var(--accent-green);">Entonces, en 2009, un desarrollador con el seudónimo Satoshi Nakamoto lo resolvió.</strong><br><br>
                         Combinó criptografía, redes de computadoras e incentivos para crear el primer sistema donde <em style="color: var(--primary-orange);">las reglas, no los gobernantes,</em> controlaban el registro.
@@ -762,7 +762,7 @@
             <section class="content-section">
                 <h2 style="color: var(--primary-orange);">🧱 Un Sistema que Corre con Reglas, no con Gobernantes</h2>
 
-                <div style="margin: 2rem 0; padding: 2rem; background: rgba(33, 150, 243, 0.1); border-left: 4px solid #2196F3; border-radius: 1rem;">
+                <div style="margin: 2rem 0; padding: 2rem; background: #101010; border-left: 4px solid #2196F3; border-radius: 1rem;">
                     <p style="font-size: 1.05rem; line-height: 1.8; margin-bottom: 1rem;">
                         <strong>3 de enero de 2009.</strong> Se minó el primer bloque de Bitcoin, con un titular incrustado sobre rescates bancarios:
                     </p>
@@ -795,7 +795,7 @@
                 <div style="overflow-x: auto; margin: 2rem 0;">
                     <table style="width: 100%; border-collapse: collapse; background: var(--secondary-dark); border-radius: 1rem; overflow: hidden;">
                         <thead>
-                            <tr style="background: rgba(255, 122, 0, 0.2);">
+                            <tr style="background: #101010;">
                                 <th style="padding: 1rem; text-align: left; border-bottom: 2px solid var(--border-color); color: var(--primary-orange); font-size: 1.1rem;">Fuga</th>
                                 <th style="padding: 1rem; text-align: left; border-bottom: 2px solid var(--border-color); color: var(--text-dim);">Sistema Antiguo</th>
                                 <th style="padding: 1rem; text-align: left; border-bottom: 2px solid var(--border-color); color: var(--accent-green);">Solución de Bitcoin</th>
@@ -840,9 +840,9 @@
                 </div>
 
                 <!-- Reflection Prompt -->
-                <div style="margin: 2rem 0; padding: 1.5rem; background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; border-radius: 0.75rem;">
+                <div style="margin: 2rem 0; padding: 1.5rem; background: #101010; border-left: 4px solid #dc3545; border-radius: 0.75rem;">
                     <p style="font-size: 1.05rem; line-height: 1.8; margin: 0;">
-                        <strong style="color: #9C27B0;">💭 Reflexión:</strong><br>
+                        <strong style="color: #dc3545;">💭 Reflexión:</strong><br>
                         ¿Qué fuga afecta más tu vida hoy? ¿Y quién la controla?
                     </p>
                 </div>
@@ -880,7 +880,7 @@
                                 <p style="margin-bottom: 1rem;">
                                     Si alguien intenta crear Bitcoin extra, el resto de la red simplemente ignora sus bloques. No hace falta una autoridad central. Las reglas de consenso hacen que hacer trampa sea visible y costoso.
                                 </p>
-                                <p style="margin: 0; padding: 0.75rem; background: rgba(76, 175, 80, 0.1); border-left: 3px solid var(--accent-green); border-radius: 0.5rem;">
+                                <p style="margin: 0; padding: 0.75rem; background: #101010; border-left: 3px solid var(--accent-green); border-radius: 0.5rem;">
                                     <strong>La fórmula da la regla.</strong><br>
                                     <strong>La solución al doble gasto + proof-of-work dan el cumplimiento.</strong><br><br>
                                     Sin una forma de evitar que la gente reescriba la historia, "21 millones" sería solo una bonita promesa.
@@ -900,7 +900,7 @@
                     </div>
 
                     <!-- Rule 3 -->
-                    <div style="padding: 1.5rem; background: linear-gradient(135deg, rgba(33, 150, 243, 0.1), rgba(33, 150, 243, 0.05)); border-left: 4px solid #2196F3; border-radius: 0.75rem;">
+                    <div style="padding: 1.5rem; background: #101010; border-left: 4px solid #2196F3; border-radius: 0.75rem;">
                         <h3 style="color: #2196F3; margin-bottom: 0.75rem; font-size: 1.2rem;">
                             <span style="font-size: 1.5rem;"><span data-icon="search"></span> </span> Cualquiera puede verificar la verdad.
                         </h3>
@@ -910,7 +910,7 @@
                     </div>
                 </div>
 
-                <div style="margin: 2.5rem 0; padding: 2rem; background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 1rem; text-align: center;">
+                <div style="margin: 2.5rem 0; padding: 2rem; background: #101010; border: 2px solid var(--accent-green); border-radius: 1rem; text-align: center;">
                     <p style="font-size: 1.15rem; line-height: 1.9; margin: 0; color: var(--text-light);">
                         <strong style="color: var(--accent-green);">No te pide confianza. Te permite comprobarlo por ti mismo.</strong>
                     </p>
@@ -1063,7 +1063,7 @@
 
             <!-- The Complete Story: Synthesis Across All Modules -->
             <section class="content-section">
-                <div style="background: linear-gradient(135deg, rgba(255, 122, 0, 0.25), rgba(76, 175, 80, 0.15), rgba(33, 150, 243, 0.15)); border: 3px solid var(--primary-orange); border-radius: 1.5rem; padding: 3.5rem 2.5rem; margin: 3rem 0;">
+                <div style="background: #101010; border: 3px solid var(--primary-orange); border-radius: 1.5rem; padding: 3.5rem 2.5rem; margin: 3rem 0;">
                     <h2 style="color: var(--primary-orange); font-size: 2rem; margin-bottom: 2rem; text-align: center;"><span data-icon="book"></span> La Historia Completa</h2>
 
                     <div style="max-width: 800px; margin: 0 auto;">
@@ -1080,7 +1080,7 @@
                         </div>
 
                         <!-- Module 2 Summary -->
-                        <div style="margin-bottom: 2.5rem; padding: 2rem; background: rgba(244, 67, 54, 0.1); border-left: 5px solid #F44336; border-radius: 0.75rem;">
+                        <div style="margin-bottom: 2.5rem; padding: 2rem; background: #101010; border-left: 5px solid #F44336; border-radius: 0.75rem;">
                             <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
                                 <span style="font-size: 2.5rem;"><span data-icon="water-drop"></span> </span>
                                 <h3 style="color: #F44336; font-size: 1.3rem; margin: 0;">Módulo 2: Problemas del Dinero Tradicional</h3>
@@ -1093,7 +1093,7 @@
                         </div>
 
                         <!-- Module 3 Summary -->
-                        <div style="margin-bottom: 2.5rem; padding: 2rem; background: rgba(76, 175, 80, 0.1); border-left: 5px solid var(--accent-green); border-radius: 0.75rem;">
+                        <div style="margin-bottom: 2.5rem; padding: 2rem; background: #101010; border-left: 5px solid var(--accent-green); border-radius: 0.75rem;">
                             <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
                                 <span style="font-size: 2.5rem;"><span data-icon="tool"></span> </span>
                                 <h3 style="color: var(--accent-green); font-size: 1.3rem; margin: 0;">Módulo 3: Bitcoin Sella la Fuga</h3>
@@ -1106,7 +1106,7 @@
                         </div>
 
                         <!-- The Arc Completion -->
-                        <div style="text-align: center; margin-top: 3rem; padding: 2.5rem; background: linear-gradient(135deg, rgba(76, 175, 80, 0.2), rgba(76, 175, 80, 0.05)); border: 2px solid var(--accent-green); border-radius: 1rem;">
+                        <div style="text-align: center; margin-top: 3rem; padding: 2.5rem; background: #101010; border: 2px solid var(--accent-green); border-radius: 1rem;">
                             <p style="font-size: 1.4rem; line-height: 1.9; color: var(--text-light); margin: 0;">
                                 <strong style="color: var(--accent-green); font-size: 1.5rem;">De la confianza rota a la certeza matemática.</strong><br>
                                 <span style="font-size: 1.15rem; color: var(--text-dim); margin-top: 1rem; display: block;">
@@ -1343,7 +1343,7 @@
                     document.getElementById('g-trust').textContent = a.trust;
                     document.getElementById('g-integrity').textContent = a.integrity;
                     document.getElementById('scenario-fb').innerHTML = a.fb;
-                    document.getElementById('scenario-fb').style.background = btn.dataset.act === 'reject' ? 'rgba(76, 175, 80, 0.15)' : 'rgba(255, 107, 107, 0.15)';
+                    document.getElementById('scenario-fb').style.background = '#101010';
                     document.getElementById('scenario-fb').style.borderLeft = btn.dataset.act === 'reject' ? '4px solid var(--accent-green)' : '4px solid #ff6b6b';
                     localStorage.setItem(KEY, btn.dataset.act);
                     checkAllActivitiesComplete();
@@ -1414,7 +1414,7 @@
                 document.getElementById('completion-banner').style.display = 'block';
 
                 const notice = document.createElement('div');
-                notice.style.background = 'rgba(76, 175, 80, 0.2)';
+                notice.style.background = '#101010';
                 notice.style.padding = '1rem';
                 notice.style.borderRadius = '0.5rem';
                 notice.style.color = 'var(--accent-green)';

--- a/paths/curious/stage-1/es/module-3.html
+++ b/paths/curious/stage-1/es/module-3.html
@@ -682,8 +682,9 @@
     "audienceType": "Estudiantes interesados en Bitcoin y criptomonedas"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Ir al contenido principal</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-1/index.html
+++ b/paths/curious/stage-1/index.html
@@ -81,7 +81,7 @@
         }
 
         .stage-badge {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
             padding: 0.5rem 1rem;
             border-radius: 2rem;
@@ -100,7 +100,7 @@
 
         .progress-fill {
             height: 100%;
-            background: var(--accent-green);
+            background: #FF7A00;
             transition: width 0.3s ease;
         }
 
@@ -148,7 +148,7 @@
 
         .module-card.completed {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.05);
+            background: #101010;
         }
 
         .module-card.current {
@@ -175,7 +175,7 @@
         }
 
         .module-card.completed .module-number {
-            background: var(--accent-green);
+            background: #FF7A00;
         }
 
         .module-card.locked .module-number {
@@ -451,27 +451,27 @@
             </div>
 
             <!-- Deep Dives Section -->
-            <div class="deep-dives-section" style="margin: 3rem 0; padding: 2rem; background: linear-gradient(135deg, rgba(156, 39, 176, 0.1), rgba(123, 31, 162, 0.05)); border: 1px solid rgba(156, 39, 176, 0.3); border-radius: 0.75rem;">
-                <h3 style="color: #9C27B0; margin-bottom: 1rem; font-size: 1.5rem;"><span data-icon="books"></span> Optional Deep Dives</h3>
+            <div class="deep-dives-section" style="margin: 3rem 0; padding: 2rem; background: #101010; border: 1px solid #dc3545; border-radius: 0.75rem;">
+                <h3 style="color: #dc3545; margin-bottom: 1rem; font-size: 1.5rem;"><span data-icon="books"></span> Optional Deep Dives</h3>
                 <p style="color: var(--text-dim); margin-bottom: 1.5rem;">
                     Want to explore concepts in greater detail? These optional deep dives provide comprehensive explanations with interactive visualizations.
                 </p>
                 <div style="display: grid; gap: 1rem;">
-                    <a href="deep-dives/money-creation.html" style="display: flex; align-items: center; gap: 1rem; padding: 1rem; background: rgba(156, 39, 176, 0.1); border: 1px solid rgba(156, 39, 176, 0.3); border-radius: 0.5rem; text-decoration: none; color: var(--text-light); transition: all 0.3s ease;" onmouseover="this.style.background='rgba(156, 39, 176, 0.2)'; this.style.transform='translateX(5px)';" onmouseout="this.style.background='rgba(156, 39, 176, 0.1)'; this.style.transform='translateX(0)';">
-                        <div style="width: 50px; height: 50px; background: linear-gradient(135deg, #9C27B0, #7B1FA2); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.5rem;"><span data-icon="water-drop"></span> </div>
+                    <a href="deep-dives/money-creation.html" style="display: flex; align-items: center; gap: 1rem; padding: 1rem; background: #101010; border: 1px solid #dc3545; border-radius: 0.5rem; text-decoration: none; color: var(--text-light); transition: all 0.3s ease;" onmouseover="this.style.background='#2D2D2D'; this.style.transform='translateX(5px)';" onmouseout="this.style.background='#101010'; this.style.transform='translateX(0)';">
+                        <div style="width: 50px; height: 50px; background: #dc3545; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.5rem;"><span data-icon="water-drop"></span> </div>
                         <div style="flex: 1;">
-                            <strong style="color: #9C27B0; font-size: 1.1rem;">Two-Layer Money Fountain</strong>
+                            <strong style="color: #dc3545; font-size: 1.1rem;">Two-Layer Money Fountain</strong>
                             <p style="margin: 0.25rem 0 0 0; font-size: 0.9rem; color: var(--text-dim);">How central banks and commercial banks create money in today's system</p>
                         </div>
-                        <span style="color: #9C27B0; font-size: 1.2rem;">→</span>
+                        <span style="color: #dc3545; font-size: 1.2rem;">→</span>
                     </a>
-                    <a href="deep-dives/fractional-reserve.html" style="display: flex; align-items: center; gap: 1rem; padding: 1rem; background: rgba(156, 39, 176, 0.1); border: 1px solid rgba(156, 39, 176, 0.3); border-radius: 0.5rem; text-decoration: none; color: var(--text-light); transition: all 0.3s ease;" onmouseover="this.style.background='rgba(156, 39, 176, 0.2)'; this.style.transform='translateX(5px)';" onmouseout="this.style.background='rgba(156, 39, 176, 0.1)'; this.style.transform='translateX(0)';">
-                        <div style="width: 50px; height: 50px; background: linear-gradient(135deg, #9C27B0, #7B1FA2); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.5rem;"><span data-icon="institution"></span> </div>
+                    <a href="deep-dives/fractional-reserve.html" style="display: flex; align-items: center; gap: 1rem; padding: 1rem; background: #101010; border: 1px solid #dc3545; border-radius: 0.5rem; text-decoration: none; color: var(--text-light); transition: all 0.3s ease;" onmouseover="this.style.background='#2D2D2D'; this.style.transform='translateX(5px)';" onmouseout="this.style.background='#101010'; this.style.transform='translateX(0)';">
+                        <div style="width: 50px; height: 50px; background: #dc3545; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.5rem;"><span data-icon="institution"></span> </div>
                         <div style="flex: 1;">
-                            <strong style="color: #9C27B0; font-size: 1.1rem;">How Banks Multiply Money</strong>
+                            <strong style="color: #dc3545; font-size: 1.1rem;">How Banks Multiply Money</strong>
                             <p style="margin: 0.25rem 0 0 0; font-size: 0.9rem; color: var(--text-dim);">Interactive exploration of fractional reserve banking and the money multiplier effect</p>
                         </div>
-                        <span style="color: #9C27B0; font-size: 1.2rem;">→</span>
+                        <span style="color: #dc3545; font-size: 1.2rem;">→</span>
                     </a>
                 </div>
             </div>

--- a/paths/curious/stage-1/index.html
+++ b/paths/curious/stage-1/index.html
@@ -329,8 +329,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Path Progress Header -->
     <header class="path-header">

--- a/paths/curious/stage-1/module-1.html
+++ b/paths/curious/stage-1/module-1.html
@@ -214,7 +214,7 @@
         }
 
         .rating-dot.filled {
-            background: var(--accent-green);
+            background: #28a745;
         }
 
         /* Quiz Section */
@@ -262,22 +262,22 @@
 
         .quiz-option:hover {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.selected {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .quiz-option.incorrect {
             border-color: #f44336;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .quiz-feedback {
@@ -292,12 +292,12 @@
         }
 
         .quiz-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
         .quiz-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #ff6b6b;
         }
 
@@ -368,7 +368,7 @@
 
         /* Key Takeaways */
         .takeaways {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1rem;
@@ -652,7 +652,7 @@
                               text-align: center;
                               margin-top: 2rem;
                               padding: 1.5rem;
-                              background: rgba(76, 175, 80, 0.1);
+                              background: #101010;
                               border-radius: 8px;
                               line-height: 1.7;">
                         You've just discovered the problem every human civilization has faced:<br>
@@ -770,7 +770,7 @@
                     }
 
                     .demo-frame.completed .frame-number-demo {
-                        background: var(--accent-green);
+                        background: #28a745;
                         color: #fff;
                     }
 
@@ -1092,7 +1092,7 @@
                                     </div>
                                 </div>
 
-                                <div style="text-align: center; padding: 0.5rem; background: rgba(76, 175, 80, 0.1); border-radius: 6px;">
+                                <div style="text-align: center; padding: 0.5rem; background: #101010; border-radius: 6px;">
                                     <p style="color: var(--accent-green); font-size: 0.75rem; margin: 0;">Your Balance: <span id="balanceDisplay" style="font-weight: bold;">$500</span></p>
                                 </div>
                             </div>
@@ -1406,7 +1406,7 @@
                     .qualities-section {
                         margin: 1rem 0;
                         padding: 1rem;
-                        background: rgba(76, 175, 80, 0.05);
+                        background: #101010;
                         border-left: 3px solid var(--accent-green);
                         border-radius: 0.5rem;
                     }
@@ -1441,7 +1441,7 @@
                     .challenges-section {
                         margin: 1rem 0;
                         padding: 1rem;
-                        background: rgba(244, 67, 54, 0.05);
+                        background: #101010;
                         border-left: 3px solid #ff6b6b;
                         border-radius: 0.5rem;
                     }
@@ -1847,7 +1847,7 @@
 
                     .property-tile.active {
                         border-color: var(--accent-green);
-                        background: rgba(76, 175, 80, 0.05);
+                        background: #101010;
                     }
 
                     .property-tile-header {
@@ -1980,9 +1980,9 @@
                     </p>
                 </div>
 
-                <div style="background: rgba(244, 67, 54, 0.05); border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 1rem; padding: 2.5rem; text-align: center; position: relative; overflow: hidden;">
+                <div style="background: #101010; border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 1rem; padding: 2.5rem; text-align: center; position: relative; overflow: hidden;">
                     <!-- Subtle leak visualization -->
-                    <div style="position: absolute; top: 0; left: 50%; transform: translateX(-50%); width: 2px; height: 100%; background: linear-gradient(to bottom, transparent, rgba(244, 67, 54, 0.4), transparent); opacity: 0.6;"></div>
+                    <div style="position: absolute; top: 0; left: 50%; transform: translateX(-50%); width: 2px; height: 100%; background: linear-gradient(to bottom, transparent, rgba(220, 53, 69, 0.15), transparent); opacity: 0.6;"></div>
 
                     <p style="font-size: 1.2rem; color: var(--text-light); margin-bottom: 1.5rem; line-height: 1.8; position: relative; z-index: 1;">
                         What if one of those "upgrades" wasn't an upgrade at all?<br>
@@ -2247,7 +2247,7 @@
                 // Show completion message
                 if (!localStorage.getItem('retention.s1m1.completed')) {
                     const msg = document.createElement('div');
-                    msg.style.cssText = 'background: rgba(76, 175, 80, 0.15); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 2rem 0; text-align: center;';
+                    msg.style.cssText = 'background: #101010; border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 2rem 0; text-align: center;';
                     msg.innerHTML = '<h4 style="color: var(--accent-green); margin-bottom: 0.5rem;">🎉 All Activities Complete!</h4><p>Great job engaging with the material. You can now proceed to Module 2.</p>';
                     document.querySelector('.retention-section').appendChild(msg);
                     localStorage.setItem('retention.s1m1.completed', 'true');
@@ -2274,7 +2274,7 @@
                 document.getElementById('next-module').classList.remove('disabled');
 
                 const notice = document.createElement('div');
-                notice.style.background = 'rgba(76, 175, 80, 0.2)';
+                notice.style.background = '#101010';
                 notice.style.padding = '1rem';
                 notice.style.borderRadius = '0.5rem';
                 notice.style.color = 'var(--accent-green)';

--- a/paths/curious/stage-1/module-1.html
+++ b/paths/curious/stage-1/module-1.html
@@ -548,8 +548,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
 <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     
     <!-- Skip Link for Accessibility (WCAG 2.4.1) -->

--- a/paths/curious/stage-1/module-2-5.html
+++ b/paths/curious/stage-1/module-2-5.html
@@ -119,7 +119,7 @@
 
         /* Intro Box */
         .intro-box {
-            background: linear-gradient(135deg, rgba(156, 39, 176, 0.15), rgba(156, 39, 176, 0.05));
+            background: #101010;
             border-left: 4px solid var(--accent-purple);
             padding: 2rem;
             border-radius: 0.5rem;
@@ -137,8 +137,8 @@
         }
 
         .patch-card {
-            background: rgba(156, 39, 176, 0.1);
-            border: 2px solid rgba(156, 39, 176, 0.3);
+            background: #101010;
+            border: 2px solid #dc3545;
             border-radius: 0.75rem;
             padding: 1.5rem;
             transition: all 0.3s ease;
@@ -168,7 +168,7 @@
         }
 
         .patch-card .why-failed {
-            background: rgba(244, 67, 54, 0.1);
+            background: #101010;
             border-left: 3px solid #f44336;
             padding: 0.75rem;
             margin-top: 1rem;
@@ -204,7 +204,7 @@
         }
 
         .breakthrough-principle {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-radius: 0.5rem;
             padding: 1.5rem;
             margin: 1.5rem 0;
@@ -476,7 +476,7 @@
                     <p style="margin-bottom: 1.5rem; font-size: 1.05rem; line-height: 1.8;">
                         But every version still asked us to trust a referee.
                     </p>
-                    <p style="margin-bottom: 0; font-size: 1.2rem; color: var(--accent-purple); font-weight: 600; text-align: center; padding: 1rem; background: rgba(156, 39, 176, 0.1); border-radius: 0.5rem;">
+                    <p style="margin-bottom: 0; font-size: 1.2rem; color: var(--accent-purple); font-weight: 600; text-align: center; padding: 1rem; background: #101010; border-radius: 0.5rem;">
                         The real breakthrough wasn't faster payments.<br>
                         It was removing the referee.
                     </p>
@@ -549,7 +549,7 @@
                         In 2009, Bitcoin fused the pen, the glass case, and the coin—<br>
                         <strong style="color: var(--primary-orange); font-size: 1.25rem;">then threw out the referee.</strong>
                     </p>
-                    <div style="display: grid; gap: 0.75rem; margin: 2rem 0; padding: 1.5rem; background: rgba(76, 175, 80, 0.1); border-radius: 0.75rem;">
+                    <div style="display: grid; gap: 0.75rem; margin: 2rem 0; padding: 1.5rem; background: #101010; border-radius: 0.75rem;">
                         <p style="margin: 0; text-align: center;">
                             <span style="font-size: 1.3rem;">✅</span> <strong>Ownership</strong>
                         </p>
@@ -597,17 +597,17 @@
                     Without Bitcoin, we'd still be choosing between:
                 </p>
                 <ul style="list-style: none; margin: 1.5rem 0;">
-                    <li style="padding: 1rem; background: rgba(244, 67, 54, 0.1); border-left: 4px solid #f44336; margin-bottom: 0.75rem; border-radius: 0.25rem;">
+                    <li style="padding: 1rem; background: #101010; border-left: 4px solid #f44336; margin-bottom: 0.75rem; border-radius: 0.25rem;">
                         <strong>📱 CBDCs / Instant Rails:</strong> Fast, but fully permissioned. Every transaction visible.
                     </li>
                     <li style="padding: 1rem; background: rgba(255, 193, 7, 0.1); border-left: 4px solid #FFC107; margin-bottom: 0.75rem; border-radius: 0.25rem;">
                         <strong><span data-icon="dollar"></span> Stablecoins:</strong> Useful, but issuers can freeze accounts. Trust required.
                     </li>
-                    <li style="padding: 1rem; background: rgba(244, 67, 54, 0.1); border-left: 4px solid #f44336; border-radius: 0.25rem;">
+                    <li style="padding: 1rem; background: #101010; border-left: 4px solid #f44336; border-radius: 0.25rem;">
                         <strong>📲 Big-Tech Wallets:</strong> Convenient, but complete surveillance. Your data is the product.
                     </li>
                 </ul>
-                <p style="font-size: 1.15rem; font-weight: 600; color: var(--accent-green); margin-top: 2rem; padding: 1.5rem; background: rgba(76, 175, 80, 0.1); border-radius: 0.5rem; text-align: center;">
+                <p style="font-size: 1.15rem; font-weight: 600; color: var(--accent-green); margin-top: 2rem; padding: 1.5rem; background: #101010; border-radius: 0.5rem; text-align: center;">
                     Bitcoin is different not because it's digital, but because no one can change the ledger.
                 </p>
             </section>
@@ -716,7 +716,7 @@
 
                 // Show completion notice
                 const notice = document.createElement('div');
-                notice.style.cssText = 'position: fixed; top: 20px; right: 20px; background: rgba(76, 175, 80, 0.9); color: white; padding: 1rem 1.5rem; border-radius: 0.5rem; box-shadow: 0 4px 6px rgba(0,0,0,0.3); z-index: 1000;';
+                notice.style.cssText = 'position: fixed; top: 20px; right: 20px; background: #28a745; color: white; padding: 1rem 1.5rem; border-radius: 0.5rem; box-shadow: 0 4px 6px rgba(0,0,0,0.3); z-index: 1000;';
                 notice.innerHTML = '✅ Module 2.5 Complete!';
                 document.body.appendChild(notice);
 

--- a/paths/curious/stage-1/module-2-5.html
+++ b/paths/curious/stage-1/module-2-5.html
@@ -437,8 +437,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-1/module-2.html
+++ b/paths/curious/stage-1/module-2.html
@@ -757,8 +757,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-1/module-2.html
+++ b/paths/curious/stage-1/module-2.html
@@ -177,7 +177,7 @@
         .calculator-result {
             margin-top: 1.5rem;
             padding: 1.5rem;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             border-left: 4px solid var(--accent-red);
             border-radius: 0.5rem;
             display: none;
@@ -249,7 +249,7 @@
             gap: 1rem;
             margin: 1rem 0;
             padding: 1rem;
-            background: rgba(244, 67, 54, 0.1);
+            background: #101010;
             border-radius: 0.5rem;
         }
 
@@ -336,7 +336,7 @@
 
         /* Key Takeaways */
         .takeaways {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -412,22 +412,22 @@
 
         .quiz-option:hover {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.selected {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .quiz-option.incorrect {
             border-color: #f44336;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .quiz-feedback {
@@ -442,12 +442,12 @@
         }
 
         .quiz-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
         .quiz-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #ff6b6b;
         }
 
@@ -635,7 +635,7 @@
         .deep-dive-link {
             display: inline-block;
             padding: 1rem 2rem;
-            background: #9C27B0;
+            background: #dc3545;
             color: white;
             text-decoration: none;
             border-radius: 0.75rem;
@@ -644,7 +644,7 @@
         }
 
         .deep-dive-link:hover {
-            background: #7B1FA2;
+            background: #dc3545;
         }
 
         /* Collapsible Details Animation */
@@ -1020,7 +1020,7 @@
                     }
 
                     .leak-explanation {
-                        background: rgba(244, 67, 54, 0.1);
+                        background: #101010;
                         border: 2px solid var(--accent-red);
                         border-radius: 1rem;
                         padding: 2rem;
@@ -1098,14 +1098,14 @@
                 </p>
 
                 <!-- Money Creation Deep Dive -->
-                <div style="background: rgba(156, 39, 176, 0.1); border: 2px solid #9C27B0; border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
+                <div style="background: #101010; border: 2px solid #dc3545; border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
                     <p style="font-size: 1.05rem; line-height: 1.8; color: var(--text-light); margin: 0 0 0.75rem 0;">
                         You saw when the gold backing was removed.<br>
                         Now a fair question appears.
                     </p>
                     <p style="font-size: 1.15rem; line-height: 1.7; color: var(--text-light); margin: 0.75rem 0;">
-                        <strong style="color: #9C27B0;">If money is no longer tied to metal, who decides how many units exist?</strong><br>
-                        <strong style="color: #9C27B0;">And who gets the new units first?</strong>
+                        <strong style="color: #dc3545;">If money is no longer tied to metal, who decides how many units exist?</strong><br>
+                        <strong style="color: #dc3545;">And who gets the new units first?</strong>
                     </p>
                     <p style="font-size: 0.95rem; color: var(--text-dim); margin: 1rem 0 1.5rem 0;">
                         Time to open the hood and see the two-layer system that runs the show.
@@ -1146,7 +1146,7 @@
                 <!-- 1) Hook (replaces pizza block) -->
                 <section id="inflation-lab" style="background: var(--secondary-dark); border-radius: 1.5rem; padding: 2.5rem; margin-bottom: 3rem; border: 2px solid var(--border-color);">
                     <!-- Hook -->
-                    <div style="background: rgba(244, 67, 54, 0.1); border-left: 4px solid var(--accent-red); border-radius: 0.75rem; padding: 2rem; margin-bottom: 2rem; text-align: center;">
+                    <div style="background: #101010; border-left: 4px solid var(--accent-red); border-radius: 0.75rem; padding: 2rem; margin-bottom: 2rem; text-align: center;">
                         <p style="font-size: 1.2rem; line-height: 1.8; color: var(--text-light); margin: 0;">
                             Your pay stays the same this month. Groceries cost a bit more. Rent too.<br>
                             <strong style="color: var(--accent-red);">Did the bread change, did your work change, or did the money change?</strong>
@@ -1184,7 +1184,7 @@
                             }
                             
                             .price-tag.increased {
-                                background: rgba(244, 67, 54, 0.1);
+                                background: #101010;
                                 border-color: var(--accent-red);
                             }
                             
@@ -1245,8 +1245,8 @@
                             }
                             
                             .socratic-prompt {
-                                background: rgba(156, 39, 176, 0.1);
-                                border-left: 4px solid #9C27B0;
+                                background: #101010;
+                                border-left: 4px solid #dc3545;
                                 border-radius: 0.5rem;
                                 padding: 1.5rem;
                                 margin: 1.5rem 0;
@@ -1288,7 +1288,7 @@
                                 </div>
                             </div>
 
-                            <div style="text-align: center; padding: 1rem; background: rgba(76, 175, 80, 0.1); border-radius: 0.5rem; margin-top: 1.5rem;">
+                            <div style="text-align: center; padding: 1rem; background: #101010; border-radius: 0.5rem; margin-top: 1.5rem;">
                                 <p style="margin: 0; color: var(--text-light);">
                                     You can afford your basics and still save money. Life feels manageable.
                                 </p>
@@ -1334,7 +1334,7 @@
                                 </div>
                             </div>
 
-                            <div style="text-align: center; padding: 1rem; background: rgba(244, 67, 54, 0.1); border-radius: 0.5rem; margin: 1.5rem 0;">
+                            <div style="text-align: center; padding: 1rem; background: #101010; border-radius: 0.5rem; margin: 1.5rem 0;">
                                 <p style="margin: 0; color: var(--text-light); font-weight: 600;">
                                     ⚠️ Your wage: Still $10/day. Your savings: Still $100. But now you can only buy half as much.
                                 </p>
@@ -1353,37 +1353,37 @@
 
                             <!-- Socratic Prompts -->
                             <div id="prompt-raise" class="socratic-prompt">
-                                <strong style="color: #9C27B0;">💭 Reflection:</strong><br>
+                                <strong style="color: #dc3545;">💭 Reflection:</strong><br>
                                 Your boss says raises happen once a year. Everyone else needs one too. Wages lag behind prices. Always.
                             </div>
                             <div id="prompt-borrow" class="socratic-prompt">
-                                <strong style="color: #9C27B0;">💭 Reflection:</strong><br>
+                                <strong style="color: #dc3545;">💭 Reflection:</strong><br>
                                 <p style="margin: 1rem 0; line-height: 1.8;">
                                     You borrowed money to keep up with rising prices.<br>
                                     Next month, the same goods cost even more, but your debt also grew.
                                 </p>
-                                <p style="margin: 1.5rem 0 1rem 0; font-weight: 600; font-size: 1.05rem; color: #9C27B0;">
+                                <p style="margin: 1.5rem 0 1rem 0; font-weight: 600; font-size: 1.05rem; color: #dc3545;">
                                     Who really benefited from the new money? The borrower, the lender, or the one who created it?
                                 </p>
                                 <div style="display: grid; gap: 0.75rem; margin-top: 1.5rem;">
-                                    <button onclick="showBorrowBranch('borrower')" style="background: rgba(156, 39, 176, 0.15); border: 2px solid rgba(156, 39, 176, 0.3); border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
+                                    <button onclick="showBorrowBranch('borrower')" style="background: #101010; border: 2px solid #dc3545; border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
                                         The Borrower (me)
                                     </button>
-                                    <button onclick="showBorrowBranch('lender')" style="background: rgba(156, 39, 176, 0.15); border: 2px solid rgba(156, 39, 176, 0.3); border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
+                                    <button onclick="showBorrowBranch('lender')" style="background: #101010; border: 2px solid #dc3545; border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
                                         The Lender (bank)
                                     </button>
-                                    <button onclick="showBorrowBranch('creator')" style="background: rgba(156, 39, 176, 0.15); border: 2px solid rgba(156, 39, 176, 0.3); border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
+                                    <button onclick="showBorrowBranch('creator')" style="background: #101010; border: 2px solid #dc3545; border-radius: 0.5rem; padding: 1rem; cursor: pointer; transition: all 0.3s ease; text-align: left; color: var(--text-light);">
                                         The Money Creator
                                     </button>
                                 </div>
-                                <div id="borrow-branch" style="display: none; margin-top: 1.5rem; padding: 1.5rem; background: rgba(26, 26, 26, 0.6); border-radius: 0.5rem; border-left: 4px solid #9C27B0;"></div>
+                                <div id="borrow-branch" style="display: none; margin-top: 1.5rem; padding: 1.5rem; background: rgba(26, 26, 26, 0.6); border-radius: 0.5rem; border-left: 4px solid #dc3545;"></div>
                             </div>
                             <div id="prompt-cut" class="socratic-prompt">
-                                <strong style="color: #9C27B0;">💭 Reflection:</strong><br>
+                                <strong style="color: #dc3545;">💭 Reflection:</strong><br>
                                 You survive by spending less. But if prices keep rising, how long can you cut?
                             </div>
                             <div id="prompt-hard" class="socratic-prompt">
-                                <strong style="color: #9C27B0;">💭 Reflection:</strong><br>
+                                <strong style="color: #dc3545;">💭 Reflection:</strong><br>
                                 Hard money doesn't lose value when the supply stays fixed. Your savings would still buy the same amount next month.
                             </div>
                         </div>
@@ -1446,7 +1446,7 @@
                     </div>
 
                     <!-- 3) Debrief (merge explanations) -->
-                    <div id="debrief-section" style="display: none; background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
+                    <div id="debrief-section" style="display: none; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
                         <h4 style="color: var(--accent-green); margin-bottom: 1.5rem;"><span data-icon="target"></span> What You Discovered</h4>
                         <div style="line-height: 2;">
                             <p style="margin: 0 0 1rem 0;">
@@ -1493,7 +1493,7 @@
                         </div>
 
                         <!-- Unlock Button -->
-                        <button id="unlock-replay" style="display: none; width: 100%; padding: 1.5rem; background: var(--accent-green); color: white; border: none; border-radius: 0.75rem; font-size: 1.15rem; font-weight: 700; cursor: pointer; margin-top: 1.5rem;" onclick="document.getElementById('sound-money-replay').style.display='block'; this.style.display='none';">
+                        <button id="unlock-replay" style="display: none; width: 100%; padding: 1.5rem; background: #FF7A00; color: white; border: none; border-radius: 0.75rem; font-size: 1.15rem; font-weight: 700; cursor: pointer; margin-top: 1.5rem;" onclick="document.getElementById('sound-money-replay').style.display='block'; this.style.display='none';">
                             🔓 Unlock "Replay with Sound Money"
                         </button>
 
@@ -1512,7 +1512,7 @@
                             
                             .quiz-option:hover {
                                 border-color: var(--primary-orange);
-                                background: rgba(255, 122, 0, 0.2);
+                                background: #101010;
                             }
                         </style>
 
@@ -1524,7 +1524,7 @@
                             feedback.style.display = 'block';
                             
                             if (isCorrect) {
-                                feedback.style.background = 'rgba(76, 175, 80, 0.2)';
+                                feedback.style.background = '#101010';
                                 feedback.style.color = 'var(--accent-green)';
                                 feedback.textContent = '✅ Correct!';
                                 correctAnswers++;
@@ -1537,7 +1537,7 @@
                                     document.getElementById('unlock-replay').style.display = 'block';
                                 }
                             } else {
-                                feedback.style.background = 'rgba(244, 67, 54, 0.2)';
+                                feedback.style.background = '#101010';
                                 feedback.style.color = '#ff6b6b';
                                 feedback.textContent = '❌ Try again';
                                 setTimeout(() => feedback.style.display = 'none', 2000);
@@ -1551,26 +1551,26 @@
                         <h4 style="color: var(--accent-green); margin-bottom: 1.5rem; text-align: center; font-size: 1.4rem;"><span data-icon="shield"></span> Sound Money Replay</h4>
                         
                         <div style="text-align: center; margin: 2rem 0;">
-                            <div style="display: inline-block; background: rgba(76, 175, 80, 0.2); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem 2rem;">
+                            <div style="display: inline-block; background: #101010; border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem 2rem;">
                                 <div style="font-size: 0.9rem; color: var(--text-dim); margin-bottom: 0.5rem;">Money Supply</div>
                                 <div style="font-size: 2rem; font-weight: 700; color: var(--accent-green);">FIXED</div>
                             </div>
                         </div>
 
                         <div class="budget-grid">
-                            <div class="price-tag" style="border-color: var(--accent-green); background: rgba(76, 175, 80, 0.1);">
+                            <div class="price-tag" style="border-color: var(--accent-green); background: #101010;">
                                 <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🍞</div>
                                 <div style="font-weight: 600;">Bread</div>
                                 <div style="font-size: 1.3rem; color: var(--accent-green); font-weight: 700;">$2</div>
                                 <div style="font-size: 0.75rem; color: var(--text-dim); margin-top: 0.25rem;">Stable ✓</div>
                             </div>
-                            <div class="price-tag" style="border-color: var(--accent-green); background: rgba(76, 175, 80, 0.1);">
+                            <div class="price-tag" style="border-color: var(--accent-green); background: #101010;">
                                 <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🥛</div>
                                 <div style="font-weight: 600;">Milk</div>
                                 <div style="font-size: 1.3rem; color: var(--accent-green); font-weight: 700;">$3</div>
                                 <div style="font-size: 0.75rem; color: var(--text-dim); margin-top: 0.25rem;">Stable ✓</div>
                             </div>
-                            <div class="price-tag" style="border-color: var(--accent-green); background: rgba(76, 175, 80, 0.1);">
+                            <div class="price-tag" style="border-color: var(--accent-green); background: #101010;">
                                 <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🏠</div>
                                 <div style="font-weight: 600;">Rent</div>
                                 <div style="font-size: 1.3rem; color: var(--accent-green); font-weight: 700;">$25</div>
@@ -1578,7 +1578,7 @@
                             </div>
                         </div>
 
-                        <div style="background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem; margin: 2rem 0;">
+                        <div style="background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem; margin: 2rem 0;">
                             <p style="margin: 0; font-size: 1.1rem; line-height: 1.8; color: var(--text-light); font-style: italic; text-align: center;">
                                 <strong style="color: var(--accent-green);">If money kept value, how would your plan change?</strong>
                             </p>
@@ -1629,7 +1629,7 @@
                         </p>
 
                         <!-- Interactive Simulator -->
-                        <div style="background: rgba(33, 150, 243, 0.1); border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem; margin: 1.5rem 0;">
+                        <div style="background: #101010; border: 2px solid #2196F3; border-radius: 0.75rem; padding: 1.5rem; margin: 1.5rem 0;">
                             <h4 style="color: #2196F3; margin-bottom: 1rem;"><span data-icon="game"></span> Try It: Adjust the Economy</h4>
                             <p style="color: var(--text-dim); font-size: 0.95rem; margin-bottom: 1.5rem;">Move the sliders to see how different conditions affect prices.</p>
 
@@ -1664,7 +1664,7 @@
                             </div>
 
                             <!-- COVID Example -->
-                            <div style="padding: 1rem; background: rgba(244, 67, 54, 0.1); border-left: 3px solid #F44336; border-radius: 0.5rem; margin-bottom: 1.5rem;">
+                            <div style="padding: 1rem; background: #101010; border-left: 3px solid #F44336; border-radius: 0.5rem; margin-bottom: 1.5rem;">
                                 <p style="color: var(--text-light); font-size: 0.95rem; margin: 0;">
                                     <strong style="color: #F44336;"><span data-icon="lightbulb"></span> Example:</strong>
                                     During COVID, governments injected trillions into the economy while supply chains froze.
@@ -1673,9 +1673,9 @@
                             </div>
 
                             <!-- Cause and Effect -->
-                            <div style="padding: 1rem; background: rgba(156, 39, 176, 0.1); border-left: 3px solid #9C27B0; border-radius: 0.5rem;">
+                            <div style="padding: 1rem; background: #101010; border-left: 3px solid #dc3545; border-radius: 0.5rem;">
                                 <p style="color: #b0b0b0; font-size: 0.95rem; margin: 0;">
-                                    <strong style="color: #9C27B0;"><span data-icon="lightbulb"></span> Cause → Effect:</strong>
+                                    <strong style="color: #dc3545;"><span data-icon="lightbulb"></span> Cause → Effect:</strong>
                                     Scarcity of goods magnifies inflation when money creation stays high.
                                 </p>
                             </div>
@@ -1698,9 +1698,9 @@
                         </div>
 
                         <!-- Socratic Question -->
-                        <div style="background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; padding: 1rem; border-radius: 0.5rem; margin-top: 1.5rem;">
+                        <div style="background: #101010; border-left: 4px solid #dc3545; padding: 1rem; border-radius: 0.5rem; margin-top: 1.5rem;">
                             <p style="margin: 0; color: #b0b0b0; font-style: italic;">
-                                <strong style="color: #9C27B0;"><span data-icon="chat"></span> Socratic Question:</strong>
+                                <strong style="color: #dc3545;"><span data-icon="chat"></span> Socratic Question:</strong>
                                 If your country's economy can swing based on a handful of decisions, how decentralized is your money, really?
                             </p>
                         </div>
@@ -1775,15 +1775,15 @@
                             When trust breaks, people rush to pull their money out and the whole chain becomes fragile.
                         </p>
 
-                        <div style="background: rgba(156, 39, 176, 0.1); border: 2px solid #9C27B0; border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
+                        <div style="background: #101010; border: 2px solid #dc3545; border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
                             <p style="font-size: 1.05rem; line-height: 1.8; color: var(--text-light); margin: 0 0 0.5rem 0;">
-                                <strong style="color: #9C27B0;">Want to replay that chain reaction?</strong>
+                                <strong style="color: #dc3545;">Want to replay that chain reaction?</strong>
                             </p>
                             <p style="font-size: 0.95rem; color: var(--text-dim); margin: 0.5rem 0 1.5rem 0;">
                                 Open the Fractional Reserve Lab and trigger a bank run.
                             </p>
                             <div style="text-align: center;">
-                                <a href="./deep-dives/fractional-reserve.html" style="display: inline-block; padding: 1rem 2rem; background: #9C27B0; color: white; text-decoration: none; border-radius: 0.75rem; font-weight: 700; transition: all 0.3s ease;" onmouseover="this.style.background='#7B1FA2'" onmouseout="this.style.background='#9C27B0'">
+                                <a href="./deep-dives/fractional-reserve.html" style="display: inline-block; padding: 1rem 2rem; background: #dc3545; color: white; text-decoration: none; border-radius: 0.75rem; font-weight: 700; transition: all 0.3s ease;" onmouseover="this.style.background='#c0392b'" onmouseout="this.style.background='#dc3545'">
                                     🔬 Follow one deposit as it multiplies into many loans →
                                 </a>
                             </div>
@@ -1821,9 +1821,9 @@
                         </ul>
                     </div>
 
-                    <div style="background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; padding: 1rem; border-radius: 0.5rem; margin-top: 1.5rem;">
+                    <div style="background: #101010; border-left: 4px solid #dc3545; padding: 1rem; border-radius: 0.5rem; margin-top: 1.5rem;">
                         <p style="margin: 0; color: #b0b0b0; font-style: italic;">
-                            <strong style="color: #9C27B0;"><span data-icon="chat"></span> Socratic Question:</strong>
+                            <strong style="color: #dc3545;"><span data-icon="chat"></span> Socratic Question:</strong>
                             If someone else can stop your transaction, is it really your money?
                         </p>
                     </div>
@@ -1887,7 +1887,7 @@
                                 <div style="font-size: 1.25rem; font-weight: 700; color: var(--accent-red);">2008</div>
                                 <div style="font-size: 0.85rem; color: var(--text-dim);">🇿🇼 Zimbabwe</div>
                             </div>
-                            <div style="background: rgba(244, 67, 54, 0.1); border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
+                            <div style="background: #101010; border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
                                 <p style="margin: 0; font-size: 0.95rem;">
                                     <strong style="color: var(--accent-red);">Hyperinflation: 79,600,000,000% per month</strong><br>
                                     $100 trillion dollar bills printed. Money became worthless overnight. Savings wiped out.
@@ -1915,7 +1915,7 @@
                                 <div style="font-size: 1.25rem; font-weight: 700; color: var(--accent-red);">2016–2019</div>
                                 <div style="font-size: 0.85rem; color: var(--text-dim);">🇻🇪 Venezuela</div>
                             </div>
-                            <div style="background: rgba(244, 67, 54, 0.1); border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
+                            <div style="background: #101010; border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
                                 <p style="margin: 0; font-size: 0.95rem;">
                                     <strong style="color: var(--accent-red);">Hyperinflation: 10,000,000%</strong><br>
                                     Wheelbarrows of cash for bread. Mass exodus. Bitcoin adoption surges as escape route.
@@ -1929,7 +1929,7 @@
                                 <div style="font-size: 1.25rem; font-weight: 700; color: var(--accent-red);">2019–Today</div>
                                 <div style="font-size: 0.85rem; color: var(--text-dim);">🇱🇧 Lebanon</div>
                             </div>
-                            <div style="background: rgba(244, 67, 54, 0.1); border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
+                            <div style="background: #101010; border-left: 4px solid var(--accent-red); padding: 1.25rem; border-radius: 0.5rem;">
                                 <p style="margin: 0; font-size: 0.95rem;">
                                     <strong style="color: var(--accent-red);">Bank withdrawals: $200/month limit</strong><br>
                                     Savings frozen. Families ruined. "Your money" but you can't access it.
@@ -1981,8 +1981,8 @@
                     </div>
 
                     <!-- Pattern Recognition Box -->
-                    <div style="background: rgba(156, 39, 176, 0.1); border: 2px solid #9C27B0; border-radius: 0.75rem; padding: 1.5rem; margin-top: 2rem;">
-                        <h4 style="color: #9C27B0; margin-bottom: 1rem;">💭 The Universal Pattern</h4>
+                    <div style="background: #101010; border: 2px solid #dc3545; border-radius: 0.75rem; padding: 1.5rem; margin-top: 2rem;">
+                        <h4 style="color: #dc3545; margin-bottom: 1rem;">💭 The Universal Pattern</h4>
                         <p style="margin: 0; line-height: 1.8;">
                             Notice the progression: <strong>Zimbabwe → Venezuela → Lebanon → ?</strong><br><br>
                             "It can't happen here" is what every country said. Until it did.<br><br>
@@ -2032,7 +2032,7 @@
                 <div class="quiz-container">
                     <h3>📝 Test What You've Learned</h3>
 
-                    <div class="takeaways" style="margin-bottom: 2rem; background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem;">
+                    <div class="takeaways" style="margin-bottom: 2rem; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem;">
                         <h4 style="color: var(--accent-green); margin-bottom: 1rem;"><span data-icon="target"></span> Key Takeaways</h4>
                         <ul style="list-style: none; padding-left: 0;">
                             <li style="padding-left: 1.5rem; margin-bottom: 0.5rem; position: relative;">
@@ -2293,7 +2293,7 @@
                 transitionFooter.style.textAlign = 'center';
                 transitionFooter.style.marginTop = '1.5rem';
                 transitionFooter.style.padding = '1rem';
-                transitionFooter.style.background = 'rgba(76, 175, 80, 0.1)';
+                transitionFooter.style.background = '#101010';
                 transitionFooter.style.borderRadius = '0.5rem';
                 transitionFooter.style.fontStyle = 'italic';
                 transitionFooter.textContent = '🔧 You\'ve seen the leak. Module 3 reveals how to seal the bucket. Permanently.';
@@ -2326,7 +2326,7 @@
                 document.getElementById('next-module').classList.remove('disabled');
 
                 const notice = document.createElement('div');
-                notice.style.background = 'rgba(76, 175, 80, 0.2)';
+                notice.style.background = '#101010';
                 notice.style.padding = '1rem';
                 notice.style.borderRadius = '0.5rem';
                 notice.style.color = 'var(--accent-green)';

--- a/paths/curious/stage-1/module-3.html
+++ b/paths/curious/stage-1/module-3.html
@@ -158,12 +158,12 @@
         }
 
         .comparison-header > div:nth-child(2) {
-            background: linear-gradient(135deg, rgba(244, 67, 54, 0.25), rgba(244, 67, 54, 0.1));
+            background: #101010; border-left: 4px solid #dc3545;
             color: #ff6b6b;
         }
 
         .comparison-header > div:nth-child(3) {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.25), rgba(76, 175, 80, 0.1));
+            background: #101010;
             color: var(--accent-green);
         }
 
@@ -329,7 +329,7 @@
 
         /* Takeaways */
         .takeaways {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -405,22 +405,22 @@
 
         .quiz-option:hover {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.selected {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .quiz-option.incorrect {
             border-color: #f44336;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .quiz-feedback {
@@ -435,12 +435,12 @@
         }
 
         .quiz-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
         .quiz-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #ff6b6b;
         }
 
@@ -468,7 +468,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1));
+            background: #101010;
             border: 3px solid var(--accent-green);
             border-radius: 1rem;
             padding: 2.5rem;
@@ -727,7 +727,7 @@
                     <strong>But time and again, they did.</strong>
                 </p>
 
-                <div style="margin: 2rem 0; padding: 2rem; background: linear-gradient(135deg, rgba(255, 122, 0, 0.1), rgba(156, 39, 176, 0.1)); border: 2px solid var(--primary-orange); border-radius: 1rem; text-align: center;">
+                <div style="margin: 2rem 0; padding: 2rem; background: #101010; border: 2px solid var(--primary-orange); border-radius: 1rem; text-align: center;">
                     <p style="font-size: 1.2rem; line-height: 1.9; margin: 0;">
                         <strong style="color: var(--primary-orange);">So the world faced a deeper question:</strong><br><br>
                         <span style="font-size: 1.3rem;">Can money exist without needing to trust anyone at all?</span>
@@ -749,7 +749,7 @@
                     For decades, that unsolved problem (known as the <strong style="color: var(--primary-orange);">double-spend problem</strong>) stopped every attempt at digital cash.
                 </p>
 
-                <div style="margin: 2rem 0; padding: 1.5rem; background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.75rem;">
+                <div style="margin: 2rem 0; padding: 1.5rem; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.75rem;">
                     <p style="font-size: 1.1rem; line-height: 1.8; margin: 0;">
                         <strong style="color: var(--accent-green);">Then in 2009, a pseudonymous developer named Satoshi Nakamoto solved it.</strong><br><br>
                         He combined cryptography, computer networks, and incentives to make the first system where <em style="color: var(--primary-orange);">rules, not rulers,</em> controlled the ledger.
@@ -761,7 +761,7 @@
             <section class="content-section">
                 <h2 style="color: var(--primary-orange);">🧱 A System That Runs on Rules, Not Rulers</h2>
 
-                <div style="margin: 2rem 0; padding: 2rem; background: rgba(33, 150, 243, 0.1); border-left: 4px solid #2196F3; border-radius: 1rem;">
+                <div style="margin: 2rem 0; padding: 2rem; background: #101010; border-left: 4px solid #2196F3; border-radius: 1rem;">
                     <p style="font-size: 1.05rem; line-height: 1.8; margin-bottom: 1rem;">
                         <strong>January 3, 2009.</strong> The first Bitcoin block was mined, embedding a headline about bank bailouts:
                     </p>
@@ -794,7 +794,7 @@
                 <div style="overflow-x: auto; margin: 2rem 0;">
                     <table style="width: 100%; border-collapse: collapse; background: var(--secondary-dark); border-radius: 1rem; overflow: hidden;">
                         <thead>
-                            <tr style="background: rgba(255, 122, 0, 0.2);">
+                            <tr style="background: #101010;">
                                 <th style="padding: 1rem; text-align: left; border-bottom: 2px solid var(--border-color); color: var(--primary-orange); font-size: 1.1rem;">Leak</th>
                                 <th style="padding: 1rem; text-align: left; border-bottom: 2px solid var(--border-color); color: var(--text-dim);">Old System</th>
                                 <th style="padding: 1rem; text-align: left; border-bottom: 2px solid var(--border-color); color: var(--accent-green);">Bitcoin's Fix</th>
@@ -839,9 +839,9 @@
                 </div>
 
                 <!-- Reflection Prompt -->
-                <div style="margin: 2rem 0; padding: 1.5rem; background: rgba(156, 39, 176, 0.1); border-left: 4px solid #9C27B0; border-radius: 0.75rem;">
+                <div style="margin: 2rem 0; padding: 1.5rem; background: #101010; border-left: 4px solid #dc3545; border-radius: 0.75rem;">
                     <p style="font-size: 1.05rem; line-height: 1.8; margin: 0;">
-                        <strong style="color: #9C27B0;">💭 Reflection:</strong><br>
+                        <strong style="color: #dc3545;">💭 Reflection:</strong><br>
                         Which leak affects your life the most today? And who controls it?
                     </p>
                 </div>
@@ -879,7 +879,7 @@
                                 <p style="margin-bottom: 1rem;">
                                     If one person tries to create extra Bitcoin, the rest of the network simply ignores their blocks. No central authority needed. The consensus rules make cheating visible and expensive.
                                 </p>
-                                <p style="margin: 0; padding: 0.75rem; background: rgba(76, 175, 80, 0.1); border-left: 3px solid var(--accent-green); border-radius: 0.5rem;">
+                                <p style="margin: 0; padding: 0.75rem; background: #101010; border-left: 3px solid var(--accent-green); border-radius: 0.5rem;">
                                     <strong>The formula gives the rule.</strong><br>
                                     <strong>The double-spend solution + proof-of-work give the enforcement.</strong><br><br>
                                     Without a way to stop people from rewriting history, "21 million" would just be a nice promise.
@@ -899,7 +899,7 @@
                     </div>
 
                     <!-- Rule 3 -->
-                    <div style="padding: 1.5rem; background: linear-gradient(135deg, rgba(33, 150, 243, 0.1), rgba(33, 150, 243, 0.05)); border-left: 4px solid #2196F3; border-radius: 0.75rem;">
+                    <div style="padding: 1.5rem; background: #101010; border-left: 4px solid #2196F3; border-radius: 0.75rem;">
                         <h3 style="color: #2196F3; margin-bottom: 0.75rem; font-size: 1.2rem;">
                             <span style="font-size: 1.5rem;"><span data-icon="search"></span> </span> Everyone can verify the truth.
                         </h3>
@@ -909,7 +909,7 @@
                     </div>
                 </div>
 
-                <div style="margin: 2.5rem 0; padding: 2rem; background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 1rem; text-align: center;">
+                <div style="margin: 2.5rem 0; padding: 2rem; background: #101010; border: 2px solid var(--accent-green); border-radius: 1rem; text-align: center;">
                     <p style="font-size: 1.15rem; line-height: 1.9; margin: 0; color: var(--text-light);">
                         <strong style="color: var(--accent-green);">It doesn't ask for trust. It lets you check for yourself.</strong>
                     </p>
@@ -1062,7 +1062,7 @@
 
             <!-- The Complete Story: Synthesis Across All Modules -->
             <section class="content-section">
-                <div style="background: linear-gradient(135deg, rgba(255, 122, 0, 0.25), rgba(76, 175, 80, 0.15), rgba(33, 150, 243, 0.15)); border: 3px solid var(--primary-orange); border-radius: 1.5rem; padding: 3.5rem 2.5rem; margin: 3rem 0;">
+                <div style="background: #101010; border: 3px solid var(--primary-orange); border-radius: 1.5rem; padding: 3.5rem 2.5rem; margin: 3rem 0;">
                     <h2 style="color: var(--primary-orange); font-size: 2rem; margin-bottom: 2rem; text-align: center;"><span data-icon="book"></span> The Complete Story</h2>
 
                     <div style="max-width: 800px; margin: 0 auto;">
@@ -1079,7 +1079,7 @@
                         </div>
 
                         <!-- Module 2 Summary -->
-                        <div style="margin-bottom: 2.5rem; padding: 2rem; background: rgba(244, 67, 54, 0.1); border-left: 5px solid #F44336; border-radius: 0.75rem;">
+                        <div style="margin-bottom: 2.5rem; padding: 2rem; background: #101010; border-left: 5px solid #F44336; border-radius: 0.75rem;">
                             <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
                                 <span style="font-size: 2.5rem;"><span data-icon="water-drop"></span> </span>
                                 <h3 style="color: #F44336; font-size: 1.3rem; margin: 0;">Module 2: Problems with Traditional Money</h3>
@@ -1092,7 +1092,7 @@
                         </div>
 
                         <!-- Module 3 Summary -->
-                        <div style="margin-bottom: 2.5rem; padding: 2rem; background: rgba(76, 175, 80, 0.1); border-left: 5px solid var(--accent-green); border-radius: 0.75rem;">
+                        <div style="margin-bottom: 2.5rem; padding: 2rem; background: #101010; border-left: 5px solid var(--accent-green); border-radius: 0.75rem;">
                             <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
                                 <span style="font-size: 2.5rem;"><span data-icon="tool"></span> </span>
                                 <h3 style="color: var(--accent-green); font-size: 1.3rem; margin: 0;">Module 3: Bitcoin Seals the Leak</h3>
@@ -1105,7 +1105,7 @@
                         </div>
 
                         <!-- The Arc Completion -->
-                        <div style="text-align: center; margin-top: 3rem; padding: 2.5rem; background: linear-gradient(135deg, rgba(76, 175, 80, 0.2), rgba(76, 175, 80, 0.05)); border: 2px solid var(--accent-green); border-radius: 1rem;">
+                        <div style="text-align: center; margin-top: 3rem; padding: 2.5rem; background: #101010; border: 2px solid var(--accent-green); border-radius: 1rem;">
                             <p style="font-size: 1.4rem; line-height: 1.9; color: var(--text-light); margin: 0;">
                                 <strong style="color: var(--accent-green); font-size: 1.5rem;">From broken trust to mathematical certainty.</strong><br>
                                 <span style="font-size: 1.15rem; color: var(--text-dim); margin-top: 1rem; display: block;">
@@ -1342,7 +1342,7 @@
                     document.getElementById('g-trust').textContent = a.trust;
                     document.getElementById('g-integrity').textContent = a.integrity;
                     document.getElementById('scenario-fb').innerHTML = a.fb;
-                    document.getElementById('scenario-fb').style.background = btn.dataset.act === 'reject' ? 'rgba(76, 175, 80, 0.15)' : 'rgba(255, 107, 107, 0.15)';
+                    document.getElementById('scenario-fb').style.background = '#101010';
                     document.getElementById('scenario-fb').style.borderLeft = btn.dataset.act === 'reject' ? '4px solid var(--accent-green)' : '4px solid #ff6b6b';
                     localStorage.setItem(KEY, btn.dataset.act);
                     checkAllActivitiesComplete();
@@ -1413,7 +1413,7 @@
                 document.getElementById('completion-banner').style.display = 'block';
 
                 const notice = document.createElement('div');
-                notice.style.background = 'rgba(76, 175, 80, 0.2)';
+                notice.style.background = '#101010';
                 notice.style.padding = '1rem';
                 notice.style.borderRadius = '0.5rem';
                 notice.style.color = 'var(--accent-green)';

--- a/paths/curious/stage-1/module-3.html
+++ b/paths/curious/stage-1/module-3.html
@@ -682,8 +682,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-2/index.html
+++ b/paths/curious/stage-2/index.html
@@ -348,8 +348,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Path Progress Header -->
     <header class="path-header">

--- a/paths/curious/stage-2/index.html
+++ b/paths/curious/stage-2/index.html
@@ -81,7 +81,7 @@
         }
 
         .stage-badge {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
             padding: 0.5rem 1rem;
             border-radius: 2rem;
@@ -100,7 +100,7 @@
 
         .progress-fill {
             height: 100%;
-            background: var(--accent-green);
+            background: #FF7A00;
             transition: width 0.3s ease;
         }
 
@@ -128,7 +128,7 @@
 
         /* Access Notice */
         .access-notice {
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
             border: 2px solid var(--primary-orange);
             border-radius: 1rem;
             padding: 2rem;
@@ -167,7 +167,7 @@
 
         .module-card.completed {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.05);
+            background: #101010;
         }
 
         .module-card.current {
@@ -194,7 +194,7 @@
         }
 
         .module-card.completed .module-number {
-            background: var(--accent-green);
+            background: #FF7A00;
         }
 
         .module-card.locked .module-number {

--- a/paths/curious/stage-2/module-1.html
+++ b/paths/curious/stage-2/module-1.html
@@ -228,7 +228,7 @@
         }
 
         .flow-box {
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
             border: 2px solid var(--primary-orange);
             border-radius: 0.75rem;
             padding: 1.5rem;
@@ -246,7 +246,7 @@
         }
 
         .utxo-example {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -309,7 +309,7 @@
 
         /* Key Takeaways */
         .takeaways {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -381,22 +381,22 @@
 
         .quiz-option:hover {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.selected {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .quiz-option.incorrect {
             border-color: #f44336;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .quiz-feedback {
@@ -411,12 +411,12 @@
         }
 
         .quiz-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
         .quiz-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #ff6b6b;
         }
 
@@ -852,7 +852,7 @@
 
                             <div style="margin-bottom: 1rem;">
                                 <label style="display: block; margin-bottom: 0.5rem; font-weight: 600; color: var(--accent-green);">SHA-256 Hash:</label>
-                                <div id="hash-output" style="padding: 0.75rem; background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 0.5rem; font-family: 'Courier New', monospace; font-size: 0.85rem; word-break: break-all; color: var(--accent-green); min-height: 50px;">
+                                <div id="hash-output" style="padding: 0.75rem; background: #101010; border: 2px solid var(--accent-green); border-radius: 0.5rem; font-family: 'Courier New', monospace; font-size: 0.85rem; word-break: break-all; color: var(--accent-green); min-height: 50px;">
                                     Calculating...
                                 </div>
                             </div>
@@ -871,7 +871,7 @@
                             <div style="color: var(--accent-green);">Hash: 64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c</div>
                         </div>
 
-                        <div style="background: rgba(76, 175, 80, 0.1); padding: 1.5rem; border-radius: 0.5rem; margin-top: 1.5rem; border-left: 3px solid var(--accent-green);">
+                        <div style="background: #101010; padding: 1.5rem; border-radius: 0.5rem; margin-top: 1.5rem; border-left: 3px solid var(--accent-green);">
                             <p style="margin: 0; color: var(--text-light); line-height: 1.6;">
                                 <strong style="color: var(--accent-green);"><span data-icon="lightbulb"></span> Now imagine a global competition:</strong><br><br>
                                 Everyone is racing to find a hash that begins with a 0. You can change a letter, a space, or a number and try again.
@@ -1192,7 +1192,7 @@
 
                 if (!localStorage.getItem('retention.s2m1.completed')) {
                     const msg = document.createElement('div');
-                    msg.style.cssText = 'background: rgba(76, 175, 80, 0.15); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 2rem 0; text-align: center;';
+                    msg.style.cssText = 'background: #101010; border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 2rem 0; text-align: center;';
                     msg.innerHTML = '<h4 style="color: var(--accent-green); margin-bottom: 0.5rem;">🎉 All Activities Complete!</h4><p style="color: var(--text-light);">You now understand how Bitcoin works under the hood. Ready for Module 2?</p>';
                     document.querySelector('.retention-section').appendChild(msg);
                     localStorage.setItem('retention.s2m1.completed', 'true');
@@ -1216,7 +1216,7 @@
                 document.getElementById('next-module').classList.remove('disabled');
 
                 const notice = document.createElement('div');
-                notice.style.background = 'rgba(76, 175, 80, 0.2)';
+                notice.style.background = '#101010';
                 notice.style.padding = '1rem';
                 notice.style.borderRadius = '0.5rem';
                 notice.style.color = 'var(--accent-green)';

--- a/paths/curious/stage-2/module-1.html
+++ b/paths/curious/stage-2/module-1.html
@@ -585,8 +585,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-2/module-2.html
+++ b/paths/curious/stage-2/module-2.html
@@ -623,8 +623,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-2/module-2.html
+++ b/paths/curious/stage-2/module-2.html
@@ -342,7 +342,7 @@
 
         /* Key Takeaways */
         .takeaways {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -414,22 +414,22 @@
 
         .quiz-option:hover {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.selected {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .quiz-option.incorrect {
             border-color: #f44336;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .quiz-feedback {
@@ -444,12 +444,12 @@
         }
 
         .quiz-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
         .quiz-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #ff6b6b;
         }
 
@@ -772,7 +772,7 @@
                     </div>
 
                     <div class="era-item" style="border-left-color: var(--accent-green);">
-                        <div class="era-number" style="background: var(--accent-green);">5</div>
+                        <div class="era-number" style="background: #28a745;">5</div>
                         <div class="era-info">
                             <h4>Era 5: 2024-2028 (Current)</h4>
                             <p>Fourth halving. Nation-states enter. Only 3.125 BTC per block.</p>
@@ -920,7 +920,7 @@
                         </div>
 
                         <!-- Real Example -->
-                        <div class="scenario" style="background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green);">
+                        <div class="scenario" style="background: #101010; border-left: 4px solid var(--accent-green);">
                             <div class="scenario-header">
                                 <span class="scenario-title">Real Example: China Mining Ban (2021)</span>
                                 <span class="scenario-icon"><span data-icon="globe"></span> </span>
@@ -1189,7 +1189,7 @@
             confirmBtn.addEventListener('click', () => {
                 const fb = confirmBtn.nextElementSibling || (() => {
                     const div = document.createElement('div');
-                    div.style.cssText = 'margin-top: 1rem; padding: 1rem; background: rgba(76, 175, 80, 0.2); border-radius: 0.5rem; color: var(--accent-green); text-align: center;';
+                    div.style.cssText = 'margin-top: 1rem; padding: 1rem; background: #101010; border-radius: 0.5rem; color: var(--accent-green); text-align: center;';
                     confirmBtn.parentNode.appendChild(div);
                     return div;
                 })();
@@ -1204,7 +1204,7 @@
             if (localStorage.getItem(KEY)) {
                 confirmBtn.disabled = true;
                 const fb = document.createElement('div');
-                fb.style.cssText = 'margin-top: 1rem; padding: 1rem; background: rgba(76, 175, 80, 0.2); border-radius: 0.5rem; color: var(--accent-green); text-align: center;';
+                fb.style.cssText = 'margin-top: 1rem; padding: 1rem; background: #101010; border-radius: 0.5rem; color: var(--accent-green); text-align: center;';
                 fb.innerHTML = '✓ Already completed';
                 confirmBtn.parentNode.appendChild(fb);
             }
@@ -1220,7 +1220,7 @@
                     if (el.classList.contains('revealed')) return;
                     el.classList.add('revealed');
                     el.innerHTML = `<div style="color: var(--text-light);">${answer}</div>`;
-                    el.style.background = 'rgba(76, 175, 80, 0.15)';
+                    el.style.background = '#101010';
                     el.style.borderColor = 'var(--accent-green)';
                     localStorage.setItem(KEY, 'revealed');
                     checkAllActivitiesComplete();
@@ -1230,7 +1230,7 @@
                 if (localStorage.getItem(KEY)) {
                     el.classList.add('revealed');
                     el.innerHTML = `<div style="color: var(--text-light);">${answer}</div>`;
-                    el.style.background = 'rgba(76, 175, 80, 0.15)';
+                    el.style.background = '#101010';
                     el.style.borderColor = 'var(--accent-green)';
                 }
             });
@@ -1260,7 +1260,7 @@
                     })();
 
                     if (choice === 'adjusted') {
-                        fb.style.background = 'rgba(76, 175, 80, 0.2)';
+                        fb.style.background = '#101010';
                         fb.style.color = 'var(--accent-green)';
                         fb.innerHTML = '<strong>✓ Correct!</strong><br>Bitcoin\'s difficulty adjustment kicked in automatically. No votes, no emergency meetings - just code executing as designed. The network continued producing blocks every ~10 minutes.';
                         viz.style.display = 'block';
@@ -1288,7 +1288,7 @@
                 });
                 viz.style.display = 'block';
                 const fb = document.createElement('div');
-                fb.style.cssText = 'margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; text-align: center; background: rgba(76, 175, 80, 0.2); color: var(--accent-green);';
+                fb.style.cssText = 'margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; text-align: center; background: #101010; color: var(--accent-green);';
                 fb.innerHTML = '✓ Already completed';
                 chips[0].parentNode.parentNode.appendChild(fb);
             }
@@ -1333,7 +1333,7 @@
                 document.getElementById('next-module').classList.remove('disabled');
 
                 const notice = document.createElement('div');
-                notice.style.background = 'rgba(76, 175, 80, 0.2)';
+                notice.style.background = '#101010';
                 notice.style.padding = '1rem';
                 notice.style.borderRadius = '0.5rem';
                 notice.style.color = 'var(--accent-green)';

--- a/paths/curious/stage-2/module-3.html
+++ b/paths/curious/stage-2/module-3.html
@@ -260,7 +260,7 @@
             gap: 1rem;
             margin-bottom: 1.5rem;
             padding: 1.5rem;
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-radius: 0.75rem;
         }
 
@@ -295,7 +295,7 @@
         .comparison-header {
             display: grid;
             grid-template-columns: 1fr 1fr;
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
             padding: 1rem;
             font-weight: 700;
             text-align: center;
@@ -329,7 +329,7 @@
 
         /* Key Takeaways */
         .takeaways {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -401,22 +401,22 @@
 
         .quiz-option:hover {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.selected {
             border-color: var(--primary-orange);
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
         }
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .quiz-option.incorrect {
             border-color: #f44336;
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .quiz-feedback {
@@ -431,12 +431,12 @@
         }
 
         .quiz-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
         .quiz-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #ff6b6b;
         }
 
@@ -464,7 +464,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1));
+            background: #101010;
             border: 3px solid var(--accent-green);
             border-radius: 1rem;
             padding: 2.5rem;
@@ -808,7 +808,7 @@
             <section class="content-section">
                 <style>
                     .centralization-demo-container {
-                        background: linear-gradient(135deg, rgba(244, 67, 54, 0.15), rgba(76, 175, 80, 0.15));
+                        background: #101010;
                         border: 2px solid var(--border-color);
                         border-radius: 1rem;
                         padding: 2.5rem;
@@ -978,12 +978,12 @@
                     }
 
                     .status-message.down {
-                        background: rgba(244, 67, 54, 0.2);
+                        background: #101010;
                         border: 2px solid var(--accent-red);
                     }
 
                     .status-message.resilient {
-                        background: rgba(76, 175, 80, 0.2);
+                        background: #101010;
                         border: 2px solid var(--accent-green);
                     }
 
@@ -1721,15 +1721,15 @@
                     </p>
 
                     <!-- Lightning Network Bridge -->
-                    <div style="background: var(--secondary-dark); border: 2px solid rgba(156, 39, 176, 0.3); border-radius: 0.75rem; padding: 1.5rem; margin: 1.5rem 0;">
-                        <h4 style="color: #9C27B0; margin-bottom: 0.75rem; display: flex; align-items: center; gap: 0.5rem;">
+                    <div style="background: var(--secondary-dark); border: 2px solid #dc3545; border-radius: 0.75rem; padding: 1.5rem; margin: 1.5rem 0;">
+                        <h4 style="color: #dc3545; margin-bottom: 0.75rem; display: flex; align-items: center; gap: 0.5rem;">
                             ⚡ Want to Learn About Lightning Network?
                         </h4>
                         <p style="color: var(--text-light); margin-bottom: 1rem; font-size: 0.95rem;">
                             Lightning makes Bitcoin payments <strong>instant and cheap</strong> (think pennies, not dollars for fees).
                             It's perfect for everyday purchases like coffee, online shopping, or tipping creators.
                         </p>
-                        <div style="background: rgba(156, 39, 176, 0.1); padding: 1rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                        <div style="background: #101010; padding: 1rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                             <p style="margin: 0; font-size: 0.9rem; color: var(--text-dim);">
                                 <strong style="color: var(--primary-orange);">What you'll learn:</strong><br>
                                 • How Lightning channels work<br>
@@ -1738,7 +1738,7 @@
                                 • Understanding routing and liquidity
                             </p>
                         </div>
-                        <a href="/paths/builder/stage-2/module-2.html" style="display: inline-block; padding: 0.75rem 1.5rem; background: #9C27B0; color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s ease; width: 100%; text-align: center;">
+                        <a href="/paths/builder/stage-2/module-2.html" style="display: inline-block; padding: 0.75rem 1.5rem; background: #dc3545; color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s ease; width: 100%; text-align: center;">
                             Explore Lightning Network (Builder Path) →
                         </a>
                         <p style="margin-top: 0.75rem; font-size: 0.85rem; color: var(--text-dim); text-align: center;">
@@ -1977,7 +1977,7 @@
 
                     card.classList.add('revealed');
                     card.innerHTML = `<div style="color: var(--text-light); text-align: left;">${answer}</div>`;
-                    card.style.background = 'rgba(76, 175, 80, 0.15)';
+                    card.style.background = '#101010';
                     card.style.borderColor = 'var(--accent-green)';
                     localStorage.setItem(KEY, 'revealed');
 
@@ -1993,7 +1993,7 @@
                 if (localStorage.getItem(KEY)) {
                     card.classList.add('revealed');
                     card.innerHTML = `<div style="color: var(--text-light); text-align: left;">${answer}</div>`;
-                    card.style.background = 'rgba(76, 175, 80, 0.15)';
+                    card.style.background = '#101010';
                     card.style.borderColor = 'var(--accent-green)';
                     revealedCount++;
                 }
@@ -2033,7 +2033,7 @@
                 result.style.display = 'block';
 
                 if (choice === 'nodes-rejected') {
-                    result.style.background = 'rgba(76, 175, 80, 0.2)';
+                    result.style.background = '#101010';
                     result.style.border = '2px solid var(--accent-green)';
                     result.innerHTML = `
                         <div style="color: var(--accent-green); font-weight: 700; margin-bottom: 0.5rem;">✓ Correct!</div>
@@ -2069,7 +2069,7 @@
                 chips[0].style.opacity = '0.5';
                 chips[2].style.opacity = '0.5';
                 result.style.display = 'block';
-                result.style.background = 'rgba(76, 175, 80, 0.2)';
+                result.style.background = '#101010';
                 result.innerHTML = '<div style="color: var(--accent-green);">✓ Already completed</div>';
                 revealBtn.disabled = true;
             }
@@ -2100,7 +2100,7 @@
                         </div>
                     `;
                 } else {
-                    resultDiv.style.background = 'rgba(76, 175, 80, 0.2)';
+                    resultDiv.style.background = '#101010';
                     resultDiv.style.border = '2px solid var(--accent-green)';
                     resultDiv.innerHTML = `
                         <div style="text-align: center; color: var(--text-light);">
@@ -2122,7 +2122,7 @@
 
             // Restore state
             if (localStorage.getItem(KEY)) {
-                resultDiv.style.background = 'rgba(76, 175, 80, 0.2)';
+                resultDiv.style.background = '#101010';
                 resultDiv.innerHTML = '<div style="color: var(--accent-green); text-align: center;">✓ Already completed</div>';
                 attackBtn.disabled = true;
             }
@@ -2166,7 +2166,7 @@
                 document.getElementById('completion-banner').style.display = 'block';
 
                 const notice = document.createElement('div');
-                notice.style.background = 'rgba(76, 175, 80, 0.2)';
+                notice.style.background = '#101010';
                 notice.style.padding = '1rem';
                 notice.style.borderRadius = '0.5rem';
                 notice.style.color = 'var(--accent-green)';

--- a/paths/curious/stage-2/module-3.html
+++ b/paths/curious/stage-2/module-3.html
@@ -679,8 +679,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-3/index.html
+++ b/paths/curious/stage-3/index.html
@@ -309,8 +309,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Stage Header -->
     <header class="stage-header">

--- a/paths/curious/stage-3/index.html
+++ b/paths/curious/stage-3/index.html
@@ -144,7 +144,7 @@
         }
 
         .module-number {
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             width: 40px;
             height: 40px;
@@ -208,7 +208,7 @@
 
         .module-cta {
             padding: 0.75rem 1.5rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -230,7 +230,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1));
+            background: #101010;
             border: 3px solid var(--accent-green);
             border-radius: 1rem;
             padding: 2.5rem;
@@ -254,7 +254,7 @@
             display: inline-block;
             margin-top: 1.5rem;
             padding: 1rem 2rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -488,21 +488,21 @@
                 const card = document.querySelector('[data-module="curious-3-1"]');
                 if (card) {
                     card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = 'rgba(76, 175, 80, 0.05)';
+                    card.style.background = '#101010';
                 }
             }
             if (module2Complete) {
                 const card = document.querySelector('[data-module="curious-3-2"]');
                 if (card) {
                     card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = 'rgba(76, 175, 80, 0.05)';
+                    card.style.background = '#101010';
                 }
             }
             if (module3Complete) {
                 const card = document.querySelector('[data-module="curious-3-3"]');
                 if (card) {
                     card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = 'rgba(76, 175, 80, 0.05)';
+                    card.style.background = '#101010';
                 }
             }
 

--- a/paths/curious/stage-3/module-1.html
+++ b/paths/curious/stage-3/module-1.html
@@ -386,8 +386,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-3/module-1.html
+++ b/paths/curious/stage-3/module-1.html
@@ -100,7 +100,7 @@
         }
 
         code {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             padding: 0.2rem 0.4rem;
             border-radius: 0.25rem;
             font-family: 'Courier New', monospace;
@@ -193,7 +193,7 @@
 
         /* Important Note */
         .important-note {
-            background: rgba(244, 67, 54, 0.1);
+            background: #101010;
             border-left: 4px solid #f44336;
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -207,7 +207,7 @@
 
         /* Insight Box */
         .insight-box {
-            background: rgba(33, 150, 243, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-blue);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -221,7 +221,7 @@
 
         /* Key Takeaways */
         .takeaway-box {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -263,7 +263,7 @@
 
         .nav-btn {
             padding: 0.75rem 1.5rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -548,7 +548,7 @@
                     <li><strong>Best for:</strong> Long-term savings, large amounts</li>
                 </ul>
 
-                <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(76, 175, 80, 0.1); border-radius: 0.5rem;">
+                <p style="margin-top: 1.5rem; padding: 1rem; background: #101010; border-radius: 0.5rem;">
                     <strong>Recommended approach:</strong> Use a hot wallet for daily spending and a cold wallet for
                     long-term savings—like keeping cash in your physical wallet but savings in a bank vault.
                 </p>

--- a/paths/curious/stage-3/module-2.html
+++ b/paths/curious/stage-3/module-2.html
@@ -390,8 +390,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-3/module-2.html
+++ b/paths/curious/stage-3/module-2.html
@@ -135,7 +135,7 @@
         }
 
         .badge-beginner {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             color: var(--accent-green);
         }
 
@@ -145,7 +145,7 @@
         }
 
         .badge-advanced {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             color: #f44336;
         }
 
@@ -194,7 +194,7 @@
 
         /* Warning Box */
         .warning-box {
-            background: rgba(244, 67, 54, 0.1);
+            background: #101010;
             border-left: 4px solid #f44336;
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -208,7 +208,7 @@
 
         /* Checklist */
         .checklist {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -246,7 +246,7 @@
 
         /* Key Takeaways */
         .takeaway-box {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -288,7 +288,7 @@
 
         .nav-btn {
             padding: 0.75rem 1.5rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -685,7 +685,7 @@
                     </ul>
                 </div>
 
-                <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(244, 67, 54, 0.1); border-radius: 0.5rem;">
+                <p style="margin-top: 1.5rem; padding: 1rem; background: #101010; border-radius: 0.5rem;">
                     <strong>Warning:</strong> Bitcoin ATMs charge the highest fees. Only use them if you need immediate
                     Bitcoin and have no other option. For regular purchases, use exchanges or P2P.
                 </p>

--- a/paths/curious/stage-3/module-3.html
+++ b/paths/curious/stage-3/module-3.html
@@ -397,8 +397,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-3/module-3.html
+++ b/paths/curious/stage-3/module-3.html
@@ -68,7 +68,7 @@
 
         /* Socratic Intro */
         .socratic-intro {
-            background: linear-gradient(135deg, rgba(33, 150, 243, 0.1), rgba(33, 150, 243, 0.05));
+            background: #101010;
             border: 2px solid var(--accent-blue);
             border-radius: 1rem;
             padding: 2rem;
@@ -128,7 +128,7 @@
         }
 
         code {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             padding: 0.2rem 0.4rem;
             border-radius: 0.25rem;
             font-family: 'Courier New', monospace;
@@ -153,7 +153,7 @@
 
         /* Debrief Box */
         .socratic-debrief {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -184,7 +184,7 @@
             position: absolute;
             top: -15px;
             left: 20px;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             width: 35px;
             height: 35px;
@@ -204,7 +204,7 @@
 
         /* Warning Box */
         .warning-box {
-            background: rgba(244, 67, 54, 0.1);
+            background: #101010;
             border-left: 4px solid #f44336;
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -218,7 +218,7 @@
 
         /* Info Box */
         .info-box {
-            background: rgba(33, 150, 243, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-blue);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -232,7 +232,7 @@
 
         /* Key Takeaways */
         .takeaway-box {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -274,7 +274,7 @@
 
         .nav-btn {
             padding: 0.75rem 1.5rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -573,7 +573,7 @@
                     <li><strong>Transaction broadcast</strong> - sent to Bitcoin network!</li>
                 </ol>
 
-                <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(76, 175, 80, 0.1); border-radius: 0.5rem;">
+                <p style="margin-top: 1.5rem; padding: 1rem; background: #101010; border-radius: 0.5rem;">
                     <strong>What just happened?</strong> Your wallet created a transaction, signed it with your private key,
                     and broadcast it to thousands of Bitcoin nodes worldwide. Within seconds, miners around the world
                     saw your transaction and started competing to include it in the next block.
@@ -778,7 +778,7 @@
                     <li>✅ How to send and receive bitcoin</li>
                 </ul>
 
-                <p style="margin-top: 1.5rem; padding: 1.5rem; background: rgba(76, 175, 80, 0.1); border-radius: 0.5rem; font-size: 1.05rem;">
+                <p style="margin-top: 1.5rem; padding: 1.5rem; background: #101010; border-radius: 0.5rem; font-size: 1.05rem;">
                     <strong>Next up: Stage 4 - Staying Safe</strong><br>
                     Now that you have Bitcoin, let's make sure you can keep it secure for the long term.
                     We'll cover security fundamentals, backup strategies, and how to protect yourself from

--- a/paths/curious/stage-4/index.html
+++ b/paths/curious/stage-4/index.html
@@ -86,7 +86,7 @@
 
         /* Socratic Intro */
         .socratic-warning {
-            background: linear-gradient(135deg, rgba(244, 67, 54, 0.2), rgba(244, 67, 54, 0.05));
+            background: #101010;
             border: 3px solid var(--danger-red);
             border-radius: 1rem;
             padding: 2rem;
@@ -232,7 +232,7 @@
 
         .module-cta {
             padding: 0.75rem 1.5rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -254,7 +254,7 @@
 
         /* Completion Banner */
         .completion-banner {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1));
+            background: #101010;
             border: 3px solid var(--accent-green);
             border-radius: 1rem;
             padding: 2.5rem;
@@ -278,7 +278,7 @@
             display: inline-block;
             margin-top: 1.5rem;
             padding: 1rem 2rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -535,17 +535,17 @@
                 </p>
 
                 <div style="display: grid; gap: 1rem; max-width: 600px; margin: 2rem auto 0;">
-                    <a href="/paths/builder/" style="padding: 1rem; background: rgba(33, 150, 243, 0.2); border: 2px solid #2196f3; border-radius: 0.5rem; text-decoration: none; color: var(--text-light);">
+                    <a href="/paths/builder/" style="padding: 1rem; background: #101010; border: 2px solid #2196f3; border-radius: 0.5rem; text-decoration: none; color: var(--text-light);">
                         <strong><span data-icon="lightning"></span> Continue to THE BUILDER Path</strong><br>
                         <span style="font-size: 0.9rem; color: var(--text-dim);">Learn to build applications on Bitcoin</span>
                     </a>
 
-                    <a href="/paths/sovereign/" style="padding: 1rem; background: rgba(255, 152, 0, 0.2); border: 2px solid #ff9800; border-radius: 0.5rem; text-decoration: none; color: var(--text-light);">
+                    <a href="/paths/sovereign/" style="padding: 1rem; background: #101010; border: 2px solid #ff9800; border-radius: 0.5rem; text-decoration: none; color: var(--text-light);">
                         <strong><span data-icon="target"></span> Continue to THE SOVEREIGN Path</strong><br>
                         <span style="font-size: 0.9rem; color: var(--text-dim);">Master privacy, cold storage, and sovereignty</span>
                     </a>
 
-                    <a href="/deep-dives/first-principles/" style="padding: 1rem; background: rgba(156, 39, 176, 0.2); border: 2px solid #9c27b0; border-radius: 0.5rem; text-decoration: none; color: var(--text-light);">
+                    <a href="/deep-dives/first-principles/" style="padding: 1rem; background: #101010; border: 2px solid #dc3545; border-radius: 0.5rem; text-decoration: none; color: var(--text-light);">
                         <strong><span data-icon="brain"></span> Explore First Principles</strong><br>
                         <span style="font-size: 0.9rem; color: var(--text-dim);">Question everything from the ground up</span>
                     </a>
@@ -571,21 +571,21 @@
                 const card = document.querySelector('[data-module="curious-4-1"]');
                 if (card) {
                     card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = 'rgba(76, 175, 80, 0.05)';
+                    card.style.background = '#101010';
                 }
             }
             if (module2Complete) {
                 const card = document.querySelector('[data-module="curious-4-2"]');
                 if (card) {
                     card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = 'rgba(76, 175, 80, 0.05)';
+                    card.style.background = '#101010';
                 }
             }
             if (module3Complete) {
                 const card = document.querySelector('[data-module="curious-4-3"]');
                 if (card) {
                     card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = 'rgba(76, 175, 80, 0.05)';
+                    card.style.background = '#101010';
                 }
             }
 

--- a/paths/curious/stage-4/index.html
+++ b/paths/curious/stage-4/index.html
@@ -333,8 +333,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Stage Header -->
     <header class="stage-header">

--- a/paths/curious/stage-4/module-1.html
+++ b/paths/curious/stage-4/module-1.html
@@ -453,8 +453,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-4/module-1.html
+++ b/paths/curious/stage-4/module-1.html
@@ -101,7 +101,7 @@
         }
 
         code {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             padding: 0.2rem 0.4rem;
             border-radius: 0.25rem;
             font-family: 'Courier New', monospace;
@@ -110,7 +110,7 @@
 
         /* Danger Box */
         .danger-box {
-            background: rgba(244, 67, 54, 0.1);
+            background: #101010;
             border: 2px solid var(--accent-red);
             border-radius: 0.75rem;
             padding: 1.5rem;
@@ -137,7 +137,7 @@
         }
 
         .attack-stats {
-            background: rgba(244, 67, 54, 0.1);
+            background: #101010;
             padding: 0.75rem;
             border-radius: 0.5rem;
             margin-top: 1rem;
@@ -192,17 +192,17 @@
 
         .scenario-btn:hover {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
         }
 
         .scenario-btn.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
         }
 
         .scenario-btn.incorrect {
             border-color: var(--accent-red);
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
         }
 
         .scenario-feedback {
@@ -217,13 +217,13 @@
         }
 
         .scenario-feedback.correct {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             color: var(--accent-green);
         }
 
         .scenario-feedback.incorrect {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             border-left: 4px solid var(--accent-red);
             color: var(--accent-red);
         }
@@ -270,7 +270,7 @@
         .quiz-submit {
             width: 100%;
             padding: 1rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             border: none;
             border-radius: 0.5rem;
@@ -297,20 +297,20 @@
         }
 
         .quiz-result.pass {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             border: 2px solid var(--accent-green);
             color: var(--accent-green);
         }
 
         .quiz-result.fail {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             border: 2px solid var(--accent-red);
             color: var(--accent-red);
         }
 
         /* Takeaway Box */
         .takeaway-box {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -352,7 +352,7 @@
 
         .nav-btn {
             padding: 0.75rem 1.5rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -763,25 +763,25 @@
                         <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-bottom: 1.5rem;">
                             <div>
                                 <h5 style="color: var(--accent-red); margin-bottom: 1rem;">Attacks</h5>
-                                <div class="attack-item" data-attack="phishing" style="padding: 1rem; background: rgba(244, 67, 54, 0.1); border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; cursor: pointer; transition: all 0.3s; color: var(--text-light);">
+                                <div class="attack-item" data-attack="phishing" style="padding: 1rem; background: #101010; border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; cursor: pointer; transition: all 0.3s; color: var(--text-light);">
                                     🎣 Phishing Email
                                 </div>
-                                <div class="attack-item" data-attack="sim" style="padding: 1rem; background: rgba(244, 67, 54, 0.1); border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; cursor: pointer; transition: all 0.3s; color: var(--text-light);">
+                                <div class="attack-item" data-attack="sim" style="padding: 1rem; background: #101010; border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; cursor: pointer; transition: all 0.3s; color: var(--text-light);">
                                     📱 SIM Swap
                                 </div>
-                                <div class="attack-item" data-attack="malware" style="padding: 1rem; background: rgba(244, 67, 54, 0.1); border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; cursor: pointer; transition: all 0.3s; color: var(--text-light);">
+                                <div class="attack-item" data-attack="malware" style="padding: 1rem; background: #101010; border: 2px solid rgba(244, 67, 54, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; cursor: pointer; transition: all 0.3s; color: var(--text-light);">
                                     🦠 Malware/Keylogger
                                 </div>
                             </div>
 
                             <div>
                                 <h5 style="color: var(--accent-green); margin-bottom: 1rem;">Best Defense</h5>
-                                <div class="defense-slot" data-defense="phishing" style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border: 2px dashed rgba(76, 175, 80, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; min-height: 60px; transition: all 0.3s; color: var(--text-dim);">
+                                <div class="defense-slot" data-defense="phishing" style="padding: 1rem; background: #101010; border: 2px dashed rgba(76, 175, 80, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; min-height: 60px; transition: all 0.3s; color: var(--text-dim);">
                                     ✓ Always verify URLs before clicking
                                 </div>
-                                <div class="defense-slot" data-defense="sim" style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border: 2px dashed rgba(76, 175, 80, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; min-height: 60px; transition: all 0.3s; color: var(--text-dim);"><span data-icon="lock"></span> Use authenticator apps, not SMS 2FA
+                                <div class="defense-slot" data-defense="sim" style="padding: 1rem; background: #101010; border: 2px dashed rgba(76, 175, 80, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; min-height: 60px; transition: all 0.3s; color: var(--text-dim);"><span data-icon="lock"></span> Use authenticator apps, not SMS 2FA
                                 </div>
-                                <div class="defense-slot" data-defense="malware" style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border: 2px dashed rgba(76, 175, 80, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; min-height: 60px; transition: all 0.3s; color: var(--text-dim);"><span data-icon="shield"></span> Use hardware wallet, never enter seed online
+                                <div class="defense-slot" data-defense="malware" style="padding: 1rem; background: #101010; border: 2px dashed rgba(76, 175, 80, 0.3); border-radius: 0.5rem; margin-bottom: 0.75rem; min-height: 60px; transition: all 0.3s; color: var(--text-dim);"><span data-icon="shield"></span> Use hardware wallet, never enter seed online
                                 </div>
                             </div>
                         </div>
@@ -903,7 +903,7 @@
                     if (flag.classList.contains('revealed')) return;
 
                     flag.classList.add('revealed');
-                    flag.style.background = 'rgba(244, 67, 54, 0.3)';
+                    flag.style.background = '#101010';
                     flag.style.padding = '0.2rem 0.4rem';
                     flag.style.borderRadius = '0.25rem';
                     localStorage.setItem(KEY, 'found');
@@ -921,7 +921,7 @@
                 // Restore state
                 if (localStorage.getItem(KEY)) {
                     flag.classList.add('revealed');
-                    flag.style.background = 'rgba(244, 67, 54, 0.3)';
+                    flag.style.background = '#101010';
                     flag.style.padding = '0.2rem 0.4rem';
                     flag.style.borderRadius = '0.25rem';
                     foundFlags.add(flag.dataset.id);
@@ -951,7 +951,7 @@
                     feedback.style.display = 'block';
 
                     if (choice === 'refuse') {
-                        feedback.style.background = 'rgba(76, 175, 80, 0.2)';
+                        feedback.style.background = '#101010';
                         feedback.style.border = '2px solid var(--accent-green)';
                         feedback.innerHTML = `
                             <div style="color: var(--accent-green); font-weight: 700; margin-bottom: 0.5rem;">✓ Correct!</div>
@@ -995,7 +995,7 @@
                 chips[1].style.opacity = '0.5';
                 chips[3].style.opacity = '0.5';
                 feedback.style.display = 'block';
-                feedback.style.background = 'rgba(76, 175, 80, 0.2)';
+                feedback.style.background = '#101010';
                 feedback.innerHTML = '<div style="color: var(--accent-green);">✓ Already completed</div>';
             }
         })();
@@ -1025,7 +1025,7 @@
 
                     if (selectedAttack === slot.dataset.defense) {
                         // Correct match
-                        slot.style.background = 'rgba(76, 175, 80, 0.2)';
+                        slot.style.background = '#101010';
                         slot.style.borderColor = 'var(--accent-green)';
                         slot.style.borderStyle = 'solid';
                         matches[selectedAttack] = true;
@@ -1038,7 +1038,7 @@
 
                         if (Object.keys(matches).length === 3) {
                             feedback.style.display = 'block';
-                            feedback.style.background = 'rgba(76, 175, 80, 0.2)';
+                            feedback.style.background = '#101010';
                             feedback.style.border = '2px solid var(--accent-green)';
                             feedback.innerHTML = `
                                 <div style="color: var(--accent-green); font-weight: 700; margin-bottom: 0.5rem;">✓ Perfect Matches!</div>
@@ -1061,7 +1061,7 @@
             // Restore state
             if (localStorage.getItem(KEY)) {
                 document.querySelectorAll('.defense-slot').forEach(slot => {
-                    slot.style.background = 'rgba(76, 175, 80, 0.2)';
+                    slot.style.background = '#101010';
                     slot.style.borderColor = 'var(--accent-green)';
                     slot.style.borderStyle = 'solid';
                 });
@@ -1070,7 +1070,7 @@
                     a.style.pointerEvents = 'none';
                 });
                 feedback.style.display = 'block';
-                feedback.style.background = 'rgba(76, 175, 80, 0.2)';
+                feedback.style.background = '#101010';
                 feedback.innerHTML = '<div style="color: var(--accent-green);">✓ Already completed</div>';
                 checkBtn.disabled = true;
             }

--- a/paths/curious/stage-4/module-2.html
+++ b/paths/curious/stage-4/module-2.html
@@ -469,8 +469,9 @@
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-4/module-2.html
+++ b/paths/curious/stage-4/module-2.html
@@ -111,7 +111,7 @@
         }
 
         .comparison-table th {
-            background: rgba(255, 122, 0, 0.2);
+            background: #101010;
             color: var(--primary-orange);
             padding: 1rem;
             text-align: left;
@@ -220,7 +220,7 @@
         }
 
         .checklist-item.completed {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-color: var(--accent-green);
         }
 
@@ -237,7 +237,7 @@
         }
 
         .checklist-item.completed .checklist-checkbox {
-            background: var(--accent-green);
+            background: #FF7A00;
             border-color: var(--accent-green);
         }
 
@@ -297,13 +297,13 @@
         }
 
         .url-box.legit {
-            background: rgba(76, 175, 80, 0.2);
+            background: #101010;
             border: 2px solid var(--accent-green);
             color: var(--accent-green);
         }
 
         .url-box.fake {
-            background: rgba(244, 67, 54, 0.2);
+            background: #101010;
             border: 2px solid var(--accent-red);
             color: var(--accent-red);
         }
@@ -316,7 +316,7 @@
 
         /* Takeaway Box */
         .takeaway-box {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -358,7 +358,7 @@
 
         .nav-btn {
             padding: 0.75rem 1.5rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -509,7 +509,7 @@
                     still protect you.
                 </p>
 
-                <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(76, 175, 80, 0.1); border-radius: 0.5rem; border-left: 4px solid var(--accent-green);">
+                <p style="margin-top: 1.5rem; padding: 1rem; background: #101010; border-radius: 0.5rem; border-left: 4px solid var(--accent-green);">
                     <strong>The Bitcoin Security Layers:</strong><br>
                     Device Security → Account Security → Wallet Security → Transaction Security → Storage Security
                 </p>
@@ -574,7 +574,7 @@
                     <li><strong>$50,000+:</strong> Multi-signature cold storage setup</li>
                 </ul>
 
-                <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(33, 150, 243, 0.1); border-radius: 0.5rem; border-left: 4px solid var(--accent-blue);">
+                <p style="margin-top: 1.5rem; padding: 1rem; background: #101010; border-radius: 0.5rem; border-left: 4px solid var(--accent-blue);">
                     <strong><span data-icon="lightbulb"></span> Pro Tip:</strong> Think of hot wallets like your physical wallet (cash for daily use)
                     and cold wallets like a bank vault (savings you rarely touch).
                 </p>
@@ -665,7 +665,7 @@
                     Use authenticator apps (Google Authenticator, Authy) for exchanges, email, and password managers. Never use SMS 2FA when better options exist. Always save backup codes.
                 </p>
 
-                <p style="margin-top: 1.5rem; padding: 1rem; background: rgba(244, 67, 54, 0.1); border-radius: 0.5rem; border-left: 4px solid var(--accent-red);">
+                <p style="margin-top: 1.5rem; padding: 1rem; background: #101010; border-radius: 0.5rem; border-left: 4px solid var(--accent-red);">
                     <strong>⚠️ Critical:</strong> Store your 2FA backup codes in a secure location (not the same place
                     as your seed phrase). If you lose your phone without backups, you could be locked out.
                 </p>

--- a/paths/curious/stage-4/module-3.html
+++ b/paths/curious/stage-4/module-3.html
@@ -542,8 +542,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <header class="module-header">

--- a/paths/curious/stage-4/module-3.html
+++ b/paths/curious/stage-4/module-3.html
@@ -186,7 +186,7 @@
         }
 
         .plan-section {
-            background: rgba(76, 175, 80, 0.05);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -269,7 +269,7 @@
 
         /* Warning Box */
         .warning-box {
-            background: rgba(244, 67, 54, 0.1);
+            background: #101010;
             border-left: 4px solid var(--danger-red);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -283,7 +283,7 @@
 
         /* Completion Celebration */
         .completion-celebration {
-            background: linear-gradient(135deg, rgba(76, 175, 80, 0.3), rgba(76, 175, 80, 0.1));
+            background: #101010;
             border: 3px solid var(--accent-green);
             border-radius: 1rem;
             padding: 3rem 2rem;
@@ -343,23 +343,23 @@
         }
 
         .path-builder {
-            background: rgba(33, 150, 243, 0.2);
+            background: #101010;
             border: 2px solid #2196f3;
         }
 
         .path-sovereign {
-            background: rgba(255, 152, 0, 0.2);
+            background: #101010;
             border: 2px solid #ff9800;
         }
 
         .path-principles {
-            background: rgba(156, 39, 176, 0.2);
-            border: 2px solid #9c27b0;
+            background: #101010;
+            border: 2px solid #dc3545;
         }
 
         /* Action Items */
         .action-items {
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             border-left: 4px solid var(--accent-green);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -395,7 +395,7 @@
         }
 
         .action-checkbox.checked {
-            background: var(--accent-green);
+            background: #FF7A00;
         }
 
         .action-checkbox.checked::after {
@@ -416,7 +416,7 @@
 
         .nav-btn {
             padding: 0.75rem 1.5rem;
-            background: var(--accent-green);
+            background: #FF7A00;
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -446,7 +446,7 @@
 
         .nav-btn-secondary:hover {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.1);
+            background: #101010;
             transform: translateX(-5px);
         }
 
@@ -732,19 +732,19 @@
                 <div style="background: var(--secondary-dark); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 1.5rem; margin: 2rem 0;">
                     <h4 style="color: var(--accent-green); margin-bottom: 1rem;">Recommended Metal Backup Products</h4>
                     <div style="display: grid; gap: 1rem;">
-                        <div style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border-radius: 0.5rem;">
+                        <div style="padding: 1rem; background: #101010; border-radius: 0.5rem;">
                             <strong style="color: var(--accent-green);">Blockplate</strong> - $49
                             <p style="font-size: 0.9rem; color: var(--text-dim); margin-top: 0.25rem;">
                                 Stainless steel, punch stamp included, compact design
                             </p>
                         </div>
-                        <div style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border-radius: 0.5rem;">
+                        <div style="padding: 1rem; background: #101010; border-radius: 0.5rem;">
                             <strong style="color: var(--accent-green);">CryptoSteel</strong> - $99
                             <p style="font-size: 0.9rem; color: var(--text-dim); margin-top: 0.25rem;">
                                 Modular letter tiles, premium build, easy to use
                             </p>
                         </div>
-                        <div style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border-radius: 0.5rem;">
+                        <div style="padding: 1rem; background: #101010; border-radius: 0.5rem;">
                             <strong style="color: var(--accent-green);">Billfodl</strong> - $89
                             <p style="font-size: 0.9rem; color: var(--text-dim); margin-top: 0.25rem;">
                                 Titanium option available, fire tested to 2,000°F
@@ -766,7 +766,7 @@
                 <h3>Recommended Distribution Strategy</h3>
                 <div style="background: var(--secondary-dark); border: 2px solid var(--border-color); border-radius: 0.75rem; padding: 1.5rem; margin: 1.5rem 0;">
                     <div style="display: grid; gap: 1.5rem;">
-                        <div style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border-left: 4px solid var(--accent-green); border-radius: 0.5rem;">
+                        <div style="padding: 1rem; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem;">
                             <strong style="color: var(--accent-green);">Location 1: Your Home</strong>
                             <p style="font-size: 0.95rem; margin-top: 0.5rem;">
                                 Primary backup (metal or paper) in a fireproof safe or hidden location. Easily accessible
@@ -774,7 +774,7 @@
                             </p>
                         </div>
 
-                        <div style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border-left: 4px solid var(--accent-green); border-radius: 0.5rem;">
+                        <div style="padding: 1rem; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem;">
                             <strong style="color: var(--accent-green);">Location 2: Trusted Family/Friend</strong>
                             <p style="font-size: 0.95rem; margin-top: 0.5rem;">
                                 Second backup with someone you trust implicitly (parent, sibling, best friend). Consider
@@ -782,7 +782,7 @@
                             </p>
                         </div>
 
-                        <div style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border-left: 4px solid var(--accent-green); border-radius: 0.5rem;">
+                        <div style="padding: 1rem; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem;">
                             <strong style="color: var(--accent-green);">Location 3: Bank Safe Deposit Box</strong>
                             <p style="font-size: 0.95rem; margin-top: 0.5rem;">
                                 Third backup in a bank safe deposit box (note: accessible only during bank hours, but
@@ -790,7 +790,7 @@
                             </p>
                         </div>
 
-                        <div style="padding: 1rem; background: rgba(76, 175, 80, 0.05); border-left: 4px solid var(--accent-green); border-radius: 0.5rem;">
+                        <div style="padding: 1rem; background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem;">
                             <strong style="color: var(--accent-green);">Optional Location 4: Second Property</strong>
                             <p style="font-size: 0.95rem; margin-top: 0.5rem;">
                                 If you have access to a second property (vacation home, office, etc.), store an encrypted
@@ -963,7 +963,7 @@
                     </div>
                 </div>
 
-                <div style="background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem; margin-top: 2rem;">
+                <div style="background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem; margin-top: 2rem;">
                     <h4 style="color: var(--accent-green); margin-bottom: 0.75rem;">Minimum Inheritance Action Items</h4>
                     <ul style="margin-left: 1.5rem; font-size: 0.95rem;">
                         <li style="margin-bottom: 0.5rem;">At least ONE trusted person knows you own bitcoin</li>
@@ -1146,7 +1146,7 @@
 
             <!-- Key Takeaways -->
             <section class="content-section">
-                <div style="background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem;">
+                <div style="background: #101010; border-left: 4px solid var(--accent-green); border-radius: 0.5rem; padding: 1.5rem;">
                     <h3 style="color: var(--accent-green); margin-bottom: 1rem;"><span data-icon="target"></span> Key Takeaways</h3>
                     <ul style="list-style: none; padding-left: 0;">
                         <li style="padding-left: 1.5rem; margin-bottom: 0.5rem; position: relative;">

--- a/paths/hurried/index.html
+++ b/paths/hurried/index.html
@@ -9,10 +9,10 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-gold: #FFA726;
+            --accent-gold: #f59e0b;
             --accent-green: #4caf50;
             --accent-blue: #2196f3;
-            --accent-purple: #9c27b0;
+            --accent-purple: #dc3545;
             --text-light: #e0e0e0;
             --text-dim: #999;
             --border-color: rgba(255, 167, 38, 0.3);
@@ -39,7 +39,7 @@
 
         /* Header */
         .hero-header {
-            background: linear-gradient(135deg, rgba(255, 167, 38, 0.2), rgba(255, 167, 38, 0.05));
+            background: #101010;
             border-bottom: 3px solid var(--accent-gold);
             padding: 3rem 0 2rem;
             text-align: center;
@@ -60,8 +60,8 @@
 
         .time-badge {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-gold), #FFB74D);
-            color: white;
+            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             font-weight: 700;
@@ -112,7 +112,7 @@
 
         .stage-header {
             padding: 1.5rem 2rem;
-            background: linear-gradient(135deg, rgba(255, 167, 38, 0.15), rgba(255, 167, 38, 0.05));
+            background: #2D2D2D;
             border-bottom: 2px solid var(--border-color);
         }
 
@@ -188,7 +188,7 @@
 
         /* Intro Box */
         .intro-box {
-            background: linear-gradient(135deg, rgba(33, 150, 243, 0.15), rgba(33, 150, 243, 0.05));
+            background: #101010;
             border: 3px solid var(--accent-blue);
             border-radius: 1rem;
             padding: 2rem;

--- a/paths/hurried/index.html
+++ b/paths/hurried/index.html
@@ -265,8 +265,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="hero-header">
         <main id="main-content" class="container">

--- a/paths/hurried/stage-1/module-1.html
+++ b/paths/hurried/stage-1/module-1.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-gold: #FFA726;
+            --accent-gold: #f59e0b;
             --accent-green: #4caf50;
             --accent-red: #ef4444;
             --text-light: #e0e0e0;
@@ -113,7 +113,7 @@
         .module-header {
             text-align: center;
             padding: 2rem;
-            background: linear-gradient(135deg, rgba(255, 167, 38, 0.2), rgba(255, 167, 38, 0.05));
+            background: #101010;
             border: 3px solid var(--accent-gold);
             border-radius: 1rem;
             margin-bottom: 2rem;
@@ -239,7 +239,7 @@
 
         .speed-medium {
             background: var(--accent-gold);
-            color: white;
+            color: #101010;
         }
 
         /* Action Checklist */
@@ -339,8 +339,8 @@
             align-items: center;
             gap: 0.5rem;
             padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FFB74D);
-            color: white;
+            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            color: #101010;
             border-radius: 0.5rem;
             text-decoration: none;
             font-weight: 700;
@@ -468,7 +468,7 @@
                 </div>
 
                 <div style="text-align: center;">
-                    <a href="/interactive-demos/onramp-chooser/" style="display: inline-block; padding: 1.25rem 2.5rem; background: linear-gradient(135deg, var(--accent-gold), #FFB74D); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.25rem; box-shadow: 0 4px 12px rgba(255, 167, 38, 0.4); transition: all 0.3s ease;">
+                    <a href="/interactive-demos/onramp-chooser/" style="display: inline-block; padding: 1.25rem 2.5rem; background: linear-gradient(135deg, var(--accent-gold), #FF7A00); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.25rem; box-shadow: 0 4px 12px rgba(255, 167, 38, 0.4); transition: all 0.3s ease;">
                         Find My Best Option → (2 min)
                     </a>
                 </div>
@@ -668,7 +668,7 @@
         <div class="hands-on-box" style="background: linear-gradient(135deg, rgba(255, 122, 0, 0.15), rgba(255, 122, 0, 0.05)); border: 2px solid var(--accent-gold); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
             <h3 style="color: var(--accent-gold); margin-bottom: 1rem;">🧮 Practice Tool: Bitcoin Unit Converter</h3>
             <p style="margin-bottom: 1rem;">Before you buy, practice converting between USD, BTC, and sats. Understanding units prevents costly mistakes.</p>
-            <a href="/interactive-demos/bitcoin-unit-converter/" style="display: inline-block; padding: 0.875rem 1.5rem; background: linear-gradient(135deg, var(--accent-gold), #FFB74D); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s; box-shadow: 0 4px 12px rgba(255, 167, 38, 0.3);">
+            <a href="/interactive-demos/bitcoin-unit-converter/" style="display: inline-block; padding: 0.875rem 1.5rem; background: linear-gradient(135deg, var(--accent-gold), #FF7A00); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s; box-shadow: 0 4px 12px rgba(255, 167, 38, 0.3);">
                 Try Unit Converter →
             </a>
         </div>

--- a/paths/hurried/stage-1/module-1.html
+++ b/paths/hurried/stage-1/module-1.html
@@ -402,8 +402,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Navigation -->

--- a/paths/hurried/stage-1/module-2.html
+++ b/paths/hurried/stage-1/module-2.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-gold: #FFA726;
+            --accent-gold: #f59e0b;
             --accent-green: #4caf50;
             --accent-red: #ef4444;
             --text-light: #e0e0e0;
@@ -88,7 +88,7 @@
 
         .module-header {
             text-align: center; padding: 2rem;
-            background: linear-gradient(135deg, rgba(255, 167, 38, 0.2), rgba(255, 167, 38, 0.05));
+            background: #101010;
             border: 3px solid var(--accent-gold); border-radius: 1rem; margin-bottom: 2rem;
         }
 
@@ -208,8 +208,8 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FFB74D);
-            color: white; border-radius: 0.5rem; text-decoration: none;
+            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }
 
@@ -383,8 +383,8 @@
                 <p style="margin-bottom: 1rem;">See what different Bitcoin address types look like:</p>
 
                 <div style="margin-bottom: 1.5rem;">
-                    <button onclick="generateAddress('native-segwit')" style="padding: 0.75rem 1.5rem; background: linear-gradient(135deg, var(--accent-green), #66BB6A); color: white; border: none; border-radius: 0.5rem; cursor: pointer; margin-right: 0.5rem; margin-bottom: 0.5rem; min-height: 44px; font-weight: 600;">Generate bc1 Address</button>
-                    <button onclick="generateAddress('segwit')" style="padding: 0.75rem 1.5rem; background: linear-gradient(135deg, var(--accent-gold), #FFB74D); color: white; border: none; border-radius: 0.5rem; cursor: pointer; margin-right: 0.5rem; margin-bottom: 0.5rem; min-height: 44px; font-weight: 600;">Generate 3 Address</button>
+                    <button onclick="generateAddress('native-segwit')" style="padding: 0.75rem 1.5rem; background: #28a745; color: white; border: none; border-radius: 0.5rem; cursor: pointer; margin-right: 0.5rem; margin-bottom: 0.5rem; min-height: 44px; font-weight: 600;">Generate bc1 Address</button>
+                    <button onclick="generateAddress('segwit')" style="padding: 0.75rem 1.5rem; background: linear-gradient(135deg, var(--accent-gold), #FF7A00); color: #101010; border: none; border-radius: 0.5rem; cursor: pointer; margin-right: 0.5rem; margin-bottom: 0.5rem; min-height: 44px; font-weight: 600;">Generate 3 Address</button>
                     <button onclick="generateAddress('legacy')" style="padding: 0.75rem 1.5rem; background: rgba(255, 167, 38, 0.2); color: var(--text-light); border: 2px solid var(--border-color); border-radius: 0.5rem; cursor: pointer; margin-bottom: 0.5rem; min-height: 44px; font-weight: 600;">Generate 1 Address</button>
                 </div>
 
@@ -505,7 +505,7 @@
         <div class="practice-link" style="background: rgba(33, 150, 243, 0.1); border: 2px solid var(--accent-blue); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0; text-align: center;">
             <h3 style="color: var(--accent-blue); margin-bottom: 1rem;">🛠️ Want More Wallet Practice?</h3>
             <p style="margin-bottom: 1.5rem;">Try our interactive Wallet Security Workshop to explore wallet features and security settings in a safe environment.</p>
-            <a href="/interactive-demos/wallet-security-workshop/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-blue), #42A5F5); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px;">
+            <a href="/interactive-demos/wallet-security-workshop/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-blue), #3b82f6); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px;">
                 Open Wallet Security Workshop →
             </a>
             <p style="margin-top: 1rem; font-size: 0.9rem; color: var(--text-dim);">Opens in new tab • Takes 5-10 minutes</p>
@@ -528,7 +528,7 @@
         <div class="hands-on-box" style="background: linear-gradient(135deg, rgba(76, 175, 80, 0.15), rgba(76, 175, 80, 0.05)); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
             <h3 style="color: var(--accent-green); margin-bottom: 1rem;">🔐 Workshop: Wallet Security Basics</h3>
             <p style="margin-bottom: 1rem;">Interactive guide to choosing the right wallet type and understanding security trade-offs. Perfect primer before setting up your first wallet.</p>
-            <a href="/interactive-demos/wallet-security-workshop/" style="display: inline-block; padding: 0.875rem 1.5rem; background: linear-gradient(135deg, var(--accent-green), #66bb6a); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s; box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);">
+            <a href="/interactive-demos/wallet-security-workshop/" style="display: inline-block; padding: 0.875rem 1.5rem; background: linear-gradient(135deg, var(--accent-green), #28a745); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s; box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);">
                 Start Workshop →
             </a>
         </div>

--- a/paths/hurried/stage-1/module-2.html
+++ b/paths/hurried/stage-1/module-2.html
@@ -249,8 +249,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="nav-buttons">

--- a/paths/hurried/stage-1/module-3.html
+++ b/paths/hurried/stage-1/module-3.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-gold: #FFA726;
+            --accent-gold: #f59e0b;
             --accent-green: #4caf50;
             --accent-red: #ef4444;
             --text-light: #e0e0e0;
@@ -88,7 +88,7 @@
 
         .module-header {
             text-align: center; padding: 2rem;
-            background: linear-gradient(135deg, rgba(255, 167, 38, 0.2), rgba(255, 167, 38, 0.05));
+            background: #101010;
             border: 3px solid var(--accent-gold); border-radius: 1rem; margin-bottom: 2rem;
         }
 
@@ -182,8 +182,8 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FFB74D);
-            color: white; border-radius: 0.5rem; text-decoration: none;
+            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }
 
@@ -191,11 +191,11 @@
         .progress-indicator { text-align: center; color: var(--text-dim); font-weight: 600; }
 
         .test-section {
-            background: rgba(156, 39, 176, 0.1); border: 2px solid #9c27b0;
+            background: #101010; border: 2px solid #dc3545;
             border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;
         }
 
-        .test-section h3 { color: #ce93d8; margin-bottom: 1rem; }
+        .test-section h3 { color: #dc3545; margin-bottom: 1rem; }
 
         @media (max-width: 768px) {
             .container { padding: 1.5rem; }
@@ -385,7 +385,7 @@
             <div class="practice-link" style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0; text-align: center;">
                 <h3 style="color: var(--accent-green); margin-bottom: 1rem;">🧪 Practice on Bitcoin Testnet</h3>
                 <p style="margin-bottom: 1.5rem;">Want to practice wallet recovery without risking real bitcoin? Use our Testnet Practice Guide to experiment safely.</p>
-                <a href="/interactive-demos/testnet-practice-guide/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-green), #66BB6A); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px;">
+                <a href="/interactive-demos/testnet-practice-guide/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-green), #28a745); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px;">
                     Try Testnet Practice →
                 </a>
                 <p style="margin-top: 1rem; font-size: 0.9rem; color: var(--text-dim);">Get free testnet coins • Practice sending/receiving • Test recovery</p>

--- a/paths/hurried/stage-1/module-3.html
+++ b/paths/hurried/stage-1/module-3.html
@@ -228,8 +228,9 @@
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="nav-buttons">

--- a/paths/hurried/stage-2/module-4.html
+++ b/paths/hurried/stage-2/module-4.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-gold: #FFA726;
+            --accent-gold: #f59e0b;
             --accent-green: #4caf50;
             --accent-red: #ef4444;
             --text-light: #e0e0e0;
@@ -87,7 +87,7 @@
 
         .module-header {
             text-align: center; padding: 2rem;
-            background: linear-gradient(135deg, rgba(255, 167, 38, 0.2), rgba(255, 167, 38, 0.05));
+            background: #101010;
             border: 3px solid var(--accent-gold); border-radius: 1rem; margin-bottom: 2rem;
         }
 
@@ -167,8 +167,8 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FFB74D);
-            color: white; border-radius: 0.5rem; text-decoration: none;
+            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }
 
@@ -298,7 +298,7 @@
             </div>
 
             <div style="display: flex; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;">
-                <a href="https://mempool.space/tx/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16" target="_blank" rel="noopener noreferrer" style="flex: 1; min-width: 200px; padding: 1rem; background: linear-gradient(135deg, var(--accent-blue), #42A5F5); color: white; text-decoration: none; border-radius: 0.5rem; text-align: center; font-weight: 700; transition: all 0.3s ease; min-height: 44px; display: flex; align-items: center; justify-content: center;">
+                <a href="https://mempool.space/tx/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16" target="_blank" rel="noopener noreferrer" style="flex: 1; min-width: 200px; padding: 1rem; background: linear-gradient(135deg, var(--accent-blue), #3b82f6); color: white; text-decoration: none; border-radius: 0.5rem; text-align: center; font-weight: 700; transition: all 0.3s ease; min-height: 44px; display: flex; align-items: center; justify-content: center;">
                     View on Mempool.space →
                 </a>
                 <a href="https://www.blockchain.com/explorer/transactions/btc/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16" target="_blank" rel="noopener noreferrer" style="flex: 1; min-width: 200px; padding: 1rem; background: rgba(33, 150, 243, 0.2); color: var(--accent-blue); text-decoration: none; border-radius: 0.5rem; text-align: center; font-weight: 700; border: 2px solid var(--accent-blue); transition: all 0.3s ease; min-height: 44px; display: flex; align-items: center; justify-content: center;">
@@ -371,7 +371,7 @@
             <div class="practice-link" style="background: rgba(255, 167, 38, 0.1); border: 2px solid var(--accent-gold); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0; text-align: center;">
                 <h3 style="color: var(--accent-gold); margin-bottom: 1rem;">⚡ Check Current Network Fees</h3>
                 <p style="margin-bottom: 1.5rem;">See real-time fee estimates and mempool status:</p>
-                <a href="https://mempool.space/" target="_blank" rel="noopener noreferrer" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-gold), #FFB74D); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px; margin-right: 1rem; margin-bottom: 1rem;">
+                <a href="https://mempool.space/" target="_blank" rel="noopener noreferrer" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-gold), #FF7A00); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px; margin-right: 1rem; margin-bottom: 1rem;">
                     View Live Mempool →
                 </a>
                 <a href="/interactive-demos/fee-master-tool/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: rgba(255, 167, 38, 0.2); color: var(--accent-gold); text-decoration: none; border-radius: 0.5rem; font-weight: 700; border: 2px solid var(--accent-gold); transition: all 0.3s ease; min-height: 44px; margin-bottom: 1rem;">
@@ -410,7 +410,7 @@
         <div class="practice-link" style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0; text-align: center;">
             <h3 style="color: var(--accent-green); margin-bottom: 1rem;">🛠️ Practice Building Transactions</h3>
             <p style="margin-bottom: 1.5rem;">Learn how Bitcoin transactions work under the hood with our interactive transaction builder.</p>
-            <a href="/interactive-demos/transaction-builder/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-green), #66BB6A); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px;">
+            <a href="/interactive-demos/transaction-builder/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-green), #28a745); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px;">
                 Open Transaction Builder →
             </a>
             <p style="margin-top: 1rem; font-size: 0.9rem; color: var(--text-dim);">See inputs, outputs, and fees • No real bitcoin required</p>
@@ -455,7 +455,7 @@
             <div style="background: rgba(0, 0, 0, 0.3); border-radius: 0.5rem; padding: 1rem; margin: 1rem 0;">
                 <p style="margin: 0; font-size: 0.95rem;">✅ Free testnet coins<br>✅ Real Bitcoin transactions (but worthless)<br>✅ Practice recovery drills safely<br>✅ Make mistakes without consequences</p>
             </div>
-            <a href="/interactive-demos/testnet-practice-guide/" style="display: inline-block; padding: 0.875rem 1.5rem; background: linear-gradient(135deg, var(--accent-green), #66bb6a); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s; box-shadow: 0 4px 12px rgba(76, 175, 80, 0.4); font-size: 1.05rem;">
+            <a href="/interactive-demos/testnet-practice-guide/" style="display: inline-block; padding: 0.875rem 1.5rem; background: linear-gradient(135deg, var(--accent-green), #28a745); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s; box-shadow: 0 4px 12px rgba(76, 175, 80, 0.4); font-size: 1.05rem;">
                 Start Testnet Practice →
             </a>
             <p style="margin-top: 1rem; font-size: 0.9rem; color: var(--text-dim);">Recommended: Spend 15 minutes here before using real Bitcoin</p>

--- a/paths/hurried/stage-2/module-4.html
+++ b/paths/hurried/stage-2/module-4.html
@@ -210,8 +210,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="nav-buttons">

--- a/paths/hurried/stage-2/module-5.html
+++ b/paths/hurried/stage-2/module-5.html
@@ -203,8 +203,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="nav-buttons">

--- a/paths/hurried/stage-2/module-5.html
+++ b/paths/hurried/stage-2/module-5.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-gold: #FFA726;
+            --accent-gold: #f59e0b;
             --accent-green: #4caf50;
             --accent-red: #ef4444;
             --text-light: #e0e0e0;
@@ -87,7 +87,7 @@
 
         .module-header {
             text-align: center; padding: 2rem;
-            background: linear-gradient(135deg, rgba(255, 167, 38, 0.2), rgba(255, 167, 38, 0.05));
+            background: #101010;
             border: 3px solid var(--accent-gold); border-radius: 1rem; margin-bottom: 2rem;
         }
 
@@ -166,8 +166,8 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FFB74D);
-            color: white; border-radius: 0.5rem; text-decoration: none;
+            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }
 

--- a/paths/hurried/stage-3/module-6.html
+++ b/paths/hurried/stage-3/module-6.html
@@ -9,9 +9,9 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-gold: #FFA726;
-            --accent-green: #4caf50;
-            --accent-purple: #9c27b0;
+            --accent-gold: #f59e0b;
+            --accent-green: #28a745;
+            --accent-purple: #dc3545;
             --text-light: #e0e0e0;
             --text-dim: #b3b3b3;
             --border-color: rgba(255, 167, 38, 0.3);
@@ -87,7 +87,7 @@
 
         .module-header {
             text-align: center; padding: 2rem;
-            background: linear-gradient(135deg, rgba(156, 39, 176, 0.2), rgba(156, 39, 176, 0.05));
+            background: #101010;
             border: 3px solid var(--accent-purple); border-radius: 1rem; margin-bottom: 2rem;
         }
 
@@ -157,7 +157,7 @@
         .key-points li:before { content: "→"; position: absolute; left: 0; color: #2196f3; font-weight: bold; }
 
         .use-case {
-            background: rgba(156, 39, 176, 0.1); border: 2px solid var(--accent-purple);
+            background: #101010; border: 2px solid var(--accent-purple);
             border-radius: 0.75rem; padding: 1.5rem; margin: 1rem 0;
         }
 
@@ -170,8 +170,8 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FFB74D);
-            color: white; border-radius: 0.5rem; text-decoration: none;
+            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }
 
@@ -244,10 +244,10 @@
             </div>
 
             <!-- Interactive Lightning Demo -->
-            <div class="practice-link" style="background: rgba(156, 39, 176, 0.1); border: 2px solid var(--accent-purple); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0; text-align: center;">
+            <div class="practice-link" style="background: #101010; border: 2px solid var(--accent-purple); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0; text-align: center;">
                 <h3 style="color: var(--accent-purple); margin-bottom: 1rem;">⚡ See Lightning in Action</h3>
                 <p style="margin-bottom: 1.5rem;">Explore how Lightning Network channels and routing work with our interactive demo.</p>
-                <a href="/interactive-demos/lightning-network-demo/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-purple), #AB47BC); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px;">
+                <a href="/interactive-demos/lightning-network-demo/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-purple), #c0392b); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px;">
                     Try Lightning Demo →
                 </a>
                 <p style="margin-top: 1rem; font-size: 0.9rem; color: var(--text-dim);">Visualize payment channels • No real bitcoin required</p>

--- a/paths/hurried/stage-3/module-6.html
+++ b/paths/hurried/stage-3/module-6.html
@@ -208,8 +208,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="nav-buttons">

--- a/paths/hurried/stage-3/module-7.html
+++ b/paths/hurried/stage-3/module-7.html
@@ -236,8 +236,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="nav-buttons">

--- a/paths/hurried/stage-3/module-7.html
+++ b/paths/hurried/stage-3/module-7.html
@@ -9,7 +9,7 @@
             --primary-orange: #FF7A00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-gold: #FFA726;
+            --accent-gold: #f59e0b;
             --accent-green: #4caf50;
             --accent-red: #E53935;
             --text-light: #e0e0e0;
@@ -82,7 +82,7 @@
 
         .module-header {
             text-align: center; padding: 2rem;
-            background: linear-gradient(135deg, rgba(229, 57, 53, 0.2), rgba(229, 57, 53, 0.05));
+            background: #101010;
             border: 3px solid var(--accent-red); border-radius: 1rem; margin-bottom: 2rem;
         }
 
@@ -198,7 +198,7 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-green), #66BB6A);
+            background: linear-gradient(135deg, var(--accent-green), #28a745);
             color: white; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }

--- a/paths/index.html
+++ b/paths/index.html
@@ -99,7 +99,7 @@
             border-bottom: 1px dashed currentColor;
             padding-bottom: 2px;
         }
-        .hero .quiz-link:hover { text-decoration: none; color: #ffb74d; }
+        .hero .quiz-link:hover { text-decoration: none; color: #FF7A00; }
 
         .grid {
             display: grid;
@@ -212,38 +212,38 @@
             letter-spacing: 0.05em;
             color: var(--primary-orange);
         }
-        .card:hover .cta { color: #ffb74d; }
+        .card:hover .cta { color: #FF7A00; }
 
-        /* Path-specific accent colors */
-        .card.skeptic { border-color: rgba(168, 169, 173, 0.3); }
-        .card.skeptic:hover { border-color: var(--path-skeptic); box-shadow: 0 12px 28px rgba(168, 169, 173, 0.18); }
-        .card.skeptic .badge { background: rgba(168, 169, 173, 0.18); color: #d4d4d8; }
-        .card.skeptic .cta { color: #d4d4d8; }
+        /* Path-specific accent colors — uniform orange per design system */
+        .card.skeptic { border-color: rgba(255, 122, 0, 0.18); }
+        .card.skeptic:hover { border-color: var(--primary-orange); box-shadow: 0 12px 28px rgba(255, 122, 0, 0.18); }
+        .card.skeptic .badge { background: rgba(255, 122, 0, 0.15); color: var(--primary-orange); }
+        .card.skeptic .cta { color: var(--primary-orange); }
 
-        .card.hurried { border-color: rgba(255, 167, 38, 0.3); }
-        .card.hurried:hover { border-color: var(--path-hurried); box-shadow: 0 12px 28px rgba(255, 167, 38, 0.18); }
+        .card.hurried { border-color: rgba(255, 122, 0, 0.18); }
+        .card.hurried:hover { border-color: var(--primary-orange); box-shadow: 0 12px 28px rgba(255, 122, 0, 0.18); }
 
-        .card.curious { border-color: rgba(76, 175, 80, 0.3); }
-        .card.curious:hover { border-color: var(--path-curious); box-shadow: 0 12px 28px rgba(76, 175, 80, 0.18); }
-        .card.curious .badge { background: rgba(76, 175, 80, 0.18); color: #81c784; }
-        .card.curious .cta { color: #81c784; }
+        .card.curious { border-color: rgba(255, 122, 0, 0.18); }
+        .card.curious:hover { border-color: var(--primary-orange); box-shadow: 0 12px 28px rgba(255, 122, 0, 0.18); }
+        .card.curious .badge { background: rgba(255, 122, 0, 0.15); color: var(--primary-orange); }
+        .card.curious .cta { color: var(--primary-orange); }
 
-        .card.pragmatist { border-color: rgba(0, 188, 212, 0.3); }
-        .card.pragmatist:hover { border-color: var(--path-pragmatist); box-shadow: 0 12px 28px rgba(0, 188, 212, 0.18); }
-        .card.pragmatist .cta { color: #4dd0e1; }
+        .card.pragmatist { border-color: rgba(255, 122, 0, 0.18); }
+        .card.pragmatist:hover { border-color: var(--primary-orange); box-shadow: 0 12px 28px rgba(255, 122, 0, 0.18); }
+        .card.pragmatist .cta { color: var(--primary-orange); }
 
-        .card.principled { border-color: rgba(31, 32, 36, 0.3); }
-        .card.principled:hover { border-color: var(--path-principled); box-shadow: 0 12px 28px rgba(31, 32, 36, 0.2); }
-        .card.principled .cta { color: #c9a87c; }
+        .card.principled { border-color: rgba(255, 122, 0, 0.18); }
+        .card.principled:hover { border-color: var(--primary-orange); box-shadow: 0 12px 28px rgba(255, 122, 0, 0.18); }
+        .card.principled .cta { color: var(--primary-orange); }
 
-        .card.sovereign { border-color: rgba(229, 57, 53, 0.3); }
-        .card.sovereign:hover { border-color: var(--path-sovereign); box-shadow: 0 12px 28px rgba(229, 57, 53, 0.2); }
-        .card.sovereign .cta { color: #ef5350; }
+        .card.sovereign { border-color: rgba(255, 122, 0, 0.18); }
+        .card.sovereign:hover { border-color: var(--primary-orange); box-shadow: 0 12px 28px rgba(255, 122, 0, 0.18); }
+        .card.sovereign .cta { color: var(--primary-orange); }
 
-        .card.builder { border-color: rgba(156, 39, 176, 0.3); }
-        .card.builder:hover { border-color: var(--path-builder); box-shadow: 0 12px 28px rgba(156, 39, 176, 0.22); }
-        .card.builder .badge { background: rgba(156, 39, 176, 0.18); color: #ce93d8; }
-        .card.builder .cta { color: #ce93d8; }
+        .card.builder { border-color: rgba(255, 122, 0, 0.18); }
+        .card.builder:hover { border-color: var(--primary-orange); box-shadow: 0 12px 28px rgba(255, 122, 0, 0.18); }
+        .card.builder .badge { background: rgba(255, 122, 0, 0.15); color: var(--primary-orange); }
+        .card.builder .cta { color: var(--primary-orange); }
 
         .footer-cta {
             text-align: center;
@@ -264,7 +264,7 @@
             font-weight: 700;
             letter-spacing: 0.02em;
         }
-        .footer-cta a:hover { background: #ffb74d; text-decoration: none; }
+        .footer-cta a:hover { background: #FF7A00; text-decoration: none; }
 
         @media (prefers-reduced-motion: reduce) {
             .card, .card:hover { transition: none; transform: none; }
@@ -360,10 +360,10 @@
                 <span class="badge">Start here</span>
                 <span class="icon" aria-hidden="true">
                     <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <circle cx="50" cy="50" r="45" stroke="#4CAF50" stroke-width="3" fill="rgba(76, 175, 80, 0.1)"/>
-                        <circle cx="50" cy="50" r="35" stroke="#4CAF50" stroke-width="2" fill="rgba(76, 175, 80, 0.05)"/>
-                        <path d="M50 15 L55 35 L50 30 L45 35 Z" fill="#4CAF50"/>
-                        <circle cx="50" cy="50" r="5" fill="#4CAF50"/>
+                        <circle cx="50" cy="50" r="45" stroke="#FF7A00" stroke-width="3" fill="rgba(255, 122, 0, 0.1)"/>
+                        <circle cx="50" cy="50" r="35" stroke="#FF7A00" stroke-width="2" fill="rgba(255, 122, 0, 0.05)"/>
+                        <path d="M50 15 L55 35 L50 30 L45 35 Z" fill="#FF7A00"/>
+                        <circle cx="50" cy="50" r="5" fill="#FF7A00"/>
                     </svg>
                 </span>
                 <h2>The Curious</h2>
@@ -393,9 +393,9 @@
             <a href="/paths/pragmatist/" class="card pragmatist" aria-label="The Pragmatist path — 3 stages, 9 hands-on modules, 6 to 8 hours to build real Bitcoin skills">
                 <span class="icon" aria-hidden="true">
                     <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <rect x="35" y="15" width="12" height="50" rx="2" fill="#00BCD4" stroke="#00ACC1" stroke-width="2"/>
-                        <ellipse cx="41" cy="60" rx="8" ry="4" fill="#0097A7"/>
-                        <path d="M47 35 L85 60 L80 70 L42 45 Z" fill="#00BCD4" stroke="#00ACC1" stroke-width="2"/>
+                        <rect x="35" y="15" width="12" height="50" rx="2" fill="#FF7A00" stroke="#FF7A00" stroke-width="2"/>
+                        <ellipse cx="41" cy="60" rx="8" ry="4" fill="rgba(255,122,0,0.4)"/>
+                        <path d="M47 35 L85 60 L80 70 L42 45 Z" fill="#FF7A00" stroke="#FF7A00" stroke-width="2"/>
                     </svg>
                 </span>
                 <h2>The Pragmatist</h2>
@@ -457,8 +457,8 @@
                 <span class="badge">Advanced</span>
                 <span class="icon" aria-hidden="true">
                     <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M50 10 L80 25 L80 50 Q80 75 50 90 Q20 75 20 50 L20 25 Z" fill="rgba(229, 57, 53, 0.2)" stroke="#E53935" stroke-width="3"/>
-                        <path d="M40 45 L46 52 L60 38" stroke="#E53935" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+                        <path d="M50 10 L80 25 L80 50 Q80 75 50 90 Q20 75 20 50 L20 25 Z" fill="rgba(255, 122, 0, 0.15)" stroke="#FF7A00" stroke-width="3"/>
+                        <path d="M40 45 L46 52 L60 38" stroke="#FF7A00" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
                     </svg>
                 </span>
                 <h2>The Sovereign</h2>
@@ -489,11 +489,11 @@
                 <span class="badge">Expert</span>
                 <span class="icon" aria-hidden="true">
                     <svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <rect x="20" y="60" width="60" height="25" rx="2" fill="rgba(156, 39, 176, 0.25)" stroke="#9c27b0" stroke-width="2.5"/>
-                        <rect x="44" y="20" width="6" height="45" fill="#9c27b0"/>
-                        <path d="M50 22 L82 28 L82 35 L50 30 Z" fill="#9c27b0" stroke="#7b1fa2" stroke-width="1.5"/>
-                        <line x1="78" y1="30" x2="74" y2="55" stroke="#9c27b0" stroke-width="2" stroke-linecap="round"/>
-                        <rect x="71" y="55" width="8" height="6" fill="#9c27b0"/>
+                        <rect x="20" y="60" width="60" height="25" rx="2" fill="rgba(255, 122, 0, 0.15)" stroke="#FF7A00" stroke-width="2.5"/>
+                        <rect x="44" y="20" width="6" height="45" fill="#FF7A00"/>
+                        <path d="M50 22 L82 28 L82 35 L50 30 Z" fill="#FF7A00" stroke="#FF7A00" stroke-width="1.5"/>
+                        <line x1="78" y1="30" x2="74" y2="55" stroke="#FF7A00" stroke-width="2" stroke-linecap="round"/>
+                        <rect x="71" y="55" width="8" height="6" fill="#FF7A00"/>
                     </svg>
                 </span>
                 <h2>The Builder</h2>

--- a/paths/index.html
+++ b/paths/index.html
@@ -270,8 +270,9 @@
             .card, .card:hover { transition: none; transform: none; }
         }
     </style>
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
 
     <header class="topbar">

--- a/paths/pragmatist/index.html
+++ b/paths/pragmatist/index.html
@@ -391,8 +391,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Path Header -->
     <header class="path-header">

--- a/paths/pragmatist/index.html
+++ b/paths/pragmatist/index.html
@@ -44,7 +44,7 @@
         /* Path Header */
         .path-header {
             background: var(--secondary-dark);
-            border-bottom: 3px solid var(--pragmatist-cyan);
+            border-bottom: 3px solid #FF7A00;
             padding: 2rem 0;
         }
 
@@ -67,7 +67,7 @@
 
         .path-title h1 {
             font-size: 2.5rem;
-            color: var(--pragmatist-cyan);
+            color: #FF7A00;
             margin-bottom: 0.5rem;
         }
 
@@ -84,8 +84,8 @@
         }
 
         .stat-card {
-            background: rgba(0, 188, 212, 0.1);
-            border: 2px solid var(--pragmatist-cyan);
+            background: rgba(255, 122, 0, 0.08);
+            border: 2px solid #FF7A00;
             border-radius: 0.75rem;
             padding: 1.5rem;
             text-align: center;
@@ -94,7 +94,7 @@
         .stat-value {
             font-size: 2rem;
             font-weight: 700;
-            color: var(--pragmatist-cyan);
+            color: #FF7A00;
             margin-bottom: 0.5rem;
         }
 
@@ -106,7 +106,7 @@
         .progress-bar-header {
             width: 100%;
             height: 10px;
-            background: rgba(0, 188, 212, 0.1);
+            background: rgba(255, 122, 0, 0.15);
             border-radius: 5px;
             overflow: hidden;
             margin-top: 2rem;
@@ -114,7 +114,7 @@
 
         .progress-fill-header {
             height: 100%;
-            background: var(--pragmatist-cyan);
+            background: #FF7A00;
             transition: width 0.3s ease;
         }
 
@@ -150,7 +150,7 @@
 
         .stage-card {
             background: var(--secondary-dark);
-            border: 3px solid var(--border-color);
+            border: 3px solid rgba(255, 122, 0, 0.18);
             border-radius: 1rem;
             padding: 2rem;
             transition: all 0.3s ease;
@@ -158,12 +158,12 @@
         }
 
         .stage-card.completed {
-            border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.05);
+            border-color: #B3B3B3;
+            background: rgba(255, 122, 0, 0.04);
         }
 
         .stage-card.current {
-            border-color: var(--pragmatist-cyan);
+            border-color: #FF7A00;
             box-shadow: 0 0 30px rgba(255, 122, 0, 0.4);
         }
 
@@ -177,7 +177,7 @@
             align-items: flex-start;
             margin-bottom: 1.5rem;
             padding-bottom: 1rem;
-            border-bottom: 2px solid var(--border-color);
+            border-bottom: 2px solid rgba(255, 122, 0, 0.18);
         }
 
         .stage-title {
@@ -191,7 +191,7 @@
 
         .stage-title h3 {
             font-size: 1.75rem;
-            color: var(--pragmatist-cyan);
+            color: #FF7A00;
             margin-bottom: 0.5rem;
         }
 
@@ -203,8 +203,8 @@
         }
 
         .stage-badge {
-            background: rgba(255, 122, 0, 0.2);
-            color: var(--pragmatist-cyan);
+            background: rgba(255, 122, 0, 0.15);
+            color: #FF7A00;
             padding: 0.5rem 1rem;
             border-radius: 2rem;
             font-size: 0.85rem;
@@ -242,13 +242,13 @@
             background: rgba(255, 122, 0, 0.1);
             padding: 0.75rem 1rem;
             border-radius: 0.5rem;
-            border-left: 3px solid var(--pragmatist-cyan);
+            border-left: 3px solid #FF7A00;
             font-size: 0.95rem;
         }
 
         .stage-card.completed .module-item {
-            background: rgba(76, 175, 80, 0.1);
-            border-left-color: var(--accent-green);
+            background: rgba(255, 122, 0, 0.06);
+            border-left-color: #B3B3B3;
         }
 
         .stage-card.locked .module-item {
@@ -263,8 +263,8 @@
         .stage-btn {
             display: inline-block;
             padding: 1rem 2rem;
-            background: var(--pragmatist-cyan);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             text-decoration: none;
             border-radius: 0.75rem;
             font-weight: 600;
@@ -285,15 +285,16 @@
         }
 
         .stage-card.locked .stage-btn {
-            background: var(--text-dim);
+            background: #2D2D2D;
+            color: #B3B3B3;
             cursor: not-allowed;
             pointer-events: none;
         }
 
         /* Gamification Preview */
         .gamification-note {
-            background: rgba(76, 175, 80, 0.1);
-            border: 2px solid var(--accent-green);
+            background: rgba(255, 122, 0, 0.06);
+            border: 2px solid #FF7A00;
             border-radius: 1rem;
             padding: 2rem;
             text-align: center;
@@ -312,14 +313,14 @@
         /* Footer Nav */
         .footer-nav {
             background: var(--secondary-dark);
-            border: 1px solid var(--border-color);
+            border: 1px solid rgba(255, 122, 0, 0.18);
             border-radius: 0.75rem;
             padding: 2rem;
             text-align: center;
         }
 
         .footer-nav h3 {
-            color: var(--pragmatist-cyan);
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
 
@@ -339,7 +340,7 @@
             padding: 0.75rem 1.5rem;
             background: transparent;
             color: var(--text-light);
-            border: 2px solid var(--border-color);
+            border: 2px solid rgba(255, 122, 0, 0.18);
             text-decoration: none;
             border-radius: 0.5rem;
             font-weight: 600;
@@ -348,7 +349,7 @@
         }
 
         .btn-secondary:hover {
-            border-color: var(--pragmatist-cyan);
+            border-color: #FF7A00;
             background: rgba(255, 122, 0, 0.1);
         }
 
@@ -514,8 +515,8 @@
                         </div>
                     </div>
 
-                    <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 0.75rem; padding: 1.5rem; margin: 1.5rem 0;">
-                        <h4 style="color: var(--pragmatist-cyan); margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem;">
+                    <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid #FF7A00; border-radius: 0.75rem; padding: 1.5rem; margin: 1.5rem 0;">
+                        <h4 style="color: #FF7A00; margin-bottom: 1rem; display: flex; align-items: center; gap: 0.5rem;">
                             <span><span data-icon="lightbulb"></span> </span>
                             <span>Bonus Resource</span>
                         </h4>
@@ -525,7 +526,7 @@
                                 <strong style="color: var(--text-light); display: block; margin-bottom: 0.25rem;">Bank &amp; Payment Friction Guide</strong>
                                 <p style="color: var(--text-dim); font-size: 0.85rem; margin: 0;">Navigate bank policies and exchange restrictions when buying Bitcoin.</p>
                             </div>
-                            <a href="/paths/pragmatist/stage-2/bank-friction.html" style="padding: 0.5rem 1rem; background: var(--pragmatist-cyan); color: var(--primary-dark); text-decoration: none; border-radius: 0.5rem; font-weight: 600; font-size: 0.9rem; white-space: nowrap;">Read Guide →</a>
+                            <a href="/paths/pragmatist/stage-2/bank-friction.html" style="padding: 0.5rem 1rem; background: #FF7A00; color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 600; font-size: 0.9rem; white-space: nowrap;">Read Guide →</a>
                         </div>
                     </div>
 
@@ -741,7 +742,7 @@
                     if (badge2) {
                         badge2.textContent = 'Continue';
                         badge2.style.background = 'rgba(255, 122, 0, 0.2)';
-                        badge2.style.color = 'var(--pragmatist-cyan)';
+                        badge2.style.color = '#FF7A00';
                     }
                 }
 
@@ -763,7 +764,7 @@
                     if (badge3) {
                         badge3.textContent = 'Continue';
                         badge3.style.background = 'rgba(255, 122, 0, 0.2)';
-                        badge3.style.color = 'var(--pragmatist-cyan)';
+                        badge3.style.color = '#FF7A00';
                     }
                 }
 
@@ -821,20 +822,20 @@
     </script>
 
     <!-- Cross-Path Navigation Component -->
-    <div style="background: linear-gradient(135deg, #1a1a1a, #2d2d2d); border-top: 3px solid var(--pragmatist-cyan); padding: 3rem 2rem; margin-top: 4rem;">
+    <div style="background: linear-gradient(135deg, #1a1a1a, #2d2d2d); border-top: 3px solid #FF7A00; padding: 3rem 2rem; margin-top: 4rem;">
         <div style="max-width: 1100px; margin: 0 auto;">
             <div style="text-align: center; margin-bottom: 2rem;">
-                <h2 style="color: var(--pragmatist-cyan); font-size: 1.8rem; margin-bottom: 0.75rem;">Continue Your Bitcoin Journey</h2>
+                <h2 style="color: #FF7A00; font-size: 1.8rem; margin-bottom: 0.75rem;">Continue Your Bitcoin Journey</h2>
                 <p style="color: var(--text-dim); font-size: 1.1rem;">You've built practical skills. Explore these paths to deepen your knowledge.</p>
             </div>
 
             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; margin-top: 2rem;">
                 <!-- Hurried Path -->
-                <a href="/paths/hurried/" style="background: var(--secondary-dark); border: 2px solid rgba(255, 193, 7, 0.3); border-radius: 1rem; padding: 2rem; text-decoration: none; color: var(--text-light); transition: all 0.3s ease; display: block;">
+                <a href="/paths/hurried/" style="background: var(--secondary-dark); border: 2px solid rgba(255, 122, 0, 0.25); border-radius: 1rem; padding: 2rem; text-decoration: none; color: var(--text-light); transition: all 0.3s ease; display: block;">
                     <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
-                        <div style="width: 50px; height: 50px; background: linear-gradient(135deg, #FFC107, #FFB300); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.5rem;"><span data-icon="lightning"></span> </div>
+                        <div style="width: 50px; height: 50px; background: #101010; border: 2px solid #f59e0b; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.5rem;"><span data-icon="lightning"></span> </div>
                         <div>
-                            <h3 style="color: #FFC107; font-size: 1.3rem; margin: 0;">The Hurried Path</h3>
+                            <h3 style="color: #FF7A00; font-size: 1.3rem; margin: 0;">The Hurried Path</h3>
                             <p style="color: var(--text-dim); font-size: 0.85rem; margin: 0.25rem 0 0;">Quick • Essential Basics</p>
                         </div>
                     </div>
@@ -842,19 +843,19 @@
                         Need Bitcoin fast? Learn essential concepts in 30 minutes: wallets, sending, receiving, and staying safe.
                     </p>
                     <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
-                        <span style="background: rgba(255, 193, 7, 0.2); color: #FFC107; padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.8rem;">Quick Start</span>
-                        <span style="background: rgba(255, 193, 7, 0.2); color: #FFC107; padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.8rem;">Emergency Help</span>
+                        <span style="background: transparent; border: 1px solid rgba(255, 122, 0, 0.4); color: #FF7A00; padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.8rem;">Quick Start</span>
+                        <span style="background: transparent; border: 1px solid rgba(255, 122, 0, 0.4); color: #FF7A00; padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.8rem;">Emergency Help</span>
                     </div>
                 </a>
 
                 <!-- Sovereign Path -->
-                <a href="/paths/sovereign/" style="background: var(--secondary-dark); border: 2px solid rgba(212, 175, 55, 0.3); border-radius: 1rem; padding: 2rem; text-decoration: none; color: var(--text-light); transition: all 0.3s ease; display: block;">
+                <a href="/paths/sovereign/" style="background: var(--secondary-dark); border: 2px solid rgba(255, 122, 0, 0.25); border-radius: 1rem; padding: 2rem; text-decoration: none; color: var(--text-light); transition: all 0.3s ease; display: block;">
                     <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
-                        <div style="width: 50px; height: 50px; background: linear-gradient(135deg, #D4AF37, #FFD700); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.5rem;">
+                        <div style="width: 50px; height: 50px; background: #101010; border: 2px solid #FF7A00; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.5rem;">
                             👑
                         </div>
                         <div>
-                            <h3 style="color: #D4AF37; font-size: 1.3rem; margin: 0;">The Sovereign Path</h3>
+                            <h3 style="color: #FF7A00; font-size: 1.3rem; margin: 0;">The Sovereign Path</h3>
                             <p style="color: var(--text-dim); font-size: 0.85rem; margin: 0.25rem 0 0;">Advanced • Security-Focused</p>
                         </div>
                     </div>
@@ -862,15 +863,15 @@
                         Ready for full sovereignty? Master cold storage, multi-sig, privacy techniques, and inheritance planning.
                     </p>
                     <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
-                        <span style="background: rgba(212, 175, 55, 0.2); color: #D4AF37; padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.8rem;">Cold Storage</span>
-                        <span style="background: rgba(212, 175, 55, 0.2); color: #D4AF37; padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.8rem;">Multi-Sig</span>
+                        <span style="background: rgba(255, 122, 0, 0.15); color: #FF7A00; padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.8rem;">Cold Storage</span>
+                        <span style="background: rgba(255, 122, 0, 0.15); color: #FF7A00; padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.8rem;">Multi-Sig</span>
                     </div>
                 </a>
             </div>
 
-            <div style="text-align: center; margin-top: 2rem; padding-top: 2rem; border-top: 1px solid var(--border-color);">
+            <div style="text-align: center; margin-top: 2rem; padding-top: 2rem; border-top: 1px solid rgba(255, 122, 0, 0.18);">
                 <p style="color: var(--text-dim); font-size: 0.9rem;">
-                    Or return to <a href="/" style="color: var(--pragmatist-cyan); text-decoration: none; font-weight: 600;">Homepage</a> to explore all learning paths
+                    Or return to <a href="/" style="color: #FF7A00; text-decoration: none; font-weight: 600;">Homepage</a> to explore all learning paths
                 </p>
             </div>
         </div>

--- a/paths/pragmatist/stage-1/module-1.html
+++ b/paths/pragmatist/stage-1/module-1.html
@@ -138,7 +138,7 @@
 
         /* Highlight Box */
         .highlight-box {
-            background: linear-gradient(135deg, rgba(255, 215, 0, 0.1), rgba(255, 122, 0, 0.1));
+            background: linear-gradient(135deg, rgba(255, 122, 0, 0.08), rgba(255, 122, 0, 0.1));
             border-left: 4px solid var(--pragmatist-teal);
             border-radius: 0.5rem;
             padding: 1.5rem;
@@ -169,8 +169,8 @@
         }
 
         .comparison-card.bitcoin {
-            background: rgba(76, 175, 80, 0.1);
-            border: 2px solid rgba(76, 175, 80, 0.3);
+            background: rgba(40, 167, 69, 0.08);
+            border: 2px solid rgba(40, 167, 69, 0.20);
         }
 
         .comparison-card:hover {
@@ -265,7 +265,7 @@
 
         .quiz-option:hover:not(:disabled) {
             border-color: var(--pragmatist-teal);
-            background: rgba(255, 215, 0, 0.1);
+            background: rgba(255, 122, 0, 0.08);
         }
 
         .quiz-option:disabled {
@@ -274,7 +274,7 @@
 
         .quiz-option.correct {
             border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.2);
+            background: rgba(40, 167, 69, 0.12);
             animation: correctPulse 0.5s ease;
         }
 
@@ -307,12 +307,12 @@
         }
 
         .quiz-result.success {
-            background: rgba(76, 175, 80, 0.2);
+            background: rgba(40, 167, 69, 0.12);
             border: 2px solid var(--accent-green);
         }
 
         .quiz-result.partial {
-            background: rgba(255, 193, 7, 0.2);
+            background: rgba(255, 122, 0, 0.15);
             border: 2px solid var(--pragmatist-teal);
         }
 
@@ -346,7 +346,7 @@
 
         .complete-btn:not(:disabled):hover {
             transform: translateY(-2px);
-            box-shadow: 0 5px 20px rgba(255, 215, 0, 0.3);
+            box-shadow: 0 5px 20px rgba(255, 122, 0, 0.25);
         }
 
         /* Achievement Notification */
@@ -545,7 +545,7 @@
 
     <!-- In This Module Block -->
     <div class="container" style="margin-top: 2rem;">
-        <div style="background: linear-gradient(135deg, rgba(0, 188, 212, 0.15), rgba(0, 172, 193, 0.05)); border-left: 4px solid var(--pragmatist-teal); border-radius: 0.75rem; padding: 1.5rem; margin-bottom: 2rem;">
+        <div style="background: linear-gradient(135deg, rgba(255, 122, 0, 0.10), rgba(255, 122, 0, 0.04)); border-left: 4px solid var(--pragmatist-teal); border-radius: 0.75rem; padding: 1.5rem; margin-bottom: 2rem;">
             <h3 style="color: var(--pragmatist-teal); margin-bottom: 1rem; font-size: 1.2rem;">In this module you will:</h3>
             <ul style="list-style: none; padding: 0; margin: 0;">
                 <li style="padding: 0.5rem 0; color: var(--text-light); font-size: 1.05rem;">• Understand why Bitcoin was invented after the internet</li>
@@ -774,7 +774,7 @@
         </section>
 
         <!-- Bitcoin Genesis Timeline Interactive Demo -->
-        <section class="content-section" style="background: linear-gradient(135deg, rgba(0, 188, 212, 0.1), rgba(0, 172, 193, 0.05)); border: 2px solid var(--pragmatist-teal); margin: 3rem 0;">
+        <section class="content-section" style="background: linear-gradient(135deg, rgba(255, 122, 0, 0.08), rgba(255, 122, 0, 0.04)); border: 2px solid var(--pragmatist-teal); margin: 3rem 0;">
             <h2 style="color: var(--pragmatist-teal); text-align: center; margin-bottom: 1rem;">
                 <span data-icon="chart"></span> Interactive: Bitcoin's Historical Journey
             </h2>
@@ -793,7 +793,7 @@
             </div>
 
             <div style="text-align: center; margin-top: 2rem;">
-                <a href="/interactive-demos/bitcoin-price-timeline/" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--pragmatist-cyan), var(--pragmatist-teal)); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.1rem; box-shadow: 0 4px 12px rgba(0, 188, 212, 0.3); transition: all 0.3s ease;">
+                <a href="/interactive-demos/bitcoin-price-timeline/" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--pragmatist-cyan), var(--pragmatist-teal)); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.1rem; box-shadow: 0 4px 12px rgba(255, 122, 0, 0.25); transition: all 0.3s ease;">
                     Explore Bitcoin Genesis Timeline →
                 </a>
             </div>
@@ -945,7 +945,7 @@
         </section>
 
         <!-- Action in Next 5 Minutes -->
-        <section class="content-section" style="background: linear-gradient(135deg, rgba(0, 188, 212, 0.1), rgba(0, 172, 193, 0.05)); border: 2px solid var(--pragmatist-teal);">
+        <section class="content-section" style="background: linear-gradient(135deg, rgba(255, 122, 0, 0.08), rgba(255, 122, 0, 0.04)); border: 2px solid var(--pragmatist-teal);">
             <h2 style="color: var(--pragmatist-teal);"><span data-icon="target"></span> Action in the next 5 minutes</h2>
             <p style="margin-bottom: 1.5rem;">
                 Look at your main bank app or payment app.
@@ -1514,14 +1514,14 @@
 
     <!-- Add condensed CSS framework -->
     <style>
-        .reflection-tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 2px solid rgba(0, 188, 212, 0.2); padding-bottom: 0.5rem; }
-        .reflection-tab { background: transparent; color: var(--text-dim); border: 2px solid rgba(0, 188, 212, 0.3); padding: 0.5rem 1.25rem; border-radius: 8px 8px 0 0; font-weight: 600; font-size: 0.95rem; cursor: pointer; transition: all 0.3s ease; }
-        .reflection-tab.active { background: linear-gradient(135deg, rgba(0, 188, 212, 0.2), rgba(0, 172, 193, 0.1)); color: var(--pragmatist-cyan); border-color: var(--pragmatist-cyan); }
-        .reflection-panel { display: none; padding: 1.5rem; background: rgba(26, 26, 26, 0.8); border-radius: 0 8px 8px 8px; border: 2px solid rgba(0, 188, 212, 0.2); }
+        .reflection-tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 2px solid rgba(255, 122, 0, 0.15); padding-bottom: 0.5rem; }
+        .reflection-tab { background: transparent; color: var(--text-dim); border: 2px solid rgba(255, 122, 0, 0.25); padding: 0.5rem 1.25rem; border-radius: 8px 8px 0 0; font-weight: 600; font-size: 0.95rem; cursor: pointer; transition: all 0.3s ease; }
+        .reflection-tab.active { background: linear-gradient(135deg, rgba(255, 122, 0, 0.15), rgba(255, 122, 0, 0.06)); color: var(--pragmatist-cyan); border-color: var(--pragmatist-cyan); }
+        .reflection-panel { display: none; padding: 1.5rem; background: rgba(26, 26, 26, 0.8); border-radius: 0 8px 8px 8px; border: 2px solid rgba(255, 122, 0, 0.15); }
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
-        .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: var(--text-light); }
+        .feedback-box.positive { background: rgba(40, 167, 69, 0.08); border-color: #4caf50; color: var(--text-light); }
         .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #ff9800; color: var(--text-light); }
         @media (max-width: 768px) {
             .reflection-tabs { flex-direction: column; }

--- a/paths/pragmatist/stage-1/module-1.html
+++ b/paths/pragmatist/stage-1/module-1.html
@@ -513,8 +513,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Achievement Notification -->
     <div class="achievement-notification" id="achievement-notification">

--- a/paths/pragmatist/stage-1/module-1.html
+++ b/paths/pragmatist/stage-1/module-1.html
@@ -403,7 +403,7 @@
 
         .ticker-label {
             background: var(--pragmatist-cyan);
-            color: white;
+            color: #101010;
             padding: 0 1rem;
             font-weight: 700;
             font-size: 0.85rem;
@@ -794,7 +794,7 @@
             </div>
 
             <div style="text-align: center; margin-top: 2rem;">
-                <a href="/interactive-demos/bitcoin-price-timeline/" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--pragmatist-cyan), var(--pragmatist-teal)); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.1rem; box-shadow: 0 4px 12px rgba(255, 122, 0, 0.25); transition: all 0.3s ease;">
+                <a href="/interactive-demos/bitcoin-price-timeline/" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--pragmatist-cyan), var(--pragmatist-teal)); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.1rem; box-shadow: 0 4px 12px rgba(255, 122, 0, 0.25); transition: all 0.3s ease;">
                     Explore Bitcoin Genesis Timeline →
                 </a>
             </div>

--- a/paths/pragmatist/stage-1/module-2.html
+++ b/paths/pragmatist/stage-1/module-2.html
@@ -33,8 +33,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">

--- a/paths/pragmatist/stage-1/module-2.html
+++ b/paths/pragmatist/stage-1/module-2.html
@@ -764,14 +764,14 @@
 
     <!-- Add condensed CSS framework -->
     <style>
-        .reflection-tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 2px solid rgba(0, 188, 212, 0.2); padding-bottom: 0.5rem; }
-        .reflection-tab { background: transparent; color: var(--text-dim); border: 2px solid rgba(0, 188, 212, 0.3); padding: 0.5rem 1.25rem; border-radius: 8px 8px 0 0; font-weight: 600; font-size: 0.95rem; cursor: pointer; transition: all 0.3s ease; }
-        .reflection-tab.active { background: linear-gradient(135deg, rgba(0, 188, 212, 0.2), rgba(0, 172, 193, 0.1)); color: var(--pragmatist-cyan); border-color: var(--pragmatist-cyan); }
-        .reflection-panel { display: none; padding: 1.5rem; background: rgba(26, 26, 26, 0.8); border-radius: 0 8px 8px 8px; border: 2px solid rgba(0, 188, 212, 0.2); }
+        .reflection-tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 2px solid rgba(255, 122, 0, 0.15); padding-bottom: 0.5rem; }
+        .reflection-tab { background: transparent; color: var(--text-dim); border: 2px solid rgba(255, 122, 0, 0.25); padding: 0.5rem 1.25rem; border-radius: 8px 8px 0 0; font-weight: 600; font-size: 0.95rem; cursor: pointer; transition: all 0.3s ease; }
+        .reflection-tab.active { background: linear-gradient(135deg, rgba(255, 122, 0, 0.15), rgba(255, 122, 0, 0.06)); color: var(--pragmatist-cyan); border-color: var(--pragmatist-cyan); }
+        .reflection-panel { display: none; padding: 1.5rem; background: rgba(26, 26, 26, 0.8); border-radius: 0 8px 8px 8px; border: 2px solid rgba(255, 122, 0, 0.15); }
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
-        .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: var(--text-light); }
+        .feedback-box.positive { background: rgba(40, 167, 69, 0.08); border-color: #4caf50; color: var(--text-light); }
         .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #ff9800; color: var(--text-light); }
         @media (max-width: 768px) {
             .reflection-tabs { flex-direction: column; }

--- a/paths/pragmatist/stage-1/module-3.html
+++ b/paths/pragmatist/stage-1/module-3.html
@@ -33,8 +33,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">

--- a/paths/pragmatist/stage-1/module-3.html
+++ b/paths/pragmatist/stage-1/module-3.html
@@ -288,16 +288,16 @@
             </div>
 
             <!-- Interactive Lightning Demo -->
-            <div style="background: linear-gradient(135deg, rgba(255, 193, 7, 0.15), rgba(255, 193, 7, 0.05)); border: 2px solid #FFC107; border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid #FF7A00; border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
                 <div style="display: grid; grid-template-columns: auto 1fr auto; gap: 1rem; align-items: center;">
                     <div style="font-size: 2.5rem;"><span data-icon="lightning"></span> </div>
                     <div>
-                        <h4 style="color: #FFC107; margin: 0 0 0.5rem 0;">See Lightning in Action</h4>
+                        <h4 style="color: #FF7A00; margin: 0 0 0.5rem 0;">See Lightning in Action</h4>
                         <p style="margin: 0 0 0.5rem; color: var(--text-light); font-size: 0.95rem;">
                             Watch Bitcoin move at light speed! Interactive demo showing instant settlement.
                         </p>
                     </div>
-                    <a href="/interactive-demos/lightning-network-demo/index.html" style="display: inline-block; padding: 0.875rem 1.25rem; background: linear-gradient(135deg, #FFC107, #FFA000); color: #000; text-decoration: none; border-radius: 0.5rem; font-weight: 600; white-space: nowrap; transition: all 0.3s; box-shadow: 0 4px 12px rgba(255, 193, 7, 0.3);">
+                    <a href="/interactive-demos/lightning-network-demo/index.html" style="display: inline-block; padding: 0.875rem 1.25rem; background: #FF7A00; color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 600; white-space: nowrap; transition: all 0.3s; box-shadow: 0 4px 12px rgba(255, 122, 0, 0.3);">
                         Watch Demo →
                     </a>
                 </div>
@@ -344,7 +344,7 @@
         </section>
 
         <!-- Testnet Lab -->
-        <section class="content-section" style="background: linear-gradient(135deg, rgba(0, 255, 0, 0.1), rgba(0, 200, 0, 0.05)); border: 3px solid var(--status-green);">
+        <section class="content-section" style="background: linear-gradient(135deg, rgba(40, 167, 69, 0.08), rgba(0, 200, 0, 0.05)); border: 3px solid var(--status-green);">
             <h2 style="text-align: center;">🧪 Testnet Lab — Learn Without Risk</h2>
             <p style="text-align: center; margin-bottom: 2rem;">Run real transactions on Bitcoin Testnet.</p>
 
@@ -769,14 +769,14 @@
 
     <!-- Add condensed CSS framework -->
     <style>
-        .reflection-tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 2px solid rgba(0, 188, 212, 0.2); padding-bottom: 0.5rem; }
-        .reflection-tab { background: transparent; color: var(--text-dim); border: 2px solid rgba(0, 188, 212, 0.3); padding: 0.5rem 1.25rem; border-radius: 8px 8px 0 0; font-weight: 600; font-size: 0.95rem; cursor: pointer; transition: all 0.3s ease; }
-        .reflection-tab.active { background: linear-gradient(135deg, rgba(0, 188, 212, 0.2), rgba(0, 172, 193, 0.1)); color: var(--pragmatist-cyan); border-color: var(--pragmatist-cyan); }
-        .reflection-panel { display: none; padding: 1.5rem; background: rgba(26, 26, 26, 0.8); border-radius: 0 8px 8px 8px; border: 2px solid rgba(0, 188, 212, 0.2); }
+        .reflection-tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 2px solid rgba(255, 122, 0, 0.15); padding-bottom: 0.5rem; }
+        .reflection-tab { background: transparent; color: var(--text-dim); border: 2px solid rgba(255, 122, 0, 0.25); padding: 0.5rem 1.25rem; border-radius: 8px 8px 0 0; font-weight: 600; font-size: 0.95rem; cursor: pointer; transition: all 0.3s ease; }
+        .reflection-tab.active { background: linear-gradient(135deg, rgba(255, 122, 0, 0.15), rgba(255, 122, 0, 0.06)); color: var(--pragmatist-cyan); border-color: var(--pragmatist-cyan); }
+        .reflection-panel { display: none; padding: 1.5rem; background: rgba(26, 26, 26, 0.8); border-radius: 0 8px 8px 8px; border: 2px solid rgba(255, 122, 0, 0.15); }
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
-        .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: var(--text-light); }
+        .feedback-box.positive { background: rgba(40, 167, 69, 0.08); border-color: #4caf50; color: var(--text-light); }
         .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #ff9800; color: var(--text-light); }
         @media (max-width: 768px) {
             .reflection-tabs { flex-direction: column; }

--- a/paths/pragmatist/stage-1/module-4.html
+++ b/paths/pragmatist/stage-1/module-4.html
@@ -82,7 +82,7 @@
             <h2><span data-icon="chart"></span> Step 1: Choose Your Exchange</h2>
             <p>An exchange is where you convert fiat currency (USD, AUD, EUR) into Bitcoin. Think of it as a currency exchange counter at an airport—but for digital money.</p>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
                 <h3 style="color: var(--pragmatist-cyan); margin-bottom: 1rem;"><span data-icon="trophy"></span> Top Exchanges for Beginners</h3>
 
                 <table style="width: 100%; border-collapse: collapse; margin: 1rem 0;">
@@ -184,7 +184,7 @@
                 <h3 style="color: var(--pragmatist-cyan);">📋 KYC Process Walkthrough</h3>
 
                 <div style="display: grid; gap: 1rem; margin-top: 1rem;">
-                    <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                    <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                         <div style="display: flex; align-items: center; gap: 1rem;">
                             <span style="font-size: 2rem;">1️⃣</span>
                             <div>
@@ -194,7 +194,7 @@
                         </div>
                     </div>
 
-                    <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                    <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                         <div style="display: flex; align-items: center; gap: 1rem;">
                             <span style="font-size: 2rem;">2️⃣</span>
                             <div>
@@ -204,7 +204,7 @@
                         </div>
                     </div>
 
-                    <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                    <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                         <div style="display: flex; align-items: center; gap: 1rem;">
                             <span style="font-size: 2rem;">3️⃣</span>
                             <div>
@@ -214,7 +214,7 @@
                         </div>
                     </div>
 
-                    <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                    <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                         <div style="display: flex; align-items: center; gap: 1rem;">
                             <span style="font-size: 2rem;">4️⃣</span>
                             <div>
@@ -224,7 +224,7 @@
                         </div>
                     </div>
 
-                    <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                    <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                         <div style="display: flex; align-items: center; gap: 1rem;">
                             <span style="font-size: 2rem;">5️⃣</span>
                             <div>
@@ -284,7 +284,7 @@
                 </tbody>
             </table>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
                 <h3 style="color: var(--pragmatist-cyan); margin-bottom: 1rem;"><span data-icon="lightbulb"></span> Pro Tips for Funding</h3>
                 <ul style="margin-left: 2rem; color: var(--text-light);">
                     <li><strong>First time?</strong> Start with a small test amount ($50-$100)</li>
@@ -305,7 +305,7 @@
 
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin: 1.5rem 0;">
                 <!-- Market Order -->
-                <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem;">
+                <div style="background: rgba(40, 167, 69, 0.08); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem;">
                     <h4 style="color: var(--accent-green); margin-bottom: 1rem;"><span data-icon="target"></span> Market Order (Recommended)</h4>
                     <p><strong>What it does:</strong> Buys Bitcoin immediately at current market price</p>
                     <p><strong>Best for:</strong> Most people, most of the time</p>
@@ -389,7 +389,7 @@
             <h3 style="color: var(--pragmatist-cyan);">📋 Withdrawal Walkthrough</h3>
 
             <div style="margin: 1.5rem 0;">
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">1️⃣</span>
                         <div>
@@ -399,7 +399,7 @@
                     </div>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">2️⃣</span>
                         <div>
@@ -409,7 +409,7 @@
                     </div>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">3️⃣</span>
                         <div>
@@ -419,7 +419,7 @@
                     </div>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">4️⃣</span>
                         <div>
@@ -429,7 +429,7 @@
                     </div>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">5️⃣</span>
                         <div>
@@ -439,7 +439,7 @@
                     </div>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">6️⃣</span>
                         <div>
@@ -449,7 +449,7 @@
                     </div>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">7️⃣</span>
                         <div>
@@ -460,7 +460,7 @@
                 </div>
             </div>
 
-            <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
+            <div style="background: rgba(40, 167, 69, 0.08); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
                 <h3 style="color: var(--accent-green); margin-bottom: 1rem;">✅ Success Checklist</h3>
                 <ul style="margin-left: 2rem; color: var(--text-light);">
                     <li>Bitcoin appears in your personal wallet</li>
@@ -484,7 +484,7 @@
             <h2><span data-icon="tool"></span> Troubleshooting Common Issues</h2>
 
             <div style="margin: 1.5rem 0;">
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);">❌ My bank blocked the transfer</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p>Common problem. Solutions:</p>
@@ -498,7 +498,7 @@
                     </div>
                 </details>
 
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);"><span data-icon="clock"></span> Withdrawal is taking forever</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p>First withdrawal may require additional security checks (24-72 hours).</p>
@@ -512,7 +512,7 @@
                     </div>
                 </details>
 
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);"><span data-icon="money-flow"></span> Withdrawal fees seem high</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p>Exchanges charge fixed withdrawal fees ($5-$25 typically).</p>
@@ -526,7 +526,7 @@
                     </div>
                 </details>
 
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);">😰 I sent to the wrong address!</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p style="color: var(--accent-red); font-weight: 600;">Unfortunately, Bitcoin transactions are irreversible.</p>
@@ -541,7 +541,7 @@
                     </div>
                 </details>
 
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);"><span data-icon="lock"></span> My account is locked / requires more verification</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p>Exchanges have automated fraud detection. Triggers:</p>
@@ -562,7 +562,7 @@
             <h2><span data-icon="target"></span> Action Checklist: Complete Your First Purchase</h2>
             <p>By the end of this module, you should have:</p>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
                 <div style="display: grid; gap: 1rem;">
                     <label style="display: flex; align-items: center; gap: 1rem; cursor: pointer;">
                         <input type="checkbox" style="width: 20px; height: 20px;">
@@ -599,7 +599,7 @@
                 </div>
             </div>
 
-            <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0; text-align: center;">
+            <div style="background: rgba(40, 167, 69, 0.08); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0; text-align: center;">
                 <p style="font-size: 1.3rem; margin: 0;">
                     <strong>🎉 Congratulations!</strong>
                 </p>

--- a/paths/pragmatist/stage-1/module-4.html
+++ b/paths/pragmatist/stage-1/module-4.html
@@ -33,8 +33,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">

--- a/paths/pragmatist/stage-2/bank-friction.html
+++ b/paths/pragmatist/stage-2/bank-friction.html
@@ -97,8 +97,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/pragmatist/stage-2/bank-friction.html
+++ b/paths/pragmatist/stage-2/bank-friction.html
@@ -53,12 +53,12 @@
         }
 
         .status-friendly {
-            background: rgba(76, 175, 80, 0.2);
+            background: rgba(40, 167, 69, 0.12);
             color: var(--status-green);
         }
 
         .workaround-box {
-            background: rgba(0, 188, 212, 0.1);
+            background: rgba(255, 122, 0, 0.08);
             border-left: 4px solid var(--pragmatist-cyan);
             padding: 1rem;
             border-radius: 0.5rem;

--- a/paths/pragmatist/stage-2/module-5-security.html
+++ b/paths/pragmatist/stage-2/module-5-security.html
@@ -74,7 +74,7 @@
 
             <div style="margin: 2rem 0;">
                 <!-- Beginner ($0-$1,000) -->
-                <div style="margin-bottom: 2rem; padding: 1.5rem; background: rgba(255, 255, 0, 0.1); border: 3px solid var(--status-yellow); border-radius: 1rem;">
+                <div style="margin-bottom: 2rem; padding: 1.5rem; background: rgba(255, 122, 0, 0.08); border: 3px solid var(--status-yellow); border-radius: 1rem;">
                     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
                         <div style="display: flex; align-items: center; gap: 1rem;">
                             <span style="font-size: 3rem;">🟡</span>
@@ -115,7 +115,7 @@
                 </div>
 
                 <!-- Advanced ($10,000+) -->
-                <div style="padding: 1.5rem; background: rgba(0, 255, 0, 0.1); border: 3px solid var(--status-green); border-radius: 1rem;">
+                <div style="padding: 1.5rem; background: rgba(40, 167, 69, 0.08); border: 3px solid var(--status-green); border-radius: 1rem;">
                     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
                         <div style="display: flex; align-items: center; gap: 1rem;">
                             <span style="font-size: 3rem;">🟢</span>
@@ -150,7 +150,7 @@
                         <strong style="color: var(--status-red); font-size: 1.3rem;">Phishing Scams</strong>
                     </div>
                     <p style="color: var(--text-light); margin-bottom: 1rem;">Fake websites, emails, or messages trying to steal your credentials or seed phrase.</p>
-                    <div style="background: rgba(255, 0, 0, 0.1); padding: 1rem; border-radius: 0.5rem;">
+                    <div style="background: rgba(220, 53, 69, 0.08); padding: 1rem; border-radius: 0.5rem;">
                         <p style="margin: 0; color: var(--text-light);"><strong>Protection:</strong></p>
                         <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-light);">
                             <li>Bookmark official wallet/exchange sites</li>
@@ -168,7 +168,7 @@
                         <strong style="color: var(--status-red); font-size: 1.3rem;">Malware &amp; Keyloggers</strong>
                     </div>
                     <p style="color: var(--text-light); margin-bottom: 1rem;">Malicious software that steals passwords, seed phrases, or Bitcoin directly.</p>
-                    <div style="background: rgba(255, 0, 0, 0.1); padding: 1rem; border-radius: 0.5rem;">
+                    <div style="background: rgba(220, 53, 69, 0.08); padding: 1rem; border-radius: 0.5rem;">
                         <p style="margin: 0; color: var(--text-light);"><strong>Protection:</strong></p>
                         <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-light);">
                             <li>Keep operating system and software updated</li>
@@ -205,7 +205,7 @@
                         <strong style="color: var(--status-yellow); font-size: 1.3rem;">Clipboard Hijacking</strong>
                     </div>
                     <p style="color: var(--text-light); margin-bottom: 1rem;">Malware that replaces Bitcoin addresses you copy with attacker's address.</p>
-                    <div style="background: rgba(255, 255, 0, 0.1); padding: 1rem; border-radius: 0.5rem;">
+                    <div style="background: rgba(255, 122, 0, 0.08); padding: 1rem; border-radius: 0.5rem;">
                         <p style="margin: 0; color: var(--text-light);"><strong>Protection:</strong></p>
                         <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-light);">
                             <li>ALWAYS verify first and last characters of address before sending</li>
@@ -299,17 +299,17 @@
                     <p style="margin: 0.5rem 0 0; color: var(--text-light);">✅ If you have your seed phrase, you can recover your wallet on a new device. This is why backup is critical!</p>
                 </div>
 
-                <div style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(255, 0, 0, 0.1); border-left: 4px solid var(--status-red); border-radius: 0.5rem;">
+                <div style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(220, 53, 69, 0.08); border-left: 4px solid var(--status-red); border-radius: 0.5rem;">
                     <strong style="color: var(--status-red);">Lost Seed Phrase</strong>
                     <p style="margin: 0.5rem 0 0; color: var(--text-light);">⚠️ If you still have access to your wallet, immediately send Bitcoin to a new wallet with properly backed up seed phrase.</p>
                 </div>
 
-                <div style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(255, 0, 0, 0.1); border-left: 4px solid var(--status-red); border-radius: 0.5rem;">
+                <div style="margin-bottom: 1.5rem; padding: 1rem; background: rgba(220, 53, 69, 0.08); border-left: 4px solid var(--status-red); border-radius: 0.5rem;">
                     <strong style="color: var(--status-red);">Sent to Wrong Address</strong>
                     <p style="margin: 0.5rem 0 0; color: var(--text-light);">❌ Bitcoin transactions are irreversible. If you sent to wrong address, funds are likely lost forever. Always verify addresses!</p>
                 </div>
 
-                <div style="padding: 1rem; background: rgba(255, 215, 0, 0.1); border-left: 4px solid var(--bright-yellow); border-radius: 0.5rem;">
+                <div style="padding: 1rem; background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--bright-yellow); border-radius: 0.5rem;">
                     <strong style="color: var(--bright-yellow);">Hardware Wallet Broken</strong>
                     <p style="margin: 0.5rem 0 0; color: var(--text-light);">✅ Buy new hardware wallet, restore using seed phrase. Your Bitcoin is on the blockchain, not the device!</p>
                 </div>
@@ -761,14 +761,14 @@
 
     <!-- Add condensed CSS framework -->
     <style>
-        .reflection-tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 2px solid rgba(0, 188, 212, 0.2); padding-bottom: 0.5rem; }
-        .reflection-tab { background: transparent; color: var(--text-dim); border: 2px solid rgba(0, 188, 212, 0.3); padding: 0.5rem 1.25rem; border-radius: 8px 8px 0 0; font-weight: 600; font-size: 0.95rem; cursor: pointer; transition: all 0.3s ease; }
-        .reflection-tab.active { background: linear-gradient(135deg, rgba(0, 188, 212, 0.2), rgba(0, 172, 193, 0.1)); color: var(--pragmatist-cyan); border-color: var(--pragmatist-cyan); }
-        .reflection-panel { display: none; padding: 1.5rem; background: rgba(26, 26, 26, 0.8); border-radius: 0 8px 8px 8px; border: 2px solid rgba(0, 188, 212, 0.2); }
+        .reflection-tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 2px solid rgba(255, 122, 0, 0.15); padding-bottom: 0.5rem; }
+        .reflection-tab { background: transparent; color: var(--text-dim); border: 2px solid rgba(255, 122, 0, 0.25); padding: 0.5rem 1.25rem; border-radius: 8px 8px 0 0; font-weight: 600; font-size: 0.95rem; cursor: pointer; transition: all 0.3s ease; }
+        .reflection-tab.active { background: linear-gradient(135deg, rgba(255, 122, 0, 0.15), rgba(255, 122, 0, 0.06)); color: var(--pragmatist-cyan); border-color: var(--pragmatist-cyan); }
+        .reflection-panel { display: none; padding: 1.5rem; background: rgba(26, 26, 26, 0.8); border-radius: 0 8px 8px 8px; border: 2px solid rgba(255, 122, 0, 0.15); }
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
-        .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: var(--text-light); }
+        .feedback-box.positive { background: rgba(40, 167, 69, 0.08); border-color: #4caf50; color: var(--text-light); }
         .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #ff9800; color: var(--text-light); }
         @media (max-width: 768px) {
             .reflection-tabs { flex-direction: column; }

--- a/paths/pragmatist/stage-2/module-5-security.html
+++ b/paths/pragmatist/stage-2/module-5-security.html
@@ -33,8 +33,9 @@
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">

--- a/paths/pragmatist/stage-2/module-6-lightning.html
+++ b/paths/pragmatist/stage-2/module-6-lightning.html
@@ -125,7 +125,7 @@
                 </tbody>
             </table>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
                 <h3 style="color: var(--pragmatist-cyan); margin-bottom: 1rem;"><span data-icon="target"></span> Decision Framework</h3>
                 <p><strong>Use On-Chain when:</strong></p>
                 <ul style="margin-left: 2rem; color: var(--text-light);">
@@ -150,7 +150,7 @@
             <p>You don't need to understand all the technical details, but here's the concept:</p>
 
             <div style="margin: 2rem 0;">
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">1️⃣</span>
                         <div>
@@ -160,7 +160,7 @@
                     </div>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">2️⃣</span>
                         <div>
@@ -170,7 +170,7 @@
                     </div>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                     <div style="display: flex; align-items: center; gap: 1rem;">
                         <span style="font-size: 2rem;">3️⃣</span>
                         <div>
@@ -195,10 +195,10 @@
 
             <div style="display: grid; gap: 1.5rem; margin: 1.5rem 0;">
                 <!-- Phoenix -->
-                <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem;">
                     <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 1rem;">
                         <h3 style="color: var(--pragmatist-cyan); margin: 0;"><span data-icon="lightning"></span> Phoenix Wallet</h3>
-                        <span style="background: rgba(76, 175, 80, 0.2); color: var(--accent-green); padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.85rem; font-weight: 600;">Recommended</span>
+                        <span style="background: rgba(40, 167, 69, 0.12); color: var(--accent-green); padding: 0.25rem 0.75rem; border-radius: 1rem; font-size: 0.85rem; font-weight: 600;">Recommended</span>
                     </div>
                     <p><strong>Best For:</strong> Most people—simple, reliable, non-custodial</p>
                     <p><strong>Pros:</strong></p>
@@ -258,7 +258,7 @@
                 </div>
             </div>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
                 <h3 style="color: var(--pragmatist-cyan); margin-bottom: 1rem;"><span data-icon="target"></span> Pragmatist Recommendation</h3>
                 <p><strong>Start with Phoenix</strong> if you want control of your keys and don't mind a small setup fee.</p>
                 <p><strong>Start with Wallet of Satoshi</strong> if you want the absolute easiest experience and are outside the US (use small amounts only).</p>
@@ -271,28 +271,28 @@
             <h2><span data-icon="rocket"></span> Quick Setup: Phoenix Wallet (5 Minutes)</h2>
 
             <div style="margin: 2rem 0;">
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">Step 1: Download &amp; Install</strong>
                     <p style="margin: 0.5rem 0 0;">App Store (iOS) or Google Play (Android) → Search "Phoenix Wallet" → Install</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">Step 2: Create Wallet</strong>
                     <p style="margin: 0.5rem 0 0;">Open app → "Create New Wallet" → Phoenix generates your seed phrase</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">Step 3: Back Up Seed Phrase</strong>
                     <p style="margin: 0.5rem 0 0;"><strong>CRITICAL:</strong> Write down all 12 words on paper. Store safely. This is your backup.</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">Step 4: Fund Your Wallet</strong>
                     <p style="margin: 0.5rem 0 0;">Tap "Receive" → Copy your Bitcoin address → Send Bitcoin from your exchange or on-chain wallet</p>
                     <p style="margin: 0.5rem 0 0; color: var(--text-dim); font-size: 0.9rem;"><em>Note: Phoenix automatically opens Lightning channels when you receive. Small one-time fee applies.</em></p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                     <strong style="color: var(--pragmatist-cyan);">Step 5: Make Your First Lightning Payment</strong>
                     <p style="margin: 0.5rem 0 0;">Tap "Send" → Scan Lightning invoice QR code → Confirm → Done in less than 1 second!</p>
                 </div>
@@ -338,7 +338,7 @@
                 <li><strong>Wait for payment</strong> → Notification when it arrives (instant!)</li>
             </ol>
 
-            <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
+            <div style="background: rgba(40, 167, 69, 0.08); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
                 <p style="margin: 0;"><strong><span data-icon="lightning"></span> Pro Tip:</strong> Lightning invoices expire (usually 1 hour). If someone doesn't pay immediately, generate a fresh invoice.</p>
             </div>
         </section>
@@ -348,31 +348,31 @@
             <h2><span data-icon="globe"></span> Real-World Lightning Use Cases</h2>
 
             <div style="display: grid; gap: 1rem; margin: 1.5rem 0;">
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--pragmatist-cyan);">☕ Coffee &amp; Retail</h4>
                     <p style="margin: 0.5rem 0 0;">Hundreds of coffee shops worldwide accept Lightning. Scan, pay, done—faster than credit cards.</p>
                     <p style="margin: 0.5rem 0 0; color: var(--text-dim); font-size: 0.9rem;"><strong>Try it:</strong> Use BTCMap.org to find Lightning-accepting businesses near you</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--pragmatist-cyan);"><span data-icon="chat"></span> Tipping Content Creators</h4>
                     <p style="margin: 0.5rem 0 0;">Support podcasters, writers, artists with instant micropayments (even $0.10 works).</p>
                     <p style="margin: 0.5rem 0 0; color: var(--text-dim); font-size: 0.9rem;"><strong>Platforms:</strong> Fountain (podcasts), Stacker.news (forum), Twitter via Lightning tips</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--pragmatist-cyan);"><span data-icon="network"></span> International Remittances</h4>
                     <p style="margin: 0.5rem 0 0;">Send money globally in seconds for pennies. No banks, no 3-day wait, no $30 wire fees.</p>
                     <p style="margin: 0.5rem 0 0; color: var(--text-dim); font-size: 0.9rem;"><strong>Use case:</strong> Supporting family overseas, paying international freelancers</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--pragmatist-cyan);"><span data-icon="game"></span> Gaming &amp; Services</h4>
                     <p style="margin: 0.5rem 0 0;">Pay for VPN subscriptions, cloud storage, gaming items—all instantly with no chargebacks.</p>
                     <p style="margin: 0.5rem 0 0; color: var(--text-dim); font-size: 0.9rem;"><strong>Examples:</strong> Mullvad VPN, TIDAL music, various gaming platforms</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--pragmatist-cyan);">🤝 Splitting Bills</h4>
                     <p style="margin: 0.5rem 0 0;">Dinner with friends? Send exact amounts instantly—no Venmo, no bank delays, no 3% fees.</p>
                     <p style="margin: 0.5rem 0 0; color: var(--text-dim); font-size: 0.9rem;"><strong>Advantage:</strong> Works internationally, settles instantly, no middleman</p>
@@ -384,7 +384,7 @@
         <section class="content-section">
             <h2><span data-icon="tool"></span> Troubleshooting Common Issues</h2>
 
-            <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+            <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                 <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);">❌ Payment failed: "No route found"</summary>
                 <div style="margin-top: 1rem; color: var(--text-light);">
                     <p><strong>Cause:</strong> Lightning network couldn't find a path from you to recipient</p>
@@ -398,7 +398,7 @@
                 </div>
             </details>
 
-            <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+            <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                 <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);">⚠️ "Insufficient capacity" error</summary>
                 <div style="margin-top: 1rem; color: var(--text-light);">
                     <p><strong>Cause:</strong> You don't have enough Lightning balance in your channels</p>
@@ -411,7 +411,7 @@
                 </div>
             </details>
 
-            <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+            <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                 <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);"><span data-icon="clock"></span> Invoice expired</summary>
                 <div style="margin-top: 1rem; color: var(--text-light);">
                     <p><strong>Cause:</strong> Lightning invoices typically expire after 1 hour</p>
@@ -419,7 +419,7 @@
                 </div>
             </details>
 
-            <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem;">
+            <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem;">
                 <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);"><span data-icon="money"></span> Can't receive payments</summary>
                 <div style="margin-top: 1rem; color: var(--text-light);">
                     <p><strong>Cause:</strong> No inbound capacity in your channels</p>
@@ -437,7 +437,7 @@
         <section class="content-section">
             <h2><span data-icon="target"></span> Lightning Action Checklist</h2>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
                 <div style="display: grid; gap: 1rem;">
                     <label style="display: flex; align-items: center; gap: 1rem; cursor: pointer;">
                         <input type="checkbox" style="width: 20px; height: 20px;">
@@ -470,7 +470,7 @@
                 </div>
             </div>
 
-            <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0; text-align: center;">
+            <div style="background: rgba(40, 167, 69, 0.08); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0; text-align: center;">
                 <p style="font-size: 1.2rem; margin: 0;">
                     <strong><span data-icon="lightning"></span> You're now Lightning-enabled!</strong>
                 </p>

--- a/paths/pragmatist/stage-2/module-6-lightning.html
+++ b/paths/pragmatist/stage-2/module-6-lightning.html
@@ -33,8 +33,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">

--- a/paths/pragmatist/stage-2/module-7-economics.html
+++ b/paths/pragmatist/stage-2/module-7-economics.html
@@ -55,7 +55,7 @@
             <h2><span data-icon="money"></span> Buying Strategy: DCA vs Lump Sum</h2>
 
             <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin: 1.5rem 0;">
-                <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem;">
                     <h3 style="color: var(--pragmatist-cyan);"><span data-icon="clock"></span> Dollar-Cost Averaging (DCA)</h3>
                     <p><strong>What:</strong> Buy fixed amount regularly (e.g., $100/week)</p>
                     <p><strong>Pros:</strong></p>
@@ -178,21 +178,21 @@
             <h2>💎 HODLing vs Spending Strategy</h2>
 
             <div style="display: grid; gap: 1rem; margin: 1.5rem 0;">
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--pragmatist-cyan);">🏦 Layer 1: Long-Term Holdings (70-90%)</h4>
                     <p><strong>Strategy:</strong> Cold storage, don't touch for 4+ years</p>
                     <p><strong>Wallet:</strong> Hardware wallet (Coldcard, Foundation)</p>
                     <p><strong>Mindset:</strong> This is your savings, not spending money</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--pragmatist-cyan);"><span data-icon="lightning"></span> Layer 2: Spending Stack (10-20%)</h4>
                     <p><strong>Strategy:</strong> Lightning wallet, reload monthly</p>
                     <p><strong>Wallet:</strong> Phoenix, Muun</p>
                     <p><strong>Mindset:</strong> This is your cash—spend guilt-free</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--pragmatist-cyan);"><span data-icon="refresh"></span> Layer 3: Exchange Reserve (0-10%)</h4>
                     <p><strong>Strategy:</strong> Keep small amount on exchange for quick buys/sells</p>
                     <p><strong>Use:</strong> Take advantage of dips or cash out if needed</p>
@@ -232,7 +232,7 @@
         <section class="content-section">
             <h2><span data-icon="target"></span> Strategy Action Checklist</h2>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
                 <div style="display: grid; gap: 1rem;">
                     <label style="display: flex; align-items: center; gap: 1rem; cursor: pointer;">
                         <input type="checkbox" style="width: 20px; height: 20px;">

--- a/paths/pragmatist/stage-2/module-7-economics.html
+++ b/paths/pragmatist/stage-2/module-7-economics.html
@@ -30,8 +30,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
         <main id="main-content" class="container">

--- a/paths/pragmatist/stage-3/module-8-privacy-tax.html
+++ b/paths/pragmatist/stage-3/module-8-privacy-tax.html
@@ -30,8 +30,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
         <main id="main-content" class="container">

--- a/paths/pragmatist/stage-3/module-8-privacy-tax.html
+++ b/paths/pragmatist/stage-3/module-8-privacy-tax.html
@@ -78,12 +78,12 @@
             <h2><span data-icon="shield"></span> Basic Privacy Practices (Do These)</h2>
 
             <div style="margin: 1.5rem 0;">
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">1. Never Reuse Addresses</strong>
                     <p style="margin: 0.5rem 0 0;">Generate a new receiving address for every transaction. Modern wallets do this automatically. Reusing addresses links all your transactions together.</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">2. Separate Wallets for Different Uses</strong>
                     <p style="margin: 0.5rem 0 0;">
                         - <strong>KYC wallet:</strong> Bitcoin from exchanges (linked to your identity)<br>
@@ -93,17 +93,17 @@
                     </p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">3. Use Lightning for Spending</strong>
                     <p style="margin: 0.5rem 0 0;">Lightning transactions aren't broadcast to the blockchain—much better privacy for daily spending than on-chain.</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">4. Don't Share Addresses Publicly</strong>
                     <p style="margin: 0.5rem 0 0;">Never post receive addresses on social media, forums, or websites tied to your identity. Use fresh addresses or Lightning invoices instead.</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                     <strong style="color: var(--pragmatist-cyan);">5. Be Careful with Exchange Withdrawals</strong>
                     <p style="margin: 0.5rem 0 0;">Exchanges know your KYC info. When you withdraw, they know which address is yours. That address is now linked to your identity forever. Use it carefully.</p>
                 </div>
@@ -215,7 +215,7 @@
         <section class="content-section">
             <h2><span data-icon="chart"></span> Record-Keeping: What to Track</h2>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0;">
                 <h3 style="color: var(--pragmatist-cyan); margin-bottom: 1rem;">Essential Records:</h3>
                 <ul style="margin-left: 2rem; color: var(--text-light);">
                     <li><strong>Date</strong> of every purchase/sale</li>
@@ -268,27 +268,27 @@
             <h2><span data-icon="lightbulb"></span> Tax Optimization Strategies</h2>
 
             <div style="margin: 1.5rem 0;">
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;">
                     <h4 style="color: var(--pragmatist-cyan);">1. HODL for &gt;1 Year</h4>
                     <p>Long-term capital gains rates are significantly lower than short-term. Patience pays.</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;">
                     <h4 style="color: var(--pragmatist-cyan);">2. Tax-Loss Harvesting</h4>
                     <p>Sell losses to offset gains. If Bitcoin dips, you can sell at a loss, immediately rebuy, and use the loss to offset other capital gains. (Note: wash-sale rules don't apply to crypto in most jurisdictions yet.)</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;">
                     <h4 style="color: var(--pragmatist-cyan);">3. Specific ID Method</h4>
                     <p>If allowed in your jurisdiction, choose to sell your highest cost basis coins first (minimizes gains).</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem; margin-bottom: 1rem;">
                     <h4 style="color: var(--pragmatist-cyan);">4. Gift to Family</h4>
                     <p>Annual gift tax exemptions allow tax-free transfers to spouse/children (check limits for your country). Resets cost basis for them.</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--pragmatist-cyan);">5. Consider Retirement Accounts</h4>
                     <p>Some countries allow Bitcoin in IRAs/retirement accounts (tax-deferred or tax-free growth). Examples: Bitcoin IRA, Unchained Capital IRA.</p>
                 </div>
@@ -299,7 +299,7 @@
         <section class="content-section">
             <h2><span data-icon="target"></span> Privacy &amp; Tax Action Checklist</h2>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
                 <div style="display: grid; gap: 1rem;">
                     <label style="display: flex; align-items: center; gap: 1rem; cursor: pointer;">
                         <input type="checkbox" style="width: 20px; height: 20px;">

--- a/paths/pragmatist/stage-3/module-9-real-life.html
+++ b/paths/pragmatist/stage-3/module-9-real-life.html
@@ -30,8 +30,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
         <main id="main-content" class="container">

--- a/paths/pragmatist/stage-3/module-9-real-life.html
+++ b/paths/pragmatist/stage-3/module-9-real-life.html
@@ -61,21 +61,21 @@
             <h3 style="color: var(--pragmatist-cyan);">The Three-Layer Financial Stack:</h3>
 
             <div style="margin: 1.5rem 0;">
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">Layer 1: Emergency Fiat Fund (3-6 months expenses)</strong>
                     <p style="margin: 0.5rem 0 0;"><strong>Where:</strong> Bank savings, money market<br>
                     <strong>Why:</strong> Instant liquidity for emergencies, no volatility<br>
                     <strong>Action:</strong> Keep this in traditional finance—Bitcoin is too volatile for immediate needs</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem; margin-bottom: 1rem;">
                     <strong style="color: var(--pragmatist-cyan);">Layer 2: Bitcoin Savings (Long-term wealth)</strong>
                     <p style="margin: 0.5rem 0 0;"><strong>Where:</strong> Cold storage wallet<br>
                     <strong>Why:</strong> Hard money, inflation hedge, long-term appreciation<br>
                     <strong>Action:</strong> 5-25% of investment portfolio, HODL for 4+ years</p>
                 </div>
 
-                <div style="background: rgba(0, 188, 212, 0.1); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
+                <div style="background: rgba(255, 122, 0, 0.08); border-left: 4px solid var(--pragmatist-cyan); padding: 1.25rem; border-radius: 0.5rem;">
                     <strong style="color: var(--pragmatist-cyan);">Layer 3: Lightning Spending (Daily transactions)</strong>
                     <p style="margin: 0.5rem 0 0;"><strong>Where:</strong> Phoenix/Muun wallet<br>
                     <strong>Why:</strong> Instant, cheap, private payments<br>
@@ -89,7 +89,7 @@
             <h2>💎 Using Bitcoin as Savings</h2>
 
             <div style="display: grid; gap: 1rem; margin: 1.5rem 0;">
-                <div style="background: rgba(76, 175, 80, 0.1); border: 1px solid var(--accent-green); border-radius: 0.75rem; padding: 1.25rem;">
+                <div style="background: rgba(40, 167, 69, 0.08); border: 1px solid var(--accent-green); border-radius: 0.75rem; padding: 1.25rem;">
                     <h4 style="color: var(--accent-green);">✅ Bitcoin is Great For:</h4>
                     <ul style="margin-left: 1.5rem;">
                         <li>Long-term savings (4+ year horizon)</li>
@@ -201,7 +201,7 @@
             <h2><span data-icon="alert"></span> Emergency &amp; Crisis Scenarios</h2>
 
             <div style="margin: 1.5rem 0;">
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);">💥 Exchange Goes Bankrupt (FTX, Mt. Gox, Celsius...)</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p><strong>Prevention:</strong> Never hold large amounts on exchanges. Withdraw to self-custody regularly.</p>
@@ -216,7 +216,7 @@
                     </div>
                 </details>
 
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);">🔥 Lost Seed Phrase / Forgotten Wallet</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p><strong>Reality:</strong> Without seed phrase, Bitcoin is unrecoverable. Period.</p>
@@ -230,7 +230,7 @@
                     </div>
                 </details>
 
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);"><span data-icon="institution"></span> Government Restricts Bitcoin</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p><strong>Options:</strong></p>
@@ -244,7 +244,7 @@
                     </div>
                 </details>
 
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem; margin-bottom: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);">💀 Inheritance Planning</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p><strong>Problem:</strong> If you die, can your family access your Bitcoin?</p>
@@ -258,7 +258,7 @@
                     </div>
                 </details>
 
-                <details style="background: rgba(0, 188, 212, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem;">
+                <details style="background: rgba(255, 122, 0, 0.05); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1rem;">
                     <summary style="cursor: pointer; font-weight: 600; color: var(--pragmatist-cyan);"><span data-icon="network"></span> Internet Outage / Censorship</summary>
                     <div style="margin-top: 1rem; color: var(--text-light);">
                         <p><strong>Bitcoin continues to run</strong> even if your local internet is down.</p>
@@ -305,7 +305,7 @@
         <section class="content-section">
             <h2><span data-icon="target"></span> Real-Life Integration Checklist</h2>
 
-            <div style="background: rgba(0, 188, 212, 0.1); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
+            <div style="background: rgba(255, 122, 0, 0.08); border: 2px solid var(--pragmatist-cyan); border-radius: 1rem; padding: 2rem; margin: 1.5rem 0;">
                 <div style="display: grid; gap: 1rem;">
                     <label style="display: flex; align-items: center; gap: 1rem; cursor: pointer;">
                         <input type="checkbox" style="width: 20px; height: 20px;">
@@ -338,7 +338,7 @@
                 </div>
             </div>
 
-            <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0; text-align: center;">
+            <div style="background: rgba(40, 167, 69, 0.08); border: 2px solid var(--accent-green); border-radius: 1rem; padding: 1.5rem; margin: 1.5rem 0; text-align: center;">
                 <p style="font-size: 1.3rem; margin: 0;">
                     <strong>🎉 Congratulations, Pragmatist!</strong>
                 </p>

--- a/paths/principled/capstone/index.html
+++ b/paths/principled/capstone/index.html
@@ -44,9 +44,7 @@
         .hero-icon { font-size: 5rem; margin-bottom: 1rem; }
         .hero-section h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .hero-subtitle {
@@ -173,8 +171,8 @@
         }
         .cta-button {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 1.25rem 2.5rem;
             border-radius: 2rem;
             text-decoration: none;
@@ -185,7 +183,7 @@
         }
         .cta-button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(31, 32, 36, 0.5);
+            box-shadow: 0 8px 24px rgba(255, 122, 0, 0.4);
         }
         @media (max-width: 768px) {
             .hero-section h1 { font-size: 2rem; }

--- a/paths/principled/capstone/index.html
+++ b/paths/principled/capstone/index.html
@@ -212,8 +212,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/" class="back-btn">← Back to Principled Path</a>

--- a/paths/principled/index.html
+++ b/paths/principled/index.html
@@ -80,7 +80,7 @@
 
         .hero h1 {
             font-size: 3rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
+            background: linear-gradient(135deg, #FF7A00, #FFD400);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -348,8 +348,8 @@
             align-items: center;
             gap: 0.5rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             border-radius: 0.5rem;
             font-weight: 600;
@@ -360,7 +360,7 @@
 
         .stage-cta:hover {
             transform: translateY(-2px);
-            box-shadow: 0 5px 20px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 5px 20px rgba(255, 122, 0, 0.4);
         }
 
         .stage-cta.locked {

--- a/paths/principled/index.html
+++ b/paths/principled/index.html
@@ -515,8 +515,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Back Button -->

--- a/paths/principled/stage-1/index.html
+++ b/paths/principled/stage-1/index.html
@@ -63,9 +63,7 @@
 
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
 
@@ -126,8 +124,8 @@
 
         .module-cta {
             display: inline-block;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             text-decoration: none;

--- a/paths/principled/stage-1/index.html
+++ b/paths/principled/stage-1/index.html
@@ -176,8 +176,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/" class="back-btn">← Back to Path Overview</a>

--- a/paths/principled/stage-1/module-1.html
+++ b/paths/principled/stage-1/module-1.html
@@ -196,21 +196,22 @@
 
         .meter-fill {
             height: 100%;
-            background: linear-gradient(90deg, var(--accent-bronze), var(--accent-bronze-light));
+            background: linear-gradient(90deg, #FF7A00, #FFD400);
             transition: width 0.5s ease;
             display: flex;
             align-items: center;
             justify-content: center;
-            color: #fff;
+            color: #101010;
             font-weight: 700;
         }
 
         .meter-fill.production {
             background: linear-gradient(90deg, #4caf50, #8bc34a);
+            color: #101010;
         }
 
         .meter-fill.currency {
-            background: linear-gradient(90deg, var(--accent-bronze), var(--accent-bronze-light));
+            background: linear-gradient(90deg, #FF7A00, #FFD400);
         }
 
         .demo-controls {
@@ -244,14 +245,14 @@
             width: 20px;
             height: 20px;
             border-radius: 50%;
-            background: var(--accent-bronze);
+            background: #FF7A00;
             cursor: pointer;
         }
 
         .demo-button {
             padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             border-radius: 0.5rem;
             font-weight: 700;
@@ -262,11 +263,13 @@
 
         .demo-button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 5px 20px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 5px 20px rgba(255, 122, 0, 0.4);
         }
 
         .demo-button.danger {
-            background: linear-gradient(135deg, #ef4444, #dc2626);
+            background: #2D2D2D;
+            color: #dc3545;
+            border: 2px solid #dc3545;
         }
 
         .demo-output {
@@ -370,8 +373,8 @@
             align-items: center;
             gap: 0.5rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border-radius: 0.5rem;
             text-decoration: none;
             font-weight: 600;
@@ -404,11 +407,11 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .choice-select:focus { outline: none; border-color: var(--accent-bronze); }
-        .feedback-btn { background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze)); color: white; padding: 0.75rem 1.5rem; border: none; border-radius: 0.5rem; font-weight: 600; cursor: pointer; margin-top: 1rem; transition: all 0.3s ease; }
-        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(31, 32, 36, 0.4); }
+        .feedback-btn { background: #FF7A00; color: #101010; padding: 0.75rem 1.5rem; border: none; border-radius: 0.5rem; font-weight: 600; cursor: pointer; margin-top: 1rem; transition: all 0.3s ease; }
+        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(255, 122, 0, 0.4); }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
         .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: var(--text-light); }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #1F2024; color: var(--text-light); }
+        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #f59e0b; color: var(--text-light); }
         .feedback-box h5 { margin-top: 0; margin-bottom: 0.5rem; color: inherit; }
         .checklist-reflection { display: flex; flex-direction: column; gap: 0.75rem; }
         .checkbox-label { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; background: rgba(0, 0, 0, 0.3); border-radius: 0.5rem; cursor: pointer; transition: background 0.2s ease; }
@@ -430,8 +433,8 @@
         .draggable-item:hover { background: rgba(31, 32, 36, 0.1); border-color: var(--accent-bronze); transform: translateY(-2px); }
         .draggable-item.dragging { opacity: 0.5; transform: rotate(3deg); }
         .draggable-item strong { color: var(--accent-bronze); }
-        .check-answer-btn { width: 100%; padding: 1rem; background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze)); color: white; border: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.1rem; cursor: pointer; margin-top: 1.5rem; transition: all 0.3s ease; }
-        .check-answer-btn:hover { transform: translateY(-2px); box-shadow: 0 5px 20px rgba(31, 32, 36, 0.4); }
+        .check-answer-btn { width: 100%; padding: 1rem; background: #FF7A00; color: #101010; border: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.1rem; cursor: pointer; margin-top: 1.5rem; transition: all 0.3s ease; }
+        .check-answer-btn:hover { transform: translateY(-2px); box-shadow: 0 5px 20px rgba(255, 122, 0, 0.4); }
         .check-answer-btn:disabled { background: var(--secondary-dark); border: 2px solid var(--border-color); color: var(--text-dim); cursor: not-allowed; transform: none; }
 
         /* Responsive */

--- a/paths/principled/stage-1/module-1.html
+++ b/paths/principled/stage-1/module-1.html
@@ -533,8 +533,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Navigation -->

--- a/paths/principled/stage-1/module-2.html
+++ b/paths/principled/stage-1/module-2.html
@@ -218,7 +218,7 @@
         }
 
         .integrity-fill.degraded {
-            background: linear-gradient(90deg, #ffaa00, #1F2024);
+            background: linear-gradient(90deg, #FF7A00, #f59e0b);
         }
 
         .integrity-fill.corrupted {
@@ -255,8 +255,8 @@
 
         .demo-button {
             padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             border-radius: 0.5rem;
             font-weight: 700;
@@ -378,8 +378,8 @@
             align-items: center;
             gap: 0.5rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border-radius: 0.5rem;
             text-decoration: none;
             font-weight: 600;
@@ -404,11 +404,11 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .choice-select:focus { outline: none; border-color: var(--accent-bronze); }
-        .feedback-btn { background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze)); color: white; padding: 0.75rem 1.5rem; border: none; border-radius: 0.5rem; font-weight: 600; cursor: pointer; margin-top: 1rem; transition: all 0.3s ease; }
+        .feedback-btn { background: #FF7A00; color: #101010; padding: 0.75rem 1.5rem; border: none; border-radius: 0.5rem; font-weight: 600; cursor: pointer; margin-top: 1rem; transition: all 0.3s ease; }
         .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(31, 32, 36, 0.4); }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
         .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: var(--text-light); }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #1F2024; color: var(--text-light); }
+        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #f59e0b; color: var(--text-light); }
         .feedback-box h5 { margin-top: 0; margin-bottom: 0.5rem; color: inherit; }
         .checklist-reflection { display: flex; flex-direction: column; gap: 0.75rem; }
         .checkbox-label { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; background: rgba(0, 0, 0, 0.3); border-radius: 0.5rem; cursor: pointer; transition: background 0.2s ease; }

--- a/paths/principled/stage-1/module-2.html
+++ b/paths/principled/stage-1/module-2.html
@@ -511,8 +511,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Navigation -->

--- a/paths/principled/stage-1/module-3.html
+++ b/paths/principled/stage-1/module-3.html
@@ -279,8 +279,8 @@
 
         .demo-button {
             padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             border-radius: 0.5rem;
             font-weight: 700;
@@ -291,21 +291,25 @@
 
         .demo-button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 5px 20px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 5px 20px rgba(255, 122, 0, 0.4);
         }
 
         .demo-button.danger {
-            background: linear-gradient(135deg, #ef4444, #dc2626);
+            background: #2D2D2D;
+            color: #dc3545;
+            border: 2px solid #dc3545;
         }
 
         .demo-button.success {
-            background: linear-gradient(135deg, var(--accent-green), #8bc34a);
+            background: #2D2D2D;
+            color: #28a745;
+            border: 2px solid #28a745;
         }
 
         .demo-button.secondary {
             background: rgba(31, 32, 36, 0.2);
-            border: 2px solid var(--accent-bronze);
-            color: var(--accent-bronze);
+            border: 2px solid #FF7A00;
+            color: #FF7A00;
         }
 
         .demo-output {
@@ -404,8 +408,8 @@
             align-items: center;
             gap: 0.5rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border-radius: 0.5rem;
             text-decoration: none;
             font-weight: 600;
@@ -414,7 +418,7 @@
 
         .nav-link:hover {
             transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 5px 15px rgba(255, 122, 0, 0.4);
         }
 
         .progress-indicator {
@@ -430,11 +434,11 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .choice-select:focus { outline: none; border-color: var(--accent-bronze); }
-        .feedback-btn { background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze)); color: white; padding: 0.75rem 1.5rem; border: none; border-radius: 0.5rem; font-weight: 600; cursor: pointer; margin-top: 1rem; transition: all 0.3s ease; }
-        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(31, 32, 36, 0.4); }
+        .feedback-btn { background: #FF7A00; color: #101010; padding: 0.75rem 1.5rem; border: none; border-radius: 0.5rem; font-weight: 600; cursor: pointer; margin-top: 1rem; transition: all 0.3s ease; }
+        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(255, 122, 0, 0.4); }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
         .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: var(--text-light); }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #1F2024; color: var(--text-light); }
+        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #f59e0b; color: var(--text-light); }
         .feedback-box h5 { margin-top: 0; margin-bottom: 0.5rem; color: inherit; }
         .checklist-reflection { display: flex; flex-direction: column; gap: 0.75rem; }
         .checkbox-label { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; background: rgba(0, 0, 0, 0.3); border-radius: 0.5rem; cursor: pointer; transition: background 0.2s ease; }

--- a/paths/principled/stage-1/module-3.html
+++ b/paths/principled/stage-1/module-3.html
@@ -537,8 +537,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Navigation -->

--- a/paths/principled/stage-2/index.html
+++ b/paths/principled/stage-2/index.html
@@ -170,8 +170,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/" class="back-btn">← Back to Path Overview</a>

--- a/paths/principled/stage-2/index.html
+++ b/paths/principled/stage-2/index.html
@@ -30,8 +30,8 @@
 
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -62,9 +62,7 @@
 
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
 
@@ -125,8 +123,8 @@
 
         .module-cta {
             display: inline-block;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             text-decoration: none;

--- a/paths/principled/stage-2/module-1.html
+++ b/paths/principled/stage-2/module-1.html
@@ -564,8 +564,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Navigation -->

--- a/paths/principled/stage-2/module-1.html
+++ b/paths/principled/stage-2/module-1.html
@@ -218,9 +218,9 @@
 
         .choice-button {
             padding: 1.5rem;
-            background: linear-gradient(135deg, var(--accent-green), #8bc34a);
-            color: white;
-            border: none;
+            background: #2D2D2D;
+            color: #28a745;
+            border: 2px solid #28a745;
             border-radius: 0.75rem;
             font-weight: 700;
             font-size: 1.2rem;
@@ -234,7 +234,9 @@
         }
 
         .choice-button.betray {
-            background: linear-gradient(135deg, #ef4444, #dc2626);
+            background: #2D2D2D;
+            color: #dc3545;
+            border: 2px solid #dc3545;
         }
 
         .choice-button.betray:hover {
@@ -324,8 +326,8 @@
 
         .demo-button {
             padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             border-radius: 0.5rem;
             font-weight: 700;
@@ -336,7 +338,7 @@
 
         .demo-button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 5px 20px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 5px 20px rgba(255, 122, 0, 0.4);
         }
 
         .demo-button.secondary {
@@ -431,8 +433,8 @@
             align-items: center;
             gap: 0.5rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border-radius: 0.5rem;
             text-decoration: none;
             font-weight: 600;
@@ -459,7 +461,7 @@
         .choice-select:focus { outline: none; border-color: var(--accent-bronze); }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
         .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: var(--text-light); }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #1F2024; color: var(--text-light); }
+        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #f59e0b; color: var(--text-light); }
         .feedback-box h5 { margin-top: 0; margin-bottom: 0.5rem; color: inherit; }
         .checklist-reflection { display: flex; flex-direction: column; gap: 0.75rem; }
         .checkbox-label { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; background: rgba(0, 0, 0, 0.3); border-radius: 0.5rem; cursor: pointer; transition: background 0.2s ease; }

--- a/paths/principled/stage-2/module-2.html
+++ b/paths/principled/stage-2/module-2.html
@@ -514,8 +514,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Navigation -->

--- a/paths/principled/stage-2/module-2.html
+++ b/paths/principled/stage-2/module-2.html
@@ -273,8 +273,8 @@
 
         .demo-button {
             padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             border-radius: 0.5rem;
             font-weight: 700;
@@ -285,11 +285,13 @@
 
         .demo-button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 5px 20px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 5px 20px rgba(255, 122, 0, 0.4);
         }
 
         .demo-button.danger {
-            background: linear-gradient(135deg, #ef4444, #dc2626);
+            background: #2D2D2D;
+            color: #dc3545;
+            border: 2px solid #dc3545;
         }
 
         .demo-button.secondary {
@@ -384,8 +386,8 @@
             align-items: center;
             gap: 0.5rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border-radius: 0.5rem;
             text-decoration: none;
             font-weight: 600;
@@ -394,7 +396,7 @@
 
         .nav-link:hover {
             transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 5px 15px rgba(255, 122, 0, 0.4);
         }
 
         .progress-indicator {
@@ -412,7 +414,7 @@
         .choice-select:focus { outline: none; border-color: var(--accent-bronze); }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
         .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: var(--text-light); }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #1F2024; color: var(--text-light); }
+        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #f59e0b; color: var(--text-light); }
         .feedback-box h5 { margin-top: 0; margin-bottom: 0.5rem; color: inherit; }
         .checklist-reflection { display: flex; flex-direction: column; gap: 0.75rem; }
         .checkbox-label { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; background: rgba(0, 0, 0, 0.3); border-radius: 0.5rem; cursor: pointer; transition: background 0.2s ease; }

--- a/paths/principled/stage-2/module-3.html
+++ b/paths/principled/stage-2/module-3.html
@@ -561,8 +561,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Breadcrumb Navigation -->

--- a/paths/principled/stage-2/module-3.html
+++ b/paths/principled/stage-2/module-3.html
@@ -86,9 +86,7 @@
 
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
 
@@ -332,25 +330,27 @@
         }
 
         .demo-btn.surveillance {
-            background: var(--danger-red);
-            color: white;
+            background: #2D2D2D;
+            color: #dc3545;
+            border: 2px solid #dc3545;
         }
 
         .demo-btn.surveillance:hover {
-            background: #c0392b;
+            background: rgba(220, 53, 69, 0.15);
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(231, 76, 60, 0.4);
+            box-shadow: 0 4px 12px rgba(220, 53, 69, 0.3);
         }
 
         .demo-btn.transparency {
-            background: var(--success-green);
-            color: white;
+            background: #2D2D2D;
+            color: #28a745;
+            border: 2px solid #28a745;
         }
 
         .demo-btn.transparency:hover {
-            background: #27ae60;
+            background: rgba(40, 167, 69, 0.15);
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(46, 204, 113, 0.4);
+            box-shadow: 0 4px 12px rgba(40, 167, 69, 0.3);
         }
 
         /* Comparison Table */
@@ -450,8 +450,8 @@
         }
 
         .nav-btn-primary {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
+            background: #FF7A00;
+            color: #101010;
         }
 
         .nav-btn-primary:hover {

--- a/paths/principled/stage-3/index.html
+++ b/paths/principled/stage-3/index.html
@@ -22,8 +22,8 @@
         .container { max-width: 900px; margin: 0 auto; }
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -43,9 +43,7 @@
         .stage-number { font-size: 4rem; color: var(--accent-bronze); margin-bottom: 1rem; }
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .stage-description { font-size: 1.2rem; color: var(--text-dim); max-width: 700px; margin: 0 auto; }
@@ -69,15 +67,15 @@
         .module-description { color: var(--text-dim); margin-bottom: 1.5rem; line-height: 1.8; }
         .module-cta {
             display: inline-block;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             text-decoration: none;
             font-weight: 700;
             transition: all 0.3s ease;
         }
-        .module-cta:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(31, 32, 36, 0.4); }
+        .module-cta:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(255, 122, 0, 0.4); }
     </style>
     <link rel="stylesheet" href="/css/icons.css">
 <meta name="description" content="Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here."><link rel="canonical" href="https://bitcoinsovereign.academy/"><meta property="og:title" content="Bitcoin Sovereign Academy"><meta property="og:description" content="Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/"><meta property="og:type" content="website"><script type="application/ld+json">{

--- a/paths/principled/stage-3/index.html
+++ b/paths/principled/stage-3/index.html
@@ -99,8 +99,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/" class="back-btn">← Back to Path Overview</a>

--- a/paths/principled/stage-3/module-1.html
+++ b/paths/principled/stage-3/module-1.html
@@ -85,9 +85,7 @@
 
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
 
@@ -258,8 +256,8 @@
 
         .demo-button {
             padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             border-radius: 8px;
             font-weight: 600;
@@ -269,7 +267,7 @@
 
         .demo-button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
 
         .demo-output {
@@ -419,8 +417,8 @@
         }
 
         .feedback-btn {
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             padding: 0.75rem 1.5rem;
             border-radius: 8px;
@@ -431,7 +429,7 @@
 
         .feedback-btn:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
 
         .feedback-box {
@@ -589,13 +587,13 @@
         }
 
         .nav-btn-primary {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
+            background: #FF7A00;
+            color: #101010;
         }
 
         .nav-btn-primary:hover {
             transform: translateY(-2px);
-            box-shadow: 0 6px 16px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 6px 16px rgba(255, 122, 0, 0.4);
         }
 
         .nav-btn-secondary {

--- a/paths/principled/stage-3/module-1.html
+++ b/paths/principled/stage-3/module-1.html
@@ -642,8 +642,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Breadcrumb Navigation -->

--- a/paths/principled/stage-3/module-2.html
+++ b/paths/principled/stage-3/module-2.html
@@ -22,8 +22,8 @@
         .container { max-width: 900px; margin: 0 auto; }
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -43,9 +43,7 @@
         .module-icon { font-size: 4rem; margin-bottom: 1rem; }
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .module-subtitle { font-size: 1.2rem; color: var(--text-dim); max-width: 700px; margin: 0 auto; }
@@ -128,9 +126,9 @@
             color: var(--text-light);
         }
         .demo-tab.active {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
-            border-color: var(--accent-bronze);
+            background: #FF7A00;
+            color: #101010;
+            border-color: #FF7A00;
         }
         .demo-panel {
             display: none;
@@ -150,7 +148,7 @@
             top: 0;
             bottom: 0;
             width: 2px;
-            background: linear-gradient(180deg, var(--accent-bronze), var(--accent-bronze-light));
+            background: linear-gradient(180deg, #FF7A00, #FFD400);
         }
         .timeline-item {
             position: relative;
@@ -167,7 +165,7 @@
             top: 1.5rem;
             width: 1rem;
             height: 1rem;
-            background: var(--accent-bronze);
+            background: #FF7A00;
             border-radius: 50%;
             border: 3px solid var(--primary-dark);
         }
@@ -244,8 +242,8 @@
             flex-wrap: wrap;
         }
         button {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
@@ -255,7 +253,7 @@
         }
         button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         button:disabled {
             opacity: 0.5;
@@ -365,8 +363,8 @@
             border-color: var(--accent-bronze);
         }
         .feedback-btn {
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             padding: 0.75rem 1.5rem;
             border-radius: 8px;
@@ -376,7 +374,7 @@
         }
         .feedback-btn:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         .feedback-box {
             background: rgba(45, 45, 45, 0.8);
@@ -502,8 +500,8 @@
         }
         .next-module a {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 1.25rem 2.5rem;
             border-radius: 2rem;
             text-decoration: none;
@@ -513,7 +511,7 @@
         }
         .next-module a:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(31, 32, 36, 0.5);
+            box-shadow: 0 8px 24px rgba(255, 122, 0, 0.4);
         }
         @media (max-width: 768px) {
             .module-header h1 { font-size: 2rem; }

--- a/paths/principled/stage-3/module-2.html
+++ b/paths/principled/stage-3/module-2.html
@@ -546,8 +546,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/stage-3/" class="back-btn">← Back to Stage 3</a>

--- a/paths/principled/stage-3/module-3.html
+++ b/paths/principled/stage-3/module-3.html
@@ -516,8 +516,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/stage-3/" class="back-btn">← Back to Stage 3</a>

--- a/paths/principled/stage-3/module-3.html
+++ b/paths/principled/stage-3/module-3.html
@@ -22,8 +22,8 @@
         .container { max-width: 900px; margin: 0 auto; }
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -43,9 +43,7 @@
         .module-icon { font-size: 4rem; margin-bottom: 1rem; }
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .module-subtitle { font-size: 1.2rem; color: var(--text-dim); max-width: 700px; margin: 0 auto; }
@@ -128,9 +126,9 @@
             color: var(--text-light);
         }
         .demo-tab.active {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
-            border-color: var(--accent-bronze);
+            background: #FF7A00;
+            color: #101010;
+            border-color: #FF7A00;
         }
         .demo-panel {
             display: none;
@@ -189,19 +187,19 @@
         }
         .energy-fill {
             height: 100%;
-            background: linear-gradient(90deg, var(--accent-bronze), var(--accent-bronze-light));
+            background: linear-gradient(90deg, #FF7A00, #FFD400);
             transition: width 0.5s ease;
             display: flex;
             align-items: center;
             justify-content: flex-end;
             padding-right: 1rem;
-            color: white;
+            color: #101010;
             font-weight: 600;
             font-size: 0.9rem;
         }
         button {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
@@ -211,7 +209,7 @@
         }
         button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         button:disabled {
             opacity: 0.5;
@@ -281,8 +279,8 @@
         }
         .next-module a {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 1.25rem 2.5rem;
             border-radius: 2rem;
             text-decoration: none;
@@ -292,7 +290,7 @@
         }
         .next-module a:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(31, 32, 36, 0.5);
+            box-shadow: 0 8px 24px rgba(255, 122, 0, 0.4);
         }
         /* Interactive Reflection Styles */
         .reflection-tabs {
@@ -350,8 +348,8 @@
             border-color: var(--accent-bronze);
         }
         .feedback-btn {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             border: none;
@@ -362,7 +360,7 @@
         }
         .feedback-btn:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         .feedback-box {
             margin-top: 1.5rem;
@@ -380,7 +378,7 @@
         }
         .feedback-box.hint {
             background: rgba(255, 152, 0, 0.1);
-            border-color: #1F2024;
+            border-color: #f59e0b;
         }
         .feedback-box.hint h5 {
             color: #1F2024;

--- a/paths/principled/stage-4/index.html
+++ b/paths/principled/stage-4/index.html
@@ -22,8 +22,8 @@
         .container { max-width: 900px; margin: 0 auto; }
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -43,9 +43,7 @@
         .stage-number { font-size: 4rem; color: var(--accent-bronze); margin-bottom: 1rem; }
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .stage-description { font-size: 1.2rem; color: var(--text-dim); max-width: 700px; margin: 0 auto; }
@@ -69,15 +67,15 @@
         .module-description { color: var(--text-dim); margin-bottom: 1.5rem; line-height: 1.8; }
         .module-cta {
             display: inline-block;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             text-decoration: none;
             font-weight: 700;
             transition: all 0.3s ease;
         }
-        .module-cta:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(31, 32, 36, 0.4); }
+        .module-cta:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(255, 122, 0, 0.4); }
     </style>
     <link rel="stylesheet" href="/css/icons.css">
 <meta name="description" content="Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here."><link rel="canonical" href="https://bitcoinsovereign.academy/"><meta property="og:title" content="Bitcoin Sovereign Academy"><meta property="og:description" content="Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/"><meta property="og:type" content="website"><script type="application/ld+json">{

--- a/paths/principled/stage-4/index.html
+++ b/paths/principled/stage-4/index.html
@@ -99,8 +99,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/" class="back-btn">← Back to Path Overview</a>

--- a/paths/principled/stage-4/module-1.html
+++ b/paths/principled/stage-4/module-1.html
@@ -486,8 +486,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/stage-4/" class="back-btn">← Back to Stage 4</a>

--- a/paths/principled/stage-4/module-1.html
+++ b/paths/principled/stage-4/module-1.html
@@ -22,8 +22,8 @@
         .container { max-width: 900px; margin: 0 auto; }
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -43,9 +43,7 @@
         .module-icon { font-size: 4rem; margin-bottom: 1rem; }
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .module-subtitle { font-size: 1.2rem; color: var(--text-dim); max-width: 700px; margin: 0 auto; }
@@ -167,8 +165,8 @@
             font-size: 0.9rem;
         }
         button {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
@@ -178,7 +176,7 @@
         }
         button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         .entropy-visualizer {
             background: var(--secondary-dark);
@@ -204,7 +202,7 @@
             transition: all 0.5s ease;
         }
         .entropy-block.ordered {
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
+            background: linear-gradient(135deg, #FF7A00, #FFD400);
         }
         .reflection-section {
             background: linear-gradient(135deg, rgba(31, 32, 36, 0.1), rgba(31, 32, 36, 0.05));
@@ -252,8 +250,8 @@
         }
         .next-module a {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 1.25rem 2.5rem;
             border-radius: 2rem;
             text-decoration: none;
@@ -263,7 +261,7 @@
         }
         .next-module a:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(31, 32, 36, 0.5);
+            box-shadow: 0 8px 24px rgba(255, 122, 0, 0.4);
         }
         /* Interactive Reflection Styles */
         .reflection-tabs {
@@ -321,8 +319,8 @@
             border-color: var(--accent-bronze);
         }
         .feedback-btn {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             border: none;
@@ -333,7 +331,7 @@
         }
         .feedback-btn:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         .feedback-box {
             margin-top: 1.5rem;
@@ -351,10 +349,10 @@
         }
         .feedback-box.hint {
             background: rgba(255, 152, 0, 0.1);
-            border-color: #1F2024;
+            border-color: #f59e0b;
         }
         .feedback-box.hint h5 {
-            color: #1F2024;
+            color: #f59e0b;
             margin-bottom: 0.5rem;
         }
         .feedback-box.neutral {

--- a/paths/principled/stage-4/module-2.html
+++ b/paths/principled/stage-4/module-2.html
@@ -22,8 +22,8 @@
         .container { max-width: 900px; margin: 0 auto; }
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -43,9 +43,7 @@
         .module-icon { font-size: 4rem; margin-bottom: 1rem; }
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .module-subtitle { font-size: 1.2rem; color: var(--text-dim); max-width: 700px; margin: 0 auto; }
@@ -163,9 +161,9 @@
             color: var(--text-light);
         }
         .demo-tab.active {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
-            border-color: var(--accent-bronze);
+            background: #FF7A00;
+            color: #101010;
+            border-color: #FF7A00;
         }
         .demo-panel {
             display: none;
@@ -202,8 +200,8 @@
             margin: 0.5rem 0;
         }
         button {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
@@ -213,7 +211,7 @@
         }
         button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         button:disabled {
             opacity: 0.5;
@@ -291,8 +289,8 @@
         }
         .next-module a {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 1.25rem 2.5rem;
             border-radius: 2rem;
             text-decoration: none;
@@ -360,8 +358,8 @@
             border-color: var(--accent-bronze);
         }
         .feedback-btn {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             border: none;
@@ -372,7 +370,7 @@
         }
         .feedback-btn:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         .feedback-box {
             margin-top: 1.5rem;
@@ -390,10 +388,10 @@
         }
         .feedback-box.hint {
             background: rgba(255, 152, 0, 0.1);
-            border-color: #1F2024;
+            border-color: #f59e0b;
         }
         .feedback-box.hint h5 {
-            color: #1F2024;
+            color: #f59e0b;
             margin-bottom: 0.5rem;
         }
         .feedback-box.neutral {

--- a/paths/principled/stage-4/module-2.html
+++ b/paths/principled/stage-4/module-2.html
@@ -527,8 +527,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/stage-4/" class="back-btn">← Back to Stage 4</a>

--- a/paths/principled/stage-4/module-3.html
+++ b/paths/principled/stage-4/module-3.html
@@ -518,8 +518,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/stage-4/" class="back-btn">← Back to Stage 4</a>

--- a/paths/principled/stage-4/module-3.html
+++ b/paths/principled/stage-4/module-3.html
@@ -22,8 +22,8 @@
         .container { max-width: 900px; margin: 0 auto; }
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -43,9 +43,7 @@
         .module-icon { font-size: 4rem; margin-bottom: 1rem; }
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .module-subtitle { font-size: 1.2rem; color: var(--text-dim); max-width: 700px; margin: 0 auto; }
@@ -160,9 +158,9 @@
             color: var(--text-light);
         }
         .demo-tab.active {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
-            border-color: var(--accent-bronze);
+            background: #FF7A00;
+            color: #101010;
+            border-color: #FF7A00;
         }
         .demo-panel {
             display: none;
@@ -203,8 +201,8 @@
             border: 1px solid rgba(31, 32, 36, 0.3);
         }
         button {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
@@ -214,7 +212,7 @@
         }
         button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         .health-meter {
             margin: 2rem 0;
@@ -228,13 +226,13 @@
         }
         .health-fill {
             height: 100%;
-            background: linear-gradient(90deg, var(--accent-bronze), var(--accent-bronze-light));
+            background: linear-gradient(90deg, #FF7A00, #FFD400);
             transition: width 0.5s ease;
             display: flex;
             align-items: center;
             justify-content: flex-end;
             padding-right: 1rem;
-            color: white;
+            color: #101010;
             font-weight: 600;
         }
         .reflection-section {
@@ -283,8 +281,8 @@
         }
         .next-module a {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 1.25rem 2.5rem;
             border-radius: 2rem;
             text-decoration: none;
@@ -294,7 +292,7 @@
         }
         .next-module a:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(31, 32, 36, 0.5);
+            box-shadow: 0 8px 24px rgba(255, 122, 0, 0.4);
         }
         /* Interactive Reflection Styles */
         .reflection-tabs {
@@ -352,8 +350,8 @@
             border-color: var(--accent-bronze);
         }
         .feedback-btn {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             border: none;
@@ -364,7 +362,7 @@
         }
         .feedback-btn:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         .feedback-box {
             margin-top: 1.5rem;
@@ -382,10 +380,10 @@
         }
         .feedback-box.hint {
             background: rgba(255, 152, 0, 0.1);
-            border-color: #1F2024;
+            border-color: #f59e0b;
         }
         .feedback-box.hint h5 {
-            color: #1F2024;
+            color: #f59e0b;
             margin-bottom: 0.5rem;
         }
         .feedback-box.neutral {

--- a/paths/principled/stage-5/index.html
+++ b/paths/principled/stage-5/index.html
@@ -145,8 +145,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/" class="back-btn">← Back to Path Overview</a>
@@ -242,9 +243,9 @@
                         <h4 style="color: #2196F3; margin: 1rem 0;">Builder Path</h4>
                         <p style="color: var(--text-dim); font-size: 0.9rem;">Build Bitcoin applications</p>
                     </a>
-                    <a href="/paths/sovereign/" class="next-path-card" style="border-color: #9C27B0;">
+                    <a href="/paths/sovereign/" class="next-path-card" style="border-color: #FF7A00;">
                         <div style="font-size: 3rem;">👑</div>
-                        <h4 style="color: #9C27B0; margin: 1rem 0;">Sovereign Path</h4>
+                        <h4 style="color: #FF7A00; margin: 1rem 0;">Sovereign Path</h4>
                         <p style="color: var(--text-dim); font-size: 0.9rem;">Master self-custody &amp; security</p>
                     </a>
                 </div>

--- a/paths/principled/stage-5/index.html
+++ b/paths/principled/stage-5/index.html
@@ -22,8 +22,8 @@
         .container { max-width: 900px; margin: 0 auto; }
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -43,9 +43,7 @@
         .stage-number { font-size: 4rem; color: var(--accent-bronze); margin-bottom: 1rem; }
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .stage-description { font-size: 1.2rem; color: var(--text-dim); max-width: 700px; margin: 0 auto; }
@@ -69,15 +67,15 @@
         .module-description { color: var(--text-dim); margin-bottom: 1.5rem; line-height: 1.8; }
         .module-cta {
             display: inline-block;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: var(--primary-dark);
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
             text-decoration: none;
             font-weight: 700;
             transition: all 0.3s ease;
         }
-        .module-cta:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(31, 32, 36, 0.4); }
+        .module-cta:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(255, 122, 0, 0.4); }
         .completion-box {
             text-align: center;
             padding: 3rem 2rem;
@@ -110,8 +108,8 @@
         }
         .capstone-btn {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 1.25rem 2.5rem;
             border-radius: 2rem;
             text-decoration: none;
@@ -122,7 +120,7 @@
         }
         .capstone-btn:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(31, 32, 36, 0.5);
+            box-shadow: 0 8px 24px rgba(255, 122, 0, 0.4);
         }
     </style>
     <link rel="stylesheet" href="/css/icons.css">

--- a/paths/principled/stage-5/module-1.html
+++ b/paths/principled/stage-5/module-1.html
@@ -22,8 +22,8 @@
         .container { max-width: 900px; margin: 0 auto; }
         .back-btn {
             display: inline-block;
-            background: var(--accent-bronze);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 25px;
             text-decoration: none;
@@ -43,9 +43,7 @@
         .module-icon { font-size: 4rem; margin-bottom: 1rem; }
         h1 {
             font-size: 2.5rem;
-            background: linear-gradient(45deg, #1F2024, #272930);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
         .module-subtitle { font-size: 1.2rem; color: var(--text-dim); max-width: 700px; margin: 0 auto; }
@@ -152,8 +150,8 @@
             font-size: 0.9rem;
         }
         button {
-            background: linear-gradient(45deg, #1F2024, #272930);
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             border: none;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;
@@ -163,7 +161,7 @@
         }
         button:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4);
+            box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
         }
         .reflection-section {
             background: linear-gradient(135deg, rgba(31, 32, 36, 0.1), rgba(31, 32, 36, 0.05));
@@ -211,8 +209,8 @@
         }
         .next-module a {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-bronze-light));
-            color: white;
+            background: #FF7A00;
+            color: #101010;
             padding: 1.25rem 2.5rem;
             border-radius: 2rem;
             text-decoration: none;
@@ -222,7 +220,7 @@
         }
         .next-module a:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 24px rgba(31, 32, 36, 0.5);
+            box-shadow: 0 8px 24px rgba(255, 122, 0, 0.4);
         }
         /* Interactive Reflection Styles */
         .reflection-tabs { display: flex; gap: 0.5rem; margin-bottom: 1.5rem; border-bottom: 2px solid rgba(31, 32, 36, 0.2); padding-bottom: 0.5rem; }
@@ -233,13 +231,13 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; background: var(--secondary-dark); border: 2px solid rgba(31, 32, 36, 0.3); color: var(--text-light); padding: 0.75rem 1rem; border-radius: 8px; font-size: 1rem; margin-bottom: 1rem; cursor: pointer; }
         .choice-select:focus { outline: none; border-color: var(--accent-bronze); }
-        .feedback-btn { background: linear-gradient(45deg, #1F2024, #272930); color: white; padding: 0.75rem 1.5rem; border-radius: 2rem; border: none; font-weight: 600; cursor: pointer; transition: all 0.3s ease; margin-top: 0.5rem; }
-        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4); }
+        .feedback-btn { background: #FF7A00; color: #101010; padding: 0.75rem 1.5rem; border-radius: 2rem; border: none; font-weight: 600; cursor: pointer; transition: all 0.3s ease; margin-top: 0.5rem; }
+        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4); }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 8px; border-left: 4px solid; }
         .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; }
         .feedback-box.positive h5 { color: #4caf50; margin-bottom: 0.5rem; }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #1F2024; }
-        .feedback-box.hint h5 { color: #1F2024; margin-bottom: 0.5rem; }
+        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #f59e0b; }
+        .feedback-box.hint h5 { color: #f59e0b; margin-bottom: 0.5rem; }
         .feedback-box.neutral { background: rgba(31, 32, 36, 0.1); border-color: var(--accent-bronze); }
         .feedback-box.neutral h5 { color: var(--accent-bronze); margin-bottom: 0.5rem; }
         .checklist-reflection { display: flex; flex-direction: column; gap: 1rem; }

--- a/paths/principled/stage-5/module-1.html
+++ b/paths/principled/stage-5/module-1.html
@@ -330,8 +330,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <a href="/paths/principled/stage-5/" class="back-btn">← Back to Stage 5</a>

--- a/paths/principled/stage-5/module-2.html
+++ b/paths/principled/stage-5/module-2.html
@@ -342,13 +342,13 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; background: var(--bg-medium); border: 2px solid rgba(31, 32, 36, 0.3); color: var(--text-primary); padding: 0.75rem 1rem; border-radius: 8px; font-size: 1rem; margin-bottom: 1rem; cursor: pointer; }
         .choice-select:focus { outline: none; border-color: var(--path-color); }
-        .feedback-btn { background: linear-gradient(45deg, #1F2024, #272930); color: white; padding: 0.75rem 1.5rem; border-radius: 2rem; border: none; font-weight: 600; cursor: pointer; transition: all 0.3s ease; margin-top: 0.5rem; }
-        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(31, 32, 36, 0.4); }
+        .feedback-btn { background: #FF7A00; color: #101010; padding: 0.75rem 1.5rem; border-radius: 2rem; border: none; font-weight: 600; cursor: pointer; transition: all 0.3s ease; margin-top: 0.5rem; }
+        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4); }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 8px; border-left: 4px solid; }
         .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; }
         .feedback-box.positive h5 { color: #4caf50; margin-bottom: 0.5rem; }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #1F2024; }
-        .feedback-box.hint h5 { color: #1F2024; margin-bottom: 0.5rem; }
+        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #f59e0b; }
+        .feedback-box.hint h5 { color: #f59e0b; margin-bottom: 0.5rem; }
         .feedback-box.neutral { background: rgba(31, 32, 36, 0.1); border-color: var(--path-color); }
         .feedback-box.neutral h5 { color: var(--path-color); margin-bottom: 0.5rem; }
         .checklist-reflection { display: flex; flex-direction: column; gap: 1rem; }

--- a/paths/principled/stage-5/module-2.html
+++ b/paths/principled/stage-5/module-2.html
@@ -494,8 +494,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-container" id="main-content">
         <div class="module-header">

--- a/paths/principled/stage-5/module-3.html
+++ b/paths/principled/stage-5/module-3.html
@@ -479,11 +479,11 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(45, 45, 45, 0.6); border: 1px solid rgba(31, 32, 36, 0.3); border-radius: 8px; color: #e0e0e0; font-size: 1rem; cursor: pointer; }
         .choice-select:focus { outline: none; border-color: var(--path-color); }
-        .feedback-btn { background: linear-gradient(135deg, var(--path-color), var(--path-color-light)); color: white; padding: 0.75rem 1.5rem; border: none; border-radius: 8px; font-weight: 600; cursor: pointer; margin-top: 1rem; transition: all 0.3s ease; }
-        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(31, 32, 36, 0.4); }
+        .feedback-btn { background: #FF7A00; color: #101010; padding: 0.75rem 1.5rem; border: none; border-radius: 8px; font-weight: 600; cursor: pointer; margin-top: 1rem; transition: all 0.3s ease; }
+        .feedback-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(255, 122, 0, 0.4); }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 8px; border: 2px solid; display: none; }
         .feedback-box.positive { background: rgba(76, 175, 80, 0.1); border-color: #4caf50; color: #e0e0e0; }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #1F2024; color: #e0e0e0; }
+        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #f59e0b; color: #e0e0e0; }
         .feedback-box h5 { margin-top: 0; margin-bottom: 0.5rem; color: inherit; }
         .checklist-reflection { display: flex; flex-direction: column; gap: 0.75rem; }
         .checkbox-label { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem; background: rgba(45, 45, 45, 0.4); border-radius: 6px; cursor: pointer; transition: background 0.2s ease; }

--- a/paths/principled/stage-5/module-3.html
+++ b/paths/principled/stage-5/module-3.html
@@ -588,8 +588,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-container" id="main-content">
         <div class="module-header">

--- a/paths/skeptic/index.html
+++ b/paths/skeptic/index.html
@@ -465,8 +465,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Path Header -->
     <header class="path-header">

--- a/paths/skeptic/stage-1/index.html
+++ b/paths/skeptic/stage-1/index.html
@@ -423,8 +423,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
         <main id="main-content" class="container">

--- a/paths/skeptic/stage-2/index.html
+++ b/paths/skeptic/stage-2/index.html
@@ -261,8 +261,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
         <main id="main-content" class="container">

--- a/paths/sovereign-journey-intro.html
+++ b/paths/sovereign-journey-intro.html
@@ -443,8 +443,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Hero Section -->
     <section class="hero">

--- a/paths/sovereign-journey-intro.html
+++ b/paths/sovereign-journey-intro.html
@@ -48,8 +48,8 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: radial-gradient(circle at 30% 50%, rgba(255, 215, 0, 0.1) 0%, transparent 50%),
-                        radial-gradient(circle at 70% 80%, rgba(156, 39, 176, 0.1) 0%, transparent 50%);
+            background: radial-gradient(circle at 30% 50%, rgba(255, 122, 0, 0.08) 0%, transparent 50%),
+                        radial-gradient(circle at 70% 80%, rgba(255, 122, 0, 0.05) 0%, transparent 50%);
             pointer-events: none;
         }
 
@@ -64,7 +64,7 @@
 
         .hero h1 {
             font-size: 3.5rem;
-            background: linear-gradient(135deg, var(--accent-gold), var(--accent-purple));
+            background: linear-gradient(135deg, #FF7A00, #FFD400);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -82,7 +82,7 @@
 
         .hero-quote {
             font-size: 1.8rem;
-            color: var(--accent-gold);
+            color: var(--primary-orange);
             margin: 2rem 0;
             font-weight: 300;
             line-height: 1.4;
@@ -117,7 +117,7 @@
 
         .section-header h2 {
             font-size: 2.5rem;
-            color: var(--accent-gold);
+            color: var(--primary-orange);
             margin-bottom: 1rem;
         }
 
@@ -141,7 +141,7 @@
             top: 0;
             bottom: 0;
             width: 2px;
-            background: linear-gradient(to bottom, var(--accent-gold), var(--accent-purple));
+            background: linear-gradient(to bottom, #FF7A00, #FFD400);
             transform: translateX(-50%);
         }
 
@@ -178,15 +178,15 @@
         }
 
         .event-content:hover {
-            border-color: var(--accent-gold);
+            border-color: var(--primary-orange);
             transform: scale(1.05);
-            box-shadow: 0 10px 30px rgba(255, 215, 0, 0.2);
+            box-shadow: 0 10px 30px rgba(255, 122, 0, 0.2);
         }
 
         .event-year {
             font-size: 2rem;
             font-weight: 700;
-            color: var(--accent-gold);
+            color: var(--primary-orange);
             margin-bottom: 0.5rem;
         }
 
@@ -204,8 +204,8 @@
         .event-impact {
             margin-top: 1rem;
             padding: 1rem;
-            background: rgba(255, 215, 0, 0.1);
-            border-left: 3px solid var(--accent-gold);
+            background: rgba(255, 122, 0, 0.08);
+            border-left: 3px solid var(--primary-orange);
             border-radius: 0.5rem;
             font-style: italic;
         }
@@ -217,8 +217,8 @@
         }
 
         .pattern-box {
-            background: linear-gradient(135deg, rgba(255, 215, 0, 0.1), rgba(156, 39, 176, 0.1));
-            border: 3px solid var(--accent-purple);
+            background: rgba(255, 122, 0, 0.06);
+            border: 3px solid var(--primary-orange);
             border-radius: 1.5rem;
             padding: 3rem;
             margin: 3rem 0;
@@ -227,7 +227,7 @@
 
         .pattern-box h3 {
             font-size: 2rem;
-            color: var(--accent-purple);
+            color: var(--primary-orange);
             margin-bottom: 1.5rem;
         }
 
@@ -276,14 +276,14 @@
         }
 
         .choice-card:hover {
-            border-color: var(--accent-gold);
+            border-color: var(--primary-orange);
             transform: translateY(-10px);
-            box-shadow: 0 15px 40px rgba(255, 215, 0, 0.3);
+            box-shadow: 0 15px 40px rgba(255, 122, 0, 0.25);
         }
 
         .choice-card h4 {
             font-size: 1.5rem;
-            color: var(--accent-gold);
+            color: var(--primary-orange);
             margin-bottom: 1rem;
         }
 
@@ -303,14 +303,14 @@
             max-width: 800px;
             margin: 0 auto;
             padding: 3rem;
-            background: rgba(255, 215, 0, 0.05);
-            border: 3px solid var(--accent-gold);
+            background: rgba(255, 122, 0, 0.05);
+            border: 3px solid var(--primary-orange);
             border-radius: 1.5rem;
         }
 
         .cta-box h2 {
             font-size: 2.5rem;
-            color: var(--accent-gold);
+            color: var(--primary-orange);
             margin-bottom: 1.5rem;
         }
 
@@ -332,23 +332,23 @@
         }
 
         .cta-btn-primary {
-            background: linear-gradient(135deg, var(--accent-gold), var(--accent-purple));
-            color: white;
+            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            color: #101010;
         }
 
         .cta-btn-primary:hover {
             transform: scale(1.05);
-            box-shadow: 0 10px 30px rgba(255, 215, 0, 0.5);
+            box-shadow: 0 10px 30px rgba(255, 122, 0, 0.5);
         }
 
         .cta-btn-secondary {
             background: transparent;
-            border: 2px solid var(--accent-gold);
-            color: var(--accent-gold);
+            border: 2px solid var(--primary-orange);
+            color: var(--primary-orange);
         }
 
         .cta-btn-secondary:hover {
-            background: rgba(255, 215, 0, 0.1);
+            background: rgba(255, 122, 0, 0.1);
             transform: scale(1.05);
         }
 
@@ -453,7 +453,7 @@
             <p class="hero-subtitle">"History doesn't repeat itself, but it often rhymes."</p>
             <p class="hero-quote">
                 Every generation faces the same question:<br>
-                <strong style="color: var(--accent-purple);">Freedom or convenience?</strong>
+                <strong style="color: var(--primary-orange);">Freedom or convenience?</strong>
             </p>
             <p style="font-size: 1.1rem; color: var(--text-dim); margin-top: 2rem;">
                 Before you learn the tools of sovereignty, understand <em>why</em> they matter.
@@ -602,7 +602,7 @@
                     <li><strong>Censor it</strong> (Payment processor deplatforming)</li>
                 </ul>
 
-                <p style="font-size: 1.3rem; margin-top: 2rem; color: var(--accent-gold);">
+                <p style="font-size: 1.3rem; margin-top: 2rem; color: var(--primary-orange);">
                     <strong>The Common Thread:</strong> Centralized control always concentrates power.<br>
                     And power always gets abused.
                 </p>
@@ -613,7 +613,7 @@
                     This isn't conspiracy theory. This is documented history.<br>
                     <em>It happened to them. It can happen to you.</em>
                 </p>
-                <p style="font-size: 1.3rem; color: var(--accent-purple); margin-top: 2rem;">
+                <p style="font-size: 1.3rem; color: var(--primary-orange); margin-top: 2rem;">
                     <strong>Unless you choose sovereignty.</strong>
                 </p>
             </div>
@@ -665,7 +665,7 @@
                 </div>
             </div>
 
-            <div style="max-width: 700px; margin: 3rem auto; padding: 2rem; background: rgba(156, 39, 176, 0.1); border-left: 4px solid var(--accent-purple); border-radius: 0.75rem;">
+            <div style="max-width: 700px; margin: 3rem auto; padding: 2rem; background: rgba(255, 122, 0, 0.06); border-left: 4px solid var(--primary-orange); border-radius: 0.75rem;">
                 <p style="font-size: 1.1rem; color: var(--text-light);">
                     <strong>There's no "correct" answer.</strong> Only trade-offs.<br><br>
                     But before you decide, let's explore what each choice actually means.<br>
@@ -686,8 +686,8 @@
                 </p>
 
                 <!-- Game Instructions Narrative -->
-                <div style="background: rgba(156, 39, 176, 0.15); border: 2px solid var(--accent-purple); border-radius: 1rem; padding: 2rem; margin: 2rem 0; text-align: left;">
-                    <h3 style="color: var(--accent-purple); font-size: 1.5rem; margin-bottom: 1rem; text-align: center;">
+                <div style="background: rgba(255, 122, 0, 0.06); border: 2px solid var(--primary-orange); border-radius: 1rem; padding: 2rem; margin: 2rem 0; text-align: left;">
+                    <h3 style="color: var(--primary-orange); font-size: 1.5rem; margin-bottom: 1rem; text-align: center;">
                         🕰️ Your Mission: Rewrite History
                     </h3>
 
@@ -696,8 +696,8 @@
                         the same events—but this time, <strong>you make the choices</strong>.
                     </p>
 
-                    <div style="background: var(--secondary-dark); border-left: 4px solid var(--accent-gold); padding: 1.5rem; border-radius: 0.5rem; margin: 1.5rem 0;">
-                        <p style="font-size: 1.05rem; margin-bottom: 0.75rem;"><strong style="color: var(--accent-gold);">Your Goal:</strong></p>
+                    <div style="background: var(--secondary-dark); border-left: 4px solid var(--primary-orange); padding: 1.5rem; border-radius: 0.5rem; margin: 1.5rem 0;">
+                        <p style="font-size: 1.05rem; margin-bottom: 0.75rem;"><strong style="color: var(--primary-orange);">Your Goal:</strong></p>
                         <p style="color: var(--text-dim); margin-bottom: 1rem;">
                             Navigate economic crises by making choices based on:
                         </p>
@@ -714,30 +714,30 @@
                     </p>
 
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-top: 1.5rem;">
-                        <div style="text-align: center; padding: 1rem; background: rgba(255, 215, 0, 0.1); border-radius: 0.5rem;">
+                        <div style="text-align: center; padding: 1rem; background: rgba(255, 122, 0, 0.07); border-radius: 0.5rem;">
                             <div style="font-size: 2rem; margin-bottom: 0.5rem;">⚖️</div>
-                            <strong style="color: var(--accent-gold);">Make Trade-offs</strong>
+                            <strong style="color: var(--primary-orange);">Make Trade-offs</strong>
                             <p style="font-size: 0.9rem; color: var(--text-dim); margin-top: 0.5rem;">
                                 Sovereignty vs. Convenience
                             </p>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: rgba(255, 215, 0, 0.1); border-radius: 0.5rem;">
+                        <div style="text-align: center; padding: 1rem; background: rgba(255, 122, 0, 0.07); border-radius: 0.5rem;">
                             <div style="font-size: 2rem; margin-bottom: 0.5rem;"><span data-icon="chart"></span> </div>
-                            <strong style="color: var(--accent-gold);">See Consequences</strong>
+                            <strong style="color: var(--primary-orange);">See Consequences</strong>
                             <p style="font-size: 0.9rem; color: var(--text-dim); margin-top: 0.5rem;">
                                 How choices compound over time
                             </p>
                         </div>
-                        <div style="text-align: center; padding: 1rem; background: rgba(255, 215, 0, 0.1); border-radius: 0.5rem;">
+                        <div style="text-align: center; padding: 1rem; background: rgba(255, 122, 0, 0.07); border-radius: 0.5rem;">
                             <div style="font-size: 2rem; margin-bottom: 0.5rem;"><span data-icon="lightbulb"></span> </div>
-                            <strong style="color: var(--accent-gold);">Learn Through Doing</strong>
+                            <strong style="color: var(--primary-orange);">Learn Through Doing</strong>
                             <p style="font-size: 0.9rem; color: var(--text-dim); margin-top: 0.5rem;">
                                 Experience &gt; explanation
                             </p>
                         </div>
                     </div>
 
-                    <p style="font-size: 1rem; color: var(--accent-purple); margin-top: 1.5rem; text-align: center; font-style: italic;">
+                    <p style="font-size: 1rem; color: var(--primary-orange); margin-top: 1.5rem; text-align: center; font-style: italic;">
                         <strong>Remember:</strong> There are no "correct" answers. Only trade-offs.<br>
                         But every choice teaches you something about sovereignty.
                     </p>

--- a/paths/sovereign/index.html
+++ b/paths/sovereign/index.html
@@ -466,8 +466,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Path Header -->
     <header class="path-header">

--- a/paths/sovereign/stage-1/index.html
+++ b/paths/sovereign/stage-1/index.html
@@ -381,8 +381,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Path Progress Header -->
     <header class="path-header">

--- a/paths/sovereign/stage-1/module-1.html
+++ b/paths/sovereign/stage-1/module-1.html
@@ -399,8 +399,9 @@
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-1/module-2.html
+++ b/paths/sovereign/stage-1/module-2.html
@@ -497,8 +497,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-1/module-3.html
+++ b/paths/sovereign/stage-1/module-3.html
@@ -527,8 +527,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-2/index.html
+++ b/paths/sovereign/stage-2/index.html
@@ -371,8 +371,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="path-header">
         <div class="container">

--- a/paths/sovereign/stage-2/module-1.html
+++ b/paths/sovereign/stage-2/module-1.html
@@ -282,8 +282,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-2/module-2.html
+++ b/paths/sovereign/stage-2/module-2.html
@@ -484,8 +484,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-2/module-3.html
+++ b/paths/sovereign/stage-2/module-3.html
@@ -262,8 +262,9 @@
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-3/alternatives-to-bitcoin.html
+++ b/paths/sovereign/stage-3/alternatives-to-bitcoin.html
@@ -208,7 +208,7 @@
         .intro-text h1 {
             font-size: 2.5rem;
             margin-bottom: 1rem;
-            background: linear-gradient(135deg, var(--sovereign-gold), #ffd700);
+            background: linear-gradient(135deg, var(--sovereign-gold), #FFD400);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -224,8 +224,8 @@
         .cta-start {
             margin-top: 2rem;
             padding: 1rem 2.5rem;
-            background: linear-gradient(135deg, var(--sovereign-gold), #ffd700);
-            color: var(--primary-dark);
+            background: linear-gradient(135deg, var(--sovereign-gold), #FFD400);
+            color: #101010;
             border: none;
             border-radius: 2rem;
             font-size: 1.1rem;
@@ -599,7 +599,8 @@
 
         /* Deep Dive CTA */
         .deep-dive-cta {
-            background: linear-gradient(135deg, var(--sovereign-gold), #ffd700);
+            background: #101010;
+            border: 2px solid #FF7A00;
             border-radius: 16px;
             padding: 3rem;
             text-align: center;
@@ -609,18 +610,18 @@
 
         .deep-dive-cta:hover {
             transform: translateY(-4px);
-            box-shadow: 0 15px 40px rgba(212, 175, 55, 0.4);
+            box-shadow: 0 15px 40px rgba(255, 122, 0, 0.25);
         }
 
         .deep-dive-cta h3 {
             font-size: 2rem;
-            color: var(--primary-dark);
+            color: #FF7A00;
             margin-bottom: 1rem;
         }
 
         .deep-dive-cta p {
             font-size: 1.1rem;
-            color: rgba(15, 15, 15, 0.8);
+            color: #F7F7F2;
             margin-bottom: 0;
         }
 
@@ -760,8 +761,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Navigation -->
     <nav class="module-nav">

--- a/paths/sovereign/stage-3/collaborative-security.html
+++ b/paths/sovereign/stage-3/collaborative-security.html
@@ -216,8 +216,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="header">
         <div class="container">

--- a/paths/sovereign/stage-3/fees-utxo-guide.html
+++ b/paths/sovereign/stage-3/fees-utxo-guide.html
@@ -191,8 +191,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="header">
         <div class="container">

--- a/paths/sovereign/stage-3/index.html
+++ b/paths/sovereign/stage-3/index.html
@@ -371,8 +371,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="path-header">
         <div class="container">

--- a/paths/sovereign/stage-3/module-1.html
+++ b/paths/sovereign/stage-3/module-1.html
@@ -239,8 +239,9 @@
             display: inline-block;
             margin-top: 1rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #7b1fa2, #9c27b0);
-            color: white;
+            background: transparent;
+            border: 2px solid #FF7A00;
+            color: #FF7A00;
             text-decoration: none;
             border-radius: 0.5rem;
             font-weight: 600;
@@ -251,8 +252,8 @@
 
         .demo-link:hover {
             transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(156, 39, 176, 0.4);
-            color: white;
+            box-shadow: 0 4px 15px rgba(255, 122, 0, 0.35);
+            color: #FF7A00;
         }
     </style>
     <script src="/js/config.js"></script>
@@ -283,8 +284,9 @@
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">
@@ -778,8 +780,8 @@
 
             <!-- Interactive Lightning Network Demo -->
             <section class="content-section">
-                <div class="demo-embed" style="background: var(--secondary-dark); border: 2px solid #9C27B0; border-radius: 1rem; padding: 2rem; margin: 2rem 0; text-align: center;">
-                    <h3 style="color: #9C27B0; margin-bottom: 1rem;"><span data-icon="lightning"></span> Interactive: Lightning Network Simulator</h3>
+                <div class="demo-embed" style="background: var(--secondary-dark); border: 2px solid #FF7A00; border-radius: 1rem; padding: 2rem; margin: 2rem 0; text-align: center;">
+                    <h3 style="color: #FF7A00; margin-bottom: 1rem;"><span data-icon="lightning"></span> Interactive: Lightning Network Simulator</h3>
                     <p style="margin-bottom: 1.5rem; color: var(--text-dim);">
                         Practice channel management, routing, and HTLC mechanics in a safe simulation.
                         Understand how payments flow through the network.

--- a/paths/sovereign/stage-3/module-2.html
+++ b/paths/sovereign/stage-3/module-2.html
@@ -261,8 +261,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-3/module-3.html
+++ b/paths/sovereign/stage-3/module-3.html
@@ -261,8 +261,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-3/monetary-alternatives.html
+++ b/paths/sovereign/stage-3/monetary-alternatives.html
@@ -7,8 +7,9 @@
     <meta name="robots" content="noindex, follow">
     <meta http-equiv="refresh" content="0; url=/paths/sovereign/stage-3/alternatives-to-bitcoin.html">
     <script>window.location.replace("/paths/sovereign/stage-3/alternatives-to-bitcoin.html");</script>
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <p>This module has moved to
        <a href="/paths/sovereign/stage-3/alternatives-to-bitcoin.html">Alternatives to Bitcoin: Fiat, Stablecoins &amp; CBDCs</a>.</p>
     <footer>Created by Dalia · bitcoinsovereign.academy</footer>

--- a/paths/sovereign/stage-3/proofs-not-promises.html
+++ b/paths/sovereign/stage-3/proofs-not-promises.html
@@ -211,8 +211,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="header">
         <div class="container">

--- a/paths/sovereign/stage-3/scam-defense.html
+++ b/paths/sovereign/stage-3/scam-defense.html
@@ -211,8 +211,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="header">
         <div class="container">

--- a/paths/sovereign/stage-4/index.html
+++ b/paths/sovereign/stage-4/index.html
@@ -371,8 +371,9 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
-<body>
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="path-header">
         <div class="container">

--- a/paths/sovereign/stage-4/module-1.html
+++ b/paths/sovereign/stage-4/module-1.html
@@ -261,8 +261,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-4/module-2.html
+++ b/paths/sovereign/stage-4/module-2.html
@@ -261,8 +261,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">

--- a/paths/sovereign/stage-4/module-3.html
+++ b/paths/sovereign/stage-4/module-3.html
@@ -261,8 +261,9 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script><link rel="stylesheet" href="/css/lab-guide.css">
+    <link rel="stylesheet" href="/css/brand-consistency.css">
 </head>
-<body>
+<body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="module-header">
         <div class="container">


### PR DESCRIPTION
Completes rollout step 3 (paths, 110 pages) of the Design Conformance Contract.

**Commits:**
1. Salvaged design-QA agent fixes (~290 colored-fill conversions, ~90 contrast repairs, 84 files)
2. bsa-skin applied to all 110 path pages + bespoke identity vars (sovereign-gold, builder-purple, pragmatist-cyan, …) remapped to uniform brand orange (per Dalia 2026-06-10) + raw purple/gold usages fixed in context
3. Rendered-verification fixes (computed colors + WCAG contrast on 11 sample pages)

**Verified (contract §3):** all sampled pages: bsa-skin + sheet loads last, **zero purple/green surfaces**, contrast clean except known items below.

**Root cause found:** `css/icons.css` @imports `homepage-bsa-brand-fix.css` + `path-bsa-brand-fix.css` — a hidden second skin fighting bsa-skin with !important. Its broad `a:not(...)` recolor caused orange-text-on-orange-button bugs; now scoped to prose. Imports left in place (homepage + 37 demos depend on them) — consolidation is a follow-up.

**Known/accepted:**
- Semantic red `#dc3545` small text on dark computes 3.0–4.2:1 (palette-level; proposing a text-variant `#e4606d` as contract amendment)
- Sitewide skip-link inline style is white-on-orange 2.6:1; fixed on skinned pages via skin rule — unskinned pages need the same in a later group
- Money-creation teaching-diagram panels keep semantic blue/green hues (darkened for AA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)