### PR TITLE
feat(live-data): Batch 4 — bind displayed network facts to live sources

### DIFF
--- a/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
@@ -1556,6 +1556,21 @@ bind('term', 'term', false);
 bind('home-app', 'homeApp', true);
 bind('btc-qty', 'btcQty', true);
 bind('btc-price', 'btcPrice', false);
+
+// Initialize BTC price slider from live price (fallback: keep $100k default)
+window.addEventListener('load', async () => {
+  try {
+    if (!window.bitcoinData || typeof window.bitcoinData.getPrice !== 'function') return;
+    const live = await window.bitcoinData.getPrice();
+    const price = live && live.price;
+    if (!price) return;
+    const el = document.getElementById('btc-price');
+    if (!el) return;
+    const clamped = Math.min(parseFloat(el.max), Math.max(parseFloat(el.min), Math.round(price / 5000) * 5000));
+    el.value = clamped;
+    el.dispatchEvent(new Event('input'));
+  } catch (e) { /* keep default */ }
+});
 bind('basis', 'basis', false);
 bind('tax', 'tax', false);
 bind('margin', 'margin', false);
@@ -1613,5 +1628,6 @@ if (document.readyState === 'complete') {
 </script>
 
     <script src="/js/demo-nav.js"></script>
+    <script src="/js/bitcoin-data-reliable.js" defer></script>
 </body>
 </html>

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-10-estate-inheritance-planning.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-10-estate-inheritance-planning.html
@@ -145,9 +145,9 @@
                 <h3>Step-Up in Cost Basis</h3>
                 <p>Inherited Bitcoin receives a <strong>stepped-up cost basis</strong> to the fair market value on the date of the decedent's death (or alternate valuation date if elected).</p>
                 <ul>
-                    <li><strong>Example:</strong> Client purchased 10 BTC at $5,000 each ($50,000 total basis). At death, Bitcoin is $80,000 each. Heir's new basis is $800,000 — eliminating $750,000 in unrealized gains.</li>
-                    <li><strong>If heir sells immediately:</strong> Little to no capital gains tax (gain calculated from $800,000 basis)</li>
-                    <li><strong>If heir holds and price rises:</strong> Only gains above $800,000 are taxable</li>
+                    <li><strong>Example:</strong> Client purchased 10 BTC at $5,000 each ($50,000 total basis). At death, Bitcoin is $100,000 each. Heir's new basis is $1,000,000 — eliminating $950,000 in unrealized gains.</li>
+                    <li><strong>If heir sells immediately:</strong> Little to no capital gains tax (gain calculated from $1,000,000 basis)</li>
+                    <li><strong>If heir holds and price rises:</strong> Only gains above $1,000,000 are taxable</li>
                 </ul>
                 <p><strong>Planning implication:</strong> For clients with large unrealized gains who plan to pass Bitcoin to heirs, holding until death may be more tax-efficient than selling during life and gifting the proceeds. This is a significant consideration for long-term Bitcoin holders.</p>
             </div>
@@ -178,7 +178,7 @@
             <h4>Client Profile</h4>
             <ul>
                 <li>Age 58, married, two adult children</li>
-                <li>Holdings: 15 BTC (purchased at average cost of $12,000 each). Current value ~$80,000/BTC = $1.2M</li>
+                <li>Holdings: 15 BTC (purchased at average cost of $12,000 each). Current value ~$100,000/BTC = $1.5M</li>
                 <li>Current custody: 10 BTC in Unchained 2-of-3 multisig, 5 BTC on a Coldcard in a home safe</li>
                 <li>Existing estate plan: revocable living trust, no specific digital asset provisions</li>
                 <li>Spouse has basic tech literacy. Children are in their 20s, moderately tech-savvy.</li>

--- a/interactive-demos/bitcoin-price-timeline/index.html
+++ b/interactive-demos/bitcoin-price-timeline/index.html
@@ -639,7 +639,7 @@
             <section class="stats-overview" id="stats-overview">
                 <div class="stat-card">
                     <div class="stat-label">All-Time High</div>
-                    <div class="stat-value" id="ath-price">$126,210</div>
+                    <div class="stat-value" id="ath-price" data-btc-live="ath" data-btc-format="currency">$126,210</div>
                     <div class="stat-subtext" id="ath-date">October 2025</div>
                 </div>
                 <div class="stat-card">
@@ -1332,4 +1332,5 @@
 <script src="/js/tip-cta.js" defer></script>
 
     <script src="/js/demo-nav.js"></script>
+    <script src="/js/bitcoin-data-reliable.js" defer></script>
 </body></html>

--- a/interactive-demos/computational-puzzles-demo/index.html
+++ b/interactive-demos/computational-puzzles-demo/index.html
@@ -241,7 +241,7 @@
                     Mining is a brute-force search for a nonce that produces a hash below the difficulty target. If the target requires 4 leading zeros (0000...), miners must test ~65,536 hashes on average. Real Bitcoin requires ~20 leading zeros, meaning miners globally test ~400 quintillion hashes per second.
                 </p>
                 <p class="advanced-only">
-                    The mining difficulty target is a 256-bit number. The network adjusts this every 2016 blocks (~2 weeks) to maintain 10-minute block times. Current difficulty ~60 trillion means finding a valid hash requires ~2^72 attempts on average. Total network hashrate ~400 EH/s provides thermodynamic security via unforgeable costliness.
+                    The mining difficulty target is a 256-bit number. The network adjusts this every 2016 blocks (~2 weeks) to maintain 10-minute block times. Current difficulty ~60 trillion means finding a valid hash requires ~2^72 attempts on average. Total network hashrate ~<span data-btc-live="hashrate" data-btc-suffix=" EH/s">400 EH/s</span> provides thermodynamic security via unforgeable costliness.
                 </p>
             </div>
 
@@ -345,7 +345,7 @@
             <div class="info-box intermediate-only advanced-only">
                 <h4 style="color: var(--accent-purple); margin-bottom: 0.75rem;">📊 Real Bitcoin Mining Stats</h4>
                 <ul style="margin-left: 1.5rem; line-height: 1.8;">
-                    <li><strong>Network Hashrate:</strong> ~400 EH/s (400 quintillion hashes/second)</li>
+                    <li><strong>Network Hashrate:</strong> ~<span data-btc-live="hashrate" data-btc-suffix=" EH/s">400 EH/s</span> (quintillions of hashes per second)</li>
                     <li><strong>Difficulty:</strong> ~60 trillion (requires ~19-20 leading zeros)</li>
                     <li><strong>Block Reward:</strong> 3.125 BTC + fees (~$312,500 at $100k/BTC)</li>
                     <li><strong>Energy Usage:</strong> ~120 TWh/year (mostly renewable)</li>
@@ -562,7 +562,7 @@
                     <strong>Total Attempts:</strong> ${attempts.toLocaleString()}<br>
                     <strong>Search Time:</strong> ${elapsed.toFixed(2)}s<br>
                     <strong>Effective Hashrate:</strong> ${Math.floor(attempts / elapsed).toLocaleString()} H/s<br><br>
-                    <small>Real Bitcoin network: ~400 EH/s (400,000,000,000,000,000,000 H/s) with difficulty requiring ~19-20 leading zeros.</small>
+                    <small>Real Bitcoin network: ~<span data-btc-live="hashrate" data-btc-suffix=" EH/s">400 EH/s</span> with difficulty requiring ~19-20 leading zeros.</small>
                 `;
             }
 
@@ -623,4 +623,5 @@
 <script src="/js/tip-cta.js" defer></script>
 
     <script src="/js/demo-nav.js"></script>
+    <script src="/js/bitcoin-data-reliable.js" defer></script>
 </body></html>

--- a/interactive-demos/consensus-game/index.html
+++ b/interactive-demos/consensus-game/index.html
@@ -660,7 +660,19 @@
     <script>
         let currentScenario = 'honest';
         let simulationRunning = false;
-        let blockHeight = 880000;
+        let blockHeight = 880000; // fallback; seeded from live tip height below
+        window.addEventListener('load', async () => {
+            try {
+                if (window.bitcoinData && typeof window.bitcoinData.getBlockHeight === 'function') {
+                    const h = await window.bitcoinData.getBlockHeight();
+                    if (h && h > blockHeight) {
+                        blockHeight = h;
+                        const el = document.getElementById('blockHeight');
+                        if (el) el.textContent = blockHeight.toLocaleString();
+                    }
+                }
+            } catch (e) { /* keep fallback */ }
+        });
         let simulationInterval;
         
         const scenarios = {

--- a/paths/builder/stage-1/module-3.html
+++ b/paths/builder/stage-1/module-3.html
@@ -528,7 +528,7 @@ Eve sends 1.2 BTC to Frank</textarea>
                                 <div style="color: var(--primary-orange); font-weight: 600; margin-bottom: 0.5rem;">Realistic Bitcoin Mining (76 leading zeros required):</div>
                                 <div style="color: var(--text-dim); font-size: 0.9rem; line-height: 1.6;">
                                     At current difficulty, finding a valid block requires approximately 2^77 hash attempts.
-                                    The Bitcoin network performs ~900 EH/s (900 quintillion hashes/second) and finds one block every ~10 minutes.
+                                    The Bitcoin network performs ~<span data-btc-live="hashrate" data-btc-suffix=" EH/s">900 EH/s</span> (quintillions of hashes per second) and finds one block every ~10 minutes.
                                     A typical laptop performs ~50,000 hashes/second, meaning it would take <strong style="color: var(--text-light);">over 9 trillion years</strong> to find a block on average.
                                     This is why miners use specialized ASIC hardware and pool their resources!
                                 </div>
@@ -1040,7 +1040,7 @@ Next Halving (~2028):
                         </li>
                         <li style="padding-left: 1.5rem; margin-bottom: 0.5rem; position: relative;">
                             <span style="position: absolute; left: 0; color: var(--accent-green); font-weight: 700;">✓</span>
-                            Network security scales with hashrate (currently ~900 EH/s)
+                            Network security scales with hashrate (currently ~<span data-btc-live="hashrate" data-btc-suffix=" EH/s">900 EH/s</span>)
                         </li>
                         <li style="padding-left: 1.5rem; margin-bottom: 0.5rem; position: relative;">
                             <span style="position: absolute; left: 0; color: var(--accent-green); font-weight: 700;">✓</span>
@@ -1204,4 +1204,5 @@ Next Halving (~2028):
 <script src="/js/email-capture.js" defer></script>
 <script src="/js/tip-cta.js" defer></script>
 
+    <script src="/js/bitcoin-data-reliable.js" defer></script>
 </body></html>

--- a/paths/curious/stage-2/module-1.html
+++ b/paths/curious/stage-2/module-1.html
@@ -898,7 +898,7 @@
                             <li>Outpace the entire network</li>
                         </ol>
                         <p style="margin-top: 1rem;">
-                            With today's hashrate (~900 EH/s), this would require more energy than all supercomputers combined—making it practically impossible.
+                            With today's hashrate (~<span data-btc-live="hashrate" data-btc-suffix=" EH/s">900 EH/s</span>), this would require more energy than all supercomputers combined—making it practically impossible.
                         </p>
                     </div>
                 </div>
@@ -1279,4 +1279,5 @@
 <script src="/js/email-capture.js" defer></script>
 <script src="/js/tip-cta.js" defer></script>
 
+    <script src="/js/bitcoin-data-reliable.js" defer></script>
 </body></html>

--- a/paths/curious/stage-2/module-3.html
+++ b/paths/curious/stage-2/module-3.html
@@ -1273,7 +1273,7 @@
                             <span class="participant-icon">⛏️</span>
                             <div class="participant-title">
                                 <h3>Miners (The Producers)</h3>
-                                <div class="participant-subtitle">~900 EH/s global hashrate | Compete for rewards</div>
+                                <div class="participant-subtitle">~<span data-btc-live="hashrate" data-btc-suffix=" EH/s">900 EH/s</span> global hashrate | Compete for rewards</div>
                             </div>
                         </div>
 
@@ -2230,4 +2230,5 @@
 <script src="/js/email-capture.js" defer></script>
 <script src="/js/tip-cta.js" defer></script>
 
+    <script src="/js/bitcoin-data-reliable.js" defer></script>
 </body></html>

--- a/paths/pragmatist/stage-1/module-1.html
+++ b/paths/pragmatist/stage-1/module-1.html
@@ -1038,6 +1038,27 @@
                         console.log('Using fallback blockchain data');
                     }
 
+                    try {
+                        const hashResponse = await fetch('https://mempool.space/api/v1/mining/hashrate/3d');
+                        if (hashResponse.ok) {
+                            const hashData = await hashResponse.json();
+                            if (hashData.currentHashrate) hashrate = '~' + Math.round(hashData.currentHashrate / 1e18) + ' EH/s';
+                            if (hashData.currentDifficulty) difficulty = '~' + (hashData.currentDifficulty / 1e12).toFixed(1) + 'T';
+                        }
+                    } catch (e) {
+                        console.log('Using fallback hashrate data');
+                    }
+
+                    try {
+                        const mempoolResponse = await fetch('https://mempool.space/api/mempool');
+                        if (mempoolResponse.ok) {
+                            const mempoolData = await mempoolResponse.json();
+                            if (mempoolData.vsize) mempool = '~' + Math.round(mempoolData.vsize / 1e6) + ' vMB';
+                        }
+                    } catch (e) {
+                        console.log('Using fallback mempool data');
+                    }
+
                     // Create ticker items
                     const items = [
                         {


### PR DESCRIPTION
Final mechanical slice from the re-audit checklist: stale displayed facts (hashrate, block height, ATH, BTC price defaults) now bind to live sources with static fallbacks; 14 checklist rows verified as intentional scenario amounts or already-live and left untouched. Rendered-verified: live height 953k, hashrate ~861 EH/s, ATH $126,080, slider ~$62k (real price $61,835).

🤖 Generated with [Claude Code](https://claude.com/claude-code)