### PR TITLE
chore(analytics): retire family-custody email-capture segments

### DIFF
--- a/emergency-kit.html
+++ b/emergency-kit.html
@@ -2091,7 +2091,7 @@
             </div>
 
             <!-- Family Custody funnel: email capture lead magnet -->
-            <div id="email-capture-page" data-email-capture="family-custody-kit" data-title="🔐 For families holding their own keys" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — focused on protecting your family's Bitcoin. No spam, ever." data-button="Keep me updated"></div>
+            <div id="email-capture-page" data-email-capture="family-education-kit" data-title="🔐 For families holding their own keys" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — focused on protecting your family's Bitcoin. No spam, ever." data-button="Keep me updated"></div>
         </div>
     </div>
 

--- a/interactive-demos/sovereign-vault/index.html
+++ b/interactive-demos/sovereign-vault/index.html
@@ -995,13 +995,13 @@
 
 <!-- Analytics, Email Capture & Tip CTAs -->
 <div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
-    <!-- Closing CTA: free vault tool -> paid prevention (Family Bitcoin Recovery Kit). funnel: family-custody -->
+    <!-- Closing CTA: free vault tool -> paid prevention (Family Bitcoin Recovery Kit). funnel: family-education -->
     <div style="margin-bottom:2rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#f7931a);border-radius:8px;background:rgba(247,147,26,0.06);">
         <h3 style="margin:0 0 .5rem;">Built your vault here? Make it survivable.</h3>
         <p style="margin:0 0 1.25rem;color:var(--text-dim,#9aa0aa);">A vault only protects your family if they can actually recover it. The <strong>Family Bitcoin Recovery Kit</strong> turns what you just set up into a structured, family-readable recovery plan — tested backups, a clear sequence, and not a single exposed key.</p>
         <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#f7931a);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
     </div>
-    <div id="email-capture-page" data-email-capture="family-custody-vault" data-title="🔐 Protect your family's Bitcoin" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
+    <div id="email-capture-page" data-email-capture="family-education-vault" data-title="🔐 Protect your family's Bitcoin" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
     <div id="tip-page" data-tip-cta="compact"></div>
 </div>
 <script src="/js/analytics.js" defer></script>

--- a/interactive-demos/sovereign-vault/templates/emergency-doc.html
+++ b/interactive-demos/sovereign-vault/templates/emergency-doc.html
@@ -827,13 +827,13 @@
 
 <!-- Analytics, Email Capture & Tip CTAs -->
 <div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
-    <!-- Closing CTA: free emergency-access doc -> paid prevention (Family Bitcoin Recovery Kit). funnel: family-custody -->
+    <!-- Closing CTA: free emergency-access doc -> paid prevention (Family Bitcoin Recovery Kit). funnel: family-education -->
     <div style="margin-bottom:2rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#f7931a);border-radius:8px;background:rgba(247,147,26,0.06);">
         <h3 style="margin:0 0 .5rem;">This document is step one — not the whole plan.</h3>
         <p style="margin:0 0 1.25rem;color:var(--text-dim,#9aa0aa);">An emergency access document only works inside a tested recovery plan. The <strong>Family Bitcoin Recovery Kit</strong> is that plan: a structured, family-readable recovery sequence your loved ones can actually follow, without ever exposing your keys.</p>
         <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#f7931a);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
     </div>
-    <div id="email-capture-page" data-email-capture="family-custody-emergency-doc" data-title="🔐 Keep your family's recovery plan current" data-subtitle="Get our custody &amp; inheritance guides and updates as they ship — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
+    <div id="email-capture-page" data-email-capture="family-education-emergency-doc" data-title="🔐 Keep your family's recovery plan current" data-subtitle="Get our custody &amp; inheritance guides and updates as they ship — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
     <div id="tip-page" data-tip-cta="compact"></div>
 </div>
 <script src="/js/analytics.js" defer></script>

--- a/multisig-security-demo.html
+++ b/multisig-security-demo.html
@@ -2852,7 +2852,7 @@
          data-sub="Pick the track that fits you. Each one is a single concrete action."
          data-tracks='[{"audience":"family","time":"this week","action":"Get the Family Bitcoin Recovery Kit — a family-readable recovery plan that never exposes your keys","href":"/products/family-bitcoin-recovery-kit/"},{"audience":"holder","time":"15 min","action":"Get single-sig right first in the Wallet Workshop","href":"/interactive-demos/wallet-workshop/"}]'>
     </div>
-    <div id="email-capture-page" data-email-capture="family-custody-multisig" data-title="🔐 Protect your family's Bitcoin" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
+    <div id="email-capture-page" data-email-capture="family-education-multisig" data-title="🔐 Protect your family's Bitcoin" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
 </div>
 <script src="/js/analytics.js" defer></script>
 <script src="/js/email-capture.js" defer></script>


### PR DESCRIPTION
Internal-only rename of four email-capture segment tags (family-custody-* → family-education-*) per the retired-label rule. No public wording, CTA, or backend changes. Historical analytics before this commit appear under the old segment names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)