### PR TITLE
feat(advisor): Phase 3 — Advisor Readiness Kit templates + LinkedIn content bank

### DIFF
--- a/docs/marketing/linkedin-advisor-content-bank-2026-06.md
+++ b/docs/marketing/linkedin-advisor-content-bank-2026-06.md
@@ -1,0 +1,182 @@
+# LinkedIn Advisor Content Bank — June 2026
+
+**Status: planning cards, not final posts.** Story-driven idea bank for the Advisor Bitcoin Readiness track. Each card: a recent verifiable story, the hidden connection to advisor work, the theme, the BSA asset, and a draft direction. Final drafts are written separately, never auto-published.
+
+**Writing constraints (locked):** no em dashes; vary sentence structures; no AI-pattern phrases ("Here is the thing", "The real question is", "Now more than ever", "Let that sink in", "It is not X. It is Y."); no hype, no fear-mongering, no "crypto expert" framing; no legal/tax/investment/custody/compliance/security advice; no invented statistics. The "96% of advisors get client crypto questions" claim is NOT used anywhere in this bank; if it ever is, it must be sourced first.
+
+**Sourcing flags:** aggregator-reported figures (ETF flow totals, 13F cohort numbers, breach counts) must be verified against primary sources (Farside/SoSoValue, SEC filings, company disclosures) before any post quoting them is published. Cards note this.
+
+---
+
+## Theme 1 — Discovery before allocation
+
+**1.1 · The quiet majority of Bitcoin ETF holders are advisors' clients**
+- **Story:** Q1 2026 13F analyses report that registered investment advisors represent the largest reported cohort of spot Bitcoin ETF holdings (~58% of 13F-reported BTC), and trimmed least during the spring drawdown. *(coinpaprika.com cohort analysis; verify against primary 13F data before publishing.)*
+- **Hidden connection:** the average advisory book already contains Bitcoin exposure. Discovery is not a niche question; it is a books-and-records question.
+- **Lesson:** discovery before allocation.
+- **Asset:** 10 Questions lead magnet.
+- **Draft direction:** Hook: "The biggest holders of Bitcoin ETFs are not hedge funds. They are advisory clients." Personal angle: what surprised me in the cohort data. Key point: you cannot plan around what you have not inventoried. Soft CTA: "Ten questions worth adding to intake." Target: /guides/advisor-10-questions/. **Category: awareness.**
+
+**1.2 · The estate detail families discover too late**
+- **Story:** Mainstream coverage (TheStreet, 2026) of families discovering, post-death, that critical financial information lived inside locked email and online accounts; executors barred by terms of service. *(thestreet.com "digital estate issue families discover too late"; cybernews.com probate piece.)*
+- **Hidden connection:** the client's Bitcoin may be invisible in statements. If discovery never asked, the estate finds out the hard way.
+- **Lesson:** discovery before allocation.
+- **Asset:** 10 Questions lead magnet.
+- **Draft direction:** Hook: "An executor can hold every legal power and still be locked out." Personal angle: a planning conversation that changed after one question. Key point: existence mapping is step zero. Soft CTA: the ten questions. Target: /guides/advisor-10-questions/. **Category: trust-building.**
+
+**1.3 · Breach letters as accidental discovery**
+- **Story:** The Block reported a previously undisclosed attack on Crypto.com that leaked users' personal data; disclosure surfaced long after the fact. *(theblock.co, 2026.)*
+- **Hidden connection:** clients learn about their own exposure from breach letters. Advisors sometimes learn a client holds crypto assets the same way.
+- **Lesson:** discovery before allocation.
+- **Asset:** Client Script Builder.
+- **Draft direction:** Hook: "Some advisors find out a client owns Bitcoin from a breach notification." Personal angle: the awkwardness of being the last to know. Key point: a standing intake question beats accidental discovery. Soft CTA: scripts for the conversation that follows. Target: /institutional/wealth-advisors/tools/client-script-builder.html. **Category: awareness.**
+
+## Theme 2 — Allocation before custody
+
+**2.1 · A record outflow streak, and the question nobody asks**
+- **Story:** US spot Bitcoin ETFs posted their longest outflow streak since launch, 13 days and ~$4.3B (May 15 to June 3, 2026). *(bitcoinfoundation.org / hedgeco.net; verify totals against Farside before publishing.)*
+- **Hidden connection:** flows are the headline; custody is the substrate. When a client exits an ETF and "buys the dip directly," the planning problem changes shape entirely.
+- **Lesson:** allocation before custody.
+- **Asset:** Custody Lanes at a Glance.
+- **Draft direction:** Hook: "Thirteen straight days of ETF outflows. The headlines covered the selling. Nobody covered where some of it went." Personal angle: a client question from a red week. Key point: exposure and coins are different planning problems. Soft CTA: the one-table comparison. Target: advisor-toolkit custody table. **Category: trust-building.**
+
+**2.2 · Banks added Bitcoin exposure while hedge funds cut**
+- **Story:** Q1 2026 13F data: banks including JPMorgan, Wells Fargo, BofA and Citi grew Bitcoin ETF positions (+339% YoY by one count) while hedge funds cut sharply. *(kucoin.com / coinpaprika.com; verify against filings.)*
+- **Hidden connection:** institutions choose their wrapper deliberately. Retail clients usually do not; they conflate ETF, exchange, and self-custody as "owning Bitcoin."
+- **Lesson:** allocation before custody.
+- **Asset:** Custody Lanes at a Glance.
+- **Draft direction:** Hook: "Banks and hedge funds disagree about Bitcoin right now. Both know exactly which wrapper they hold. Most clients do not." Personal angle: the client who said "I own Bitcoin" and meant three different things. Key point: the wrapper decides the risks. Soft CTA: the lanes table. Target: advisor-toolkit. **Category: awareness.**
+
+**2.3 · The SEC now examines crypto through a suitability lens**
+- **Story:** SEC 2026 examination priorities treat crypto products through liquidity, risk, cost and suitability review for retail recommendations. *(armstrongteasdale.com summary of SEC 2026 exam priorities.)*
+- **Hidden connection:** if examiners ask how a recommendation fit the client, the custody facts behind the position belong in the file too.
+- **Lesson:** allocation before custody.
+- **Asset:** $1,997 Advisor Bitcoin Readiness Training.
+- **Draft direction:** Hook: "Suitability reviews now reach crypto positions. Most files document the allocation and say nothing about the custody." Personal angle: what a clean file looks like. Key point: documentation is the cheapest protection. Soft CTA: readiness training exists for this. Target: /institutional/wealth-advisors/. **Category: conversion.**
+
+## Theme 3 — Custody before implementation
+
+**3.1 · Ledger's breach was not Ledger's wallet**
+- **Story:** Ledger customers' personal data leaked via Global-e, a third-party payment processor (January 2026). *(pymnts.com.)*
+- **Hidden connection:** even "self-custody" users carry vendor-perimeter exposure: shipping data, support tickets, payment processors. Custody model and operational hygiene are separate columns.
+- **Lesson:** custody before implementation.
+- **Asset:** Custody Lanes at a Glance ("what can fail" column).
+- **Draft direction:** Hook: "The hardware wallet was fine. The payment processor was not." Personal angle: why the "what can fail" column exists. Key point: every lane fails somewhere; know where before implementation. Soft CTA: the comparison table. Target: advisor-toolkit. **Category: trust-building.**
+
+**3.2 · Regulators just spent months defining "possession"**
+- **Story:** SEC staff guidance (Dec 2025, follow-ups into 2026) on broker-dealer custody of crypto asset securities; Commissioner Peirce's "No Longer Special" statement. *(sec.gov; sidley.com.)*
+- **Hidden connection:** when regulators need pages to define who possesses a digital asset, "where is it held" is clearly not a small question for a client file either.
+- **Lesson:** custody before implementation.
+- **Asset:** Custody Lanes at a Glance.
+- **Draft direction:** Hook: "It took the SEC months of guidance to define possession of a digital asset. Your client answered it with 'on my Ledger, I think.'" Personal angle: respect for how hard the question actually is. Key point: who can move it is the question under every other question. Soft CTA: the lanes table. Target: advisor-toolkit. **Category: trust-building.**
+
+**3.3 · The quantum headlines your clients will read first**
+- **Story:** Fortune (April 6, 2026) covered the debate over freezing Satoshi-era wallets against future quantum risk; CoinDesk earlier sized exposed coins at ~7M BTC. *(fortune.com 2026-04-06; coindesk.com 2026-02-22.)*
+- **Hidden connection:** the client question will arrive as "is Bitcoin about to be hacked?" The advisor's job is calm framing and knowing this is a horizon-planning topic, not a panic button.
+- **Lesson:** custody before implementation.
+- **Asset:** Client Script Builder.
+- **Draft direction:** Hook: "A client sent me a quantum computing headline and asked if their Bitcoin was safe." Personal angle: answering without pretending to be a cryptographer. Key point: distinguish today's custody risks (very real, mundane) from horizon risks (watched, debated). Soft CTA: scripts for hard questions. Target: script builder. **Category: awareness.**
+
+## Theme 4 — Escalation when keys, recovery, inheritance, or setup enter the room
+
+**4.1 · The drawer, the device, and the first irreversible mistake**
+- **Story:** 2026 estate-press coverage keeps repeating one scene: a family finds a hardware device and a word list after a death and improvises. *(cryptoslate.com "inheritance time bomb"; hackardlaw.com crypto estate-dispute chapter.)*
+- **Hidden connection:** the most expensive Bitcoin mistakes often happen in the week after death, made by well-meaning people with partial knowledge.
+- **Lesson:** escalation.
+- **Asset:** Seed Phrase Red Flags tool.
+- **Draft direction:** Hook: "The first Bitcoin mistake often happens after the funeral." Personal angle: the protocol I wish every estate team had taped to the wall. Key point: nobody touches the device; sequence the professionals. Soft CTA: the eight-scenario activity. Target: seed-phrase-red-flags tool. **Category: trust-building.**
+
+**4.2 · A robo-advisor breach became a fake crypto offer**
+- **Story:** Betterment disclosed a breach affecting ~1.4M customers in which attackers used access to push a fake crypto offer to clients. *(tech.co 2026 breach tracker; verify details against Betterment's disclosure before publishing.)*
+- **Hidden connection:** clients now receive convincing crypto outreach wearing trusted brands. The advisor is the natural circuit breaker, if clients know to call first.
+- **Lesson:** escalation.
+- **Asset:** Client Script Builder.
+- **Draft direction:** Hook: "Attackers breached a robo-advisor and did not steal funds. They sent clients a crypto offer instead." Personal angle: teaching clients to forward, not click. Key point: "call me before you act" is a service. Soft CTA: the script for that conversation. Target: script builder. **Category: awareness.**
+
+**4.3 · 2026 as the year the inheritance gap shows up in court**
+- **Story:** CryptoSlate's argument that Bitcoin's self-custody culture built an inheritance time bomb and 2026 is when it starts detonating; estate-law firms publishing crypto-dispute guides in parallel. *(cryptoslate.com; trustcounsel.com.)*
+- **Hidden connection:** the gap between legal authority and practical access is where estates stall and families fracture. Building the recovery process while the client is healthy is the escalation that prevents the courtroom.
+- **Lesson:** escalation.
+- **Asset:** Advisor Toolkit / Continuity Packet ($499).
+- **Draft direction:** Hook: "A will names the heir. It does not move the Bitcoin." Personal angle: the cheapest moment to fix this is always now. Key point: authority and access are built separately, on purpose. Soft CTA: the continuity packet's scorecard. Target: /products/advisor-bitcoin-client-kit/. **Category: conversion.**
+
+## Theme 5 — Advisors guide and document; specialists implement
+
+**5.1 · FINRA is mapping firms' "nexus to crypto"**
+- **Story:** FINRA's 2026 Annual Regulatory Oversight Report includes a chapter on member firms' crypto nexus. *(finra.org 2026 report.)*
+- **Hidden connection:** the regulator's question ("what exactly is your involvement?") is the same one every advisor should answer in writing before a client asks.
+- **Lesson:** advisors guide and document; specialists implement.
+- **Asset:** Advisor Toolkit / Continuity Packet (engagement-letter language).
+- **Draft direction:** Hook: "FINRA's 2026 report asks firms to define their nexus to crypto. Can your file answer in one sentence?" Personal angle: the boundary sentence I recommend memorizing. Key point: documented role boundaries protect everyone. Soft CTA: sample boundary language. Target: kit / $499 packet. **Category: conversion.**
+
+**5.2 · Terms of service beat the will**
+- **Story:** Cybernews reporting: platforms' terms of service, not estate documents, decide what families can access after death. *(cybernews.com.)*
+- **Hidden connection:** an advisor cannot fix a platform's policy, and should not try to engineer around it. They can sequence counsel, fiduciary, and specialist so the estate is not improvising.
+- **Lesson:** advisors guide and document; specialists implement.
+- **Asset:** $3,997 Advisor Practice Readiness.
+- **Draft direction:** Hook: "In most disputes over a deceased person's accounts, the controlling document was never the will. It was the terms of service." Personal angle: coordination as the advisor's craft. Key point: your value is the sequence, not the screwdriver. Soft CTA: practice-level readiness exists. Target: /institutional/wealth-advisors/. **Category: trust-building.**
+
+**5.3 · "Qualified custodian" is genuinely hard, and that is the point**
+- **Story:** Ongoing analyses of custody rule 206(4)-2 applied to digital assets: identifying a qualified custodian is complex, and the SEC only recently acknowledged certain state-chartered trust companies. *(innreg.com; kslaw.com.)*
+- **Hidden connection:** if compliance professionals find custody classification difficult, an advisor improvising client custody design is exactly the wrong person doing exactly the wrong job.
+- **Lesson:** advisors guide and document; specialists implement.
+- **Asset:** $1,997 Advisor Bitcoin Readiness Training.
+- **Draft direction:** Hook: "If defining a qualified custodian takes specialist lawyers, designing a client's custody should not be a side task in a review meeting." Personal angle: relief, not embarrassment, in saying "that part is not my job." Key point: readiness means knowing the handoff line. Soft CTA: the training teaches the line. Target: /institutional/wealth-advisors/. **Category: conversion.**
+
+## Theme 6 — Bitcoin is not "crypto"
+
+**6.1 · One word, three different breach stories**
+- **Story:** Early-2026 coverage filed Ledger (hardware vendor), Figure (blockchain lender), and Coinbase (exchange) breaches under one "crypto company" label. *(pymnts.com; decrypt.co; bitdefender.com.)*
+- **Hidden connection:** headline vocabulary flattens an industry into an asset. A client holding Bitcoin in cold storage read three "crypto breach" headlines and may not know none of them touched the Bitcoin network.
+- **Lesson:** Bitcoin is not "crypto."
+- **Asset:** $1,997 Advisor Bitcoin Readiness Training.
+- **Draft direction:** Hook: "Three companies, three different businesses, one headline word." Personal angle: the first distinction I teach advisors. Key point: the asset, the network, and the industry around them fail separately. Soft CTA: module one of readiness training. Target: /institutional/wealth-advisors/. **Category: awareness.**
+
+**6.2 · "Lost" bitcoin, dormant bitcoin, at-risk bitcoin: precision matters**
+- **Story:** Blockworks on the myth of "lost bitcoin" in the quantum era; estimates conflate lost keys, dormant holdings, and quantum-exposed address types. *(blockworks.co; ambcrypto.com.)*
+- **Hidden connection:** sloppy vocabulary creates client fear and bad decisions. An advisor who uses words precisely earns disproportionate trust.
+- **Lesson:** Bitcoin is not "crypto."
+- **Asset:** Client Script Builder.
+- **Draft direction:** Hook: "Lost, dormant, and at-risk describe three different piles of bitcoin. Most articles use one word for all three." Personal angle: vocabulary as a trust signal. Key point: precise words calm rooms. Soft CTA: scripts that use them. Target: script builder. **Category: awareness.**
+
+**6.3 · The banks did not buy "crypto"**
+- **Story:** Q1 2026 filings show major banks adding spot Bitcoin ETF exposure specifically, not baskets of digital assets. *(kucoin.com / coinpaprika.com; verify against filings.)*
+- **Hidden connection:** institutional behavior models the distinction retail language erases: a specific asset, a specific wrapper, a documented reason.
+- **Lesson:** Bitcoin is not "crypto."
+- **Asset:** Custody Lanes at a Glance.
+- **Draft direction:** Hook: "Watch what the banks filed, not what the headlines called it." Personal angle: reading 13Fs like an anthropologist. Key point: specificity is the professional posture. Soft CTA: the lanes table makes the distinctions visible. Target: advisor-toolkit. **Category: trust-building.**
+
+## Theme 7 — Client questions are already arriving
+
+**7.1 · Red weeks generate phone calls**
+- **Story:** The May-June 2026 outflow streak and price pressure produced a wave of "should I sell / should I buy more" coverage. *(hedgeco.net; bydfi.com.)*
+- **Hidden connection:** clients call their advisor during red weeks whether or not the advisor wanted a Bitcoin practice. The question arrives before the readiness does.
+- **Lesson:** client questions are already arriving.
+- **Asset:** Client Script Builder.
+- **Draft direction:** Hook: "Nobody schedules the Bitcoin question. It calls on a Tuesday during a drawdown." Personal angle: the difference preparation made in one call. Key point: calm scripts beat improvisation. Soft CTA: six questions, six scripts. Target: script builder. **Category: trust-building.**
+
+**7.2 · The quantum question is coming for your inbox**
+- **Story:** Fortune's quantum-freeze debate (April 2026) and the 2030 timeline remarks from quantum-industry CEOs keep resurfacing in mainstream feeds. *(fortune.com.)*
+- **Hidden connection:** abstract technology headlines become concrete client anxiety. The advisor who has a two-sentence calm answer wins the moment.
+- **Lesson:** client questions are already arriving.
+- **Asset:** 10 Questions lead magnet.
+- **Draft direction:** Hook: "You do not need an opinion on quantum computing. You need an answer for the client who just read about it." Personal angle: questions I collect from advisors. Key point: readiness is mostly anticipating the question list. Soft CTA: the ten questions. Target: /guides/advisor-10-questions/. **Category: awareness.**
+
+**7.3 · Mainstream outlets are now teaching your clients to ask**
+- **Story:** Fox News, NTD and others ran practical "prepare your digital accounts before you die" guides naming legacy contacts and crypto keys. *(foxnews.com; ntd.com.)*
+- **Hidden connection:** when general-audience outlets cover digital legacy, clients arrive at the next review meeting with questions the advisor did not schedule.
+- **Lesson:** client questions are already arriving.
+- **Asset:** 10 Questions lead magnet.
+- **Draft direction:** Hook: "My client's homework came from a morning show segment about digital legacy." Personal angle: meeting clients where the coverage left them. Key point: be the second, better conversation. Soft CTA: ten questions to run in that meeting. Target: /guides/advisor-10-questions/. **Category: conversion.**
+
+---
+
+## Top 5 selected for future drafting (not written yet)
+
+1. **4.1 The drawer, the device, and the first irreversible mistake** — the strongest emotional truth in the bank, maps to the most distinctive tool.
+2. **2.1 Record outflow streak, and where the coins went** — timely (this month), bridges headline to workflow naturally.
+3. **4.2 The Betterment fake crypto offer** — unexpected story, perfect advisor-as-circuit-breaker lesson. Verify details first.
+4. **1.1 RIAs are the largest ETF cohort** — the data point that makes discovery non-optional. Verify against primary 13F data first.
+5. **5.1 FINRA's nexus-to-crypto chapter** — regulator-driven urgency without fear-mongering, routes to the paid packet.
+
+Rationale: two awareness, two trust-building, one conversion; three themes covered with the strongest story-to-asset fits; two flagged for source verification before drafting.

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/advisor-toolkit.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/advisor-toolkit.html
@@ -706,6 +706,7 @@
                 <a href="#client-discovery-tool" class="quick-link">🧭 Start with client discovery</a>
                 <a href="/institutional/wealth-advisors/tools/seed-phrase-red-flags.html" class="quick-link">🚩 Seed phrase red flags</a>
                 <a href="/institutional/wealth-advisors/tools/client-script-builder.html" class="quick-link">💬 Client script builder</a>
+                <a href="/institutional/wealth-advisors/kit/" class="quick-link">📁 Advisor Readiness Kit templates</a>
                 <a href="#allocation-tool" class="secondary-btn">📊 Go to allocation simulator</a>
                 <a href="#custody-framework-tool" class="secondary-btn">🔐 Go to custody framework</a>
             </div>

--- a/institutional/wealth-advisors/kit/advisor-role-boundary-checklist.html
+++ b/institutional/wealth-advisors/kit/advisor-role-boundary-checklist.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Advisor Role-Boundary Checklist | BSA Advisor Kit</title>
+<meta name="description" content="A two-column do and do-not checklist defining where the advisor role ends and specialist work begins. Education only.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/advisor-role-boundary-checklist.html">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>
+.kit-wrap{max-width:780px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.kit-wrap h1{color:var(--color-brand,#FF7A00);font-size:1.6rem;margin:0 0 .4rem}
+.kit-wrap .subtitle{color:#9aa4b2;font-size:.98rem;margin:0 0 1.5rem;line-height:1.6}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}
+.breadcrumb a:hover{color:#FF7A00}
+.kit-section{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.3rem 1.5rem;margin:0 0 1.1rem}
+.kit-section h2{font-size:1.05rem;color:#FF7A00;margin:0 0 .6rem}
+.kit-section h3{font-size:.92rem;color:#F7F7F2;margin:1rem 0 .4rem}
+.kit-section p,.kit-section li{color:#b3b3b3;line-height:1.65;font-size:.94rem}
+.kit-section ul,.kit-section ol{margin:.4rem 0;padding-left:1.3rem}
+.kit-section .hint{color:#777;font-size:.85rem;font-style:italic}
+.check-list{list-style:none;padding-left:0}
+.check-list li{padding:.45rem 0;border-bottom:1px solid #1c1f24;display:flex;gap:.6rem;align-items:flex-start}
+.check-list li::before{content:"☐";color:#FF7A00;font-size:1.05rem;line-height:1.4}
+.fill{border-bottom:1px dotted #555;display:inline-block;min-width:180px}
+.say{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #28a745;border-radius:8px;padding:.9rem 1rem;color:#d8d8d2;font-style:italic;line-height:1.6;font-size:.93rem;margin:.5rem 0}
+.warn{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #f59e0b;border-radius:8px;padding:.9rem 1rem;color:#b3b3b3;line-height:1.6;font-size:.9rem;margin:.5rem 0}
+.toolbar{margin:1.5rem 0;text-align:center}
+.toolbar button,.toolbar a{display:inline-block;background:transparent;border:2px solid rgba(255,122,0,.45);color:#FF7A00;font-weight:700;border-radius:10px;padding:.55rem 1.2rem;cursor:pointer;font-size:.88rem;font-family:inherit;text-decoration:none;margin:.25rem}
+.kit-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem}
+.kit-footer a{color:#999}
+table.score{width:100%;border-collapse:collapse;font-size:.88rem}
+table.score th{text-align:left;padding:.5rem .6rem;border-bottom:2px solid #2a2a2a;color:#FF7A00}
+table.score td{padding:.5rem .6rem;border-bottom:1px solid #22262e;color:#b3b3b3;vertical-align:top}
+table.score select{background:#16181C;border:1px solid #2a2a2a;color:#F7F7F2;border-radius:6px;padding:.3rem}
+@media(max-width:600px){.kit-wrap{padding:1.25rem 1rem 3rem}}
+@media print{
+  body{background:#fff!important;color:#111!important}
+  .breadcrumb,.toolbar,.kit-footer{display:none!important}
+  .kit-section{background:#fff;border-color:#bbb;break-inside:avoid}
+  .kit-section p,.kit-section li,.say,.warn{color:#222!important}
+  .kit-section h2{color:#000}
+  .bsa-boundary-note{background:#fff!important;color:#333!important;border-color:#999!important}
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="kit-wrap" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/institutional/wealth-advisors/">For Professional Advisors</a> › <a href="/institutional/wealth-advisors/kit/">Advisor Kit</a> › <span>Role boundary</span></div>
+  <h1>Advisor Role-Boundary Checklist</h1>
+  <p class="subtitle">Tape this inside the file. Every uncomfortable Bitcoin moment in practice is resolved by one of these lines.</p>
+<div class="kit-section"><h2>The advisor does</h2>
+<ul class="check-list">
+<li>Ask the discovery questions and write the answers down</li>
+<li>Map holdings to custody lanes and keep the worksheet in the file</li>
+<li>Score recovery readiness and revisit it annually</li>
+<li>Educate with general materials; send clients to reputable learning resources</li>
+<li>Coordinate the professionals: custody specialist, CPA, counsel</li>
+<li>Document what was discussed, declined, and referred, every time</li></ul></div>
+<div class="kit-section"><h2>The advisor does not</h2>
+<ul class="check-list">
+<li>See, hold, photograph, or store seed phrases or private keys</li>
+<li>Design, configure, or verify a custody setup</li>
+<li>Direct or assist the movement of funds, even small amounts, even once</li>
+<li>Give tax conclusions or draft legal language; flag and refer instead</li>
+<li>Recommend buying or selling Bitcoin as part of readiness work</li>
+<li>Store recovery instructions that contain key material, sealed or not</li></ul></div>
+<div class="kit-section"><h2>The boundary sentence, memorized</h2>
+<div class="say">"I guide and document. Specialists implement. That separation is what protects you, and it's why you can trust the process."</div></div>
+  <div class="toolbar"><button type="button" onclick="window.print()">🖨 Print / Save as PDF</button><a href="/institutional/wealth-advisors/kit/">Back to the kit →</a></div>
+<aside class="bsa-boundary-note" role="note">
+  This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
+</aside>
+  <p class="kit-footer">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+
+</body></html>

--- a/institutional/wealth-advisors/kit/client-discovery-questionnaire.html
+++ b/institutional/wealth-advisors/kit/client-discovery-questionnaire.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Bitcoin Client Discovery Questionnaire | BSA Advisor Kit</title>
+<meta name="description" content="Twenty intake questions across existence, custody, continuity, and records. For professional advisors. Education only.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/client-discovery-questionnaire.html">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>
+.kit-wrap{max-width:780px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.kit-wrap h1{color:var(--color-brand,#FF7A00);font-size:1.6rem;margin:0 0 .4rem}
+.kit-wrap .subtitle{color:#9aa4b2;font-size:.98rem;margin:0 0 1.5rem;line-height:1.6}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}
+.breadcrumb a:hover{color:#FF7A00}
+.kit-section{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.3rem 1.5rem;margin:0 0 1.1rem}
+.kit-section h2{font-size:1.05rem;color:#FF7A00;margin:0 0 .6rem}
+.kit-section h3{font-size:.92rem;color:#F7F7F2;margin:1rem 0 .4rem}
+.kit-section p,.kit-section li{color:#b3b3b3;line-height:1.65;font-size:.94rem}
+.kit-section ul,.kit-section ol{margin:.4rem 0;padding-left:1.3rem}
+.kit-section .hint{color:#777;font-size:.85rem;font-style:italic}
+.check-list{list-style:none;padding-left:0}
+.check-list li{padding:.45rem 0;border-bottom:1px solid #1c1f24;display:flex;gap:.6rem;align-items:flex-start}
+.check-list li::before{content:"☐";color:#FF7A00;font-size:1.05rem;line-height:1.4}
+.fill{border-bottom:1px dotted #555;display:inline-block;min-width:180px}
+.say{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #28a745;border-radius:8px;padding:.9rem 1rem;color:#d8d8d2;font-style:italic;line-height:1.6;font-size:.93rem;margin:.5rem 0}
+.warn{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #f59e0b;border-radius:8px;padding:.9rem 1rem;color:#b3b3b3;line-height:1.6;font-size:.9rem;margin:.5rem 0}
+.toolbar{margin:1.5rem 0;text-align:center}
+.toolbar button,.toolbar a{display:inline-block;background:transparent;border:2px solid rgba(255,122,0,.45);color:#FF7A00;font-weight:700;border-radius:10px;padding:.55rem 1.2rem;cursor:pointer;font-size:.88rem;font-family:inherit;text-decoration:none;margin:.25rem}
+.kit-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem}
+.kit-footer a{color:#999}
+table.score{width:100%;border-collapse:collapse;font-size:.88rem}
+table.score th{text-align:left;padding:.5rem .6rem;border-bottom:2px solid #2a2a2a;color:#FF7A00}
+table.score td{padding:.5rem .6rem;border-bottom:1px solid #22262e;color:#b3b3b3;vertical-align:top}
+table.score select{background:#16181C;border:1px solid #2a2a2a;color:#F7F7F2;border-radius:6px;padding:.3rem}
+@media(max-width:600px){.kit-wrap{padding:1.25rem 1rem 3rem}}
+@media print{
+  body{background:#fff!important;color:#111!important}
+  .breadcrumb,.toolbar,.kit-footer{display:none!important}
+  .kit-section{background:#fff;border-color:#bbb;break-inside:avoid}
+  .kit-section p,.kit-section li,.say,.warn{color:#222!important}
+  .kit-section h2{color:#000}
+  .bsa-boundary-note{background:#fff!important;color:#333!important;border-color:#999!important}
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="kit-wrap" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/institutional/wealth-advisors/">For Professional Advisors</a> › <a href="/institutional/wealth-advisors/kit/">Advisor Kit</a> › <span>Discovery questionnaire</span></div>
+  <h1>Bitcoin Client Discovery Questionnaire</h1>
+  <p class="subtitle">Twenty questions across four areas. Ask them in order; the client's hesitations are as informative as their answers. Nothing here requires you to see, hold, or verify keys.</p>
+<div class="kit-section"><h2>A. Existence and exposure</h2><ul class="check-list"><li><div><strong style="color:#F7F7F2">Do you own Bitcoin directly, or through an ETF, fund, or trust?</strong><br><span class="hint">Different planning problems. Exposure transfers like a security; coins move only with keys.</span></div></li><li><div><strong style="color:#F7F7F2">Do you hold any other digital assets you think of separately from Bitcoin?</strong><br><span class="hint">Surfaces the Bitcoin-vs-crypto distinction early and keeps the inventory honest.</span></div></li><li><div><strong style="color:#F7F7F2">Roughly when did you first acquire it, and in how many places?</strong><br><span class="hint">Age and spread predict record gaps and forgotten accounts.</span></div></li><li><div><strong style="color:#F7F7F2">Is any of it held by a business, trust, or jointly with another person?</strong><br><span class="hint">Title drives estate treatment and who may authorize movement.</span></div></li><li><div><strong style="color:#F7F7F2">Does anyone else in the family hold Bitcoin you should plan around?</strong><br><span class="hint">Household exposure is often larger than the client's own.</span></div></li></ul></div><div class="kit-section"><h2>B. Custody and access</h2><ul class="check-list"><li><div><strong style="color:#F7F7F2">Where is it held today: exchange, hardware wallet, multisig, collaborative custody?</strong><br><span class="hint">Each lane fails differently. Use the custody-lanes worksheet to map it.</span></div></li><li><div><strong style="color:#F7F7F2">Who, besides you, could move funds today if they wanted to?</strong><br><span class="hint">Signing ability is the real question; ownership is the legal one.</span></div></li><li><div><strong style="color:#F7F7F2">Has anyone ever seen, photographed, or stored your seed phrase or backups?</strong><br><span class="hint">Every viewer is a standing risk. Do not ask what the words are; ask who has seen them.</span></div></li><li><div><strong style="color:#F7F7F2">If you lost your phone and laptop this week, how would you recover access?</strong><br><span class="hint">Tests whether a recovery path exists outside the client's head.</span></div></li><li><div><strong style="color:#F7F7F2">When did you last verify you could actually restore from your backup?</strong><br><span class="hint">Untested backups fail at the worst moment.</span></div></li></ul></div><div class="kit-section"><h2>C. Continuity and estate</h2><ul class="check-list"><li><div><strong style="color:#F7F7F2">If you were incapacitated next month, who would know what exists and what to do first?</strong><br><span class="hint">The continuity question. Most clients answer 'nobody', and that is the finding.</span></div></li><li><div><strong style="color:#F7F7F2">Do your estate documents mention digital assets without exposing any key material?</strong><br><span class="hint">Documents should carry authority and process, never keys.</span></div></li><li><div><strong style="color:#F7F7F2">Does your executor or trustee know Bitcoin is part of the estate?</strong><br><span class="hint">An unprepared fiduciary is a delay or a loss waiting to happen.</span></div></li><li><div><strong style="color:#F7F7F2">Are heirs prepared for their roles without holding dangerous access today?</strong><br><span class="hint">Readiness without premature access is the goal.</span></div></li><li><div><strong style="color:#F7F7F2">Is there a written recovery process, and where does it live?</strong><br><span class="hint">Process, not keys: what exists, who helps, in what order.</span></div></li></ul></div><div class="kit-section"><h2>D. Records and tax awareness</h2><ul class="check-list"><li><div><strong style="color:#F7F7F2">Do you have acquisition dates and cost basis for what you hold?</strong><br><span class="hint">Gaps compound. Flag for the client's tax professional; do not give tax conclusions.</span></div></li><li><div><strong style="color:#F7F7F2">Can you distinguish transfers between your own wallets from sales?</strong><br><span class="hint">A common misclassification that a CPA will want cleaned up.</span></div></li><li><div><strong style="color:#F7F7F2">Do you have statements from every exchange you have ever used?</strong><br><span class="hint">Defunct platforms take their records with them.</span></div></li><li><div><strong style="color:#F7F7F2">Any gifts, inheritances, or charitable plans involving Bitcoin?</strong><br><span class="hint">Each has its own documentation trail; route to the right professional.</span></div></li><li><div><strong style="color:#F7F7F2">Who prepares your taxes, and do they know about these holdings?</strong><br><span class="hint">The coordination question that protects everyone.</span></div></li></ul></div>
+  <div class="toolbar"><button type="button" onclick="window.print()">🖨 Print / Save as PDF</button><a href="/institutional/wealth-advisors/kit/">Back to the kit →</a></div>
+<aside class="bsa-boundary-note" role="note">
+  This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
+</aside>
+  <p class="kit-footer">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+
+</body></html>

--- a/institutional/wealth-advisors/kit/client-meeting-script.html
+++ b/institutional/wealth-advisors/kit/client-meeting-script.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Bitcoin-Aware Client Meeting Scripts | BSA Advisor Kit</title>
+<meta name="description" content="Three meeting templates with timing, talking points, and exit criteria: discovery, the custody conversation, and the annual checkpoint. Education only.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/client-meeting-script.html">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>
+.kit-wrap{max-width:780px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.kit-wrap h1{color:var(--color-brand,#FF7A00);font-size:1.6rem;margin:0 0 .4rem}
+.kit-wrap .subtitle{color:#9aa4b2;font-size:.98rem;margin:0 0 1.5rem;line-height:1.6}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}
+.breadcrumb a:hover{color:#FF7A00}
+.kit-section{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.3rem 1.5rem;margin:0 0 1.1rem}
+.kit-section h2{font-size:1.05rem;color:#FF7A00;margin:0 0 .6rem}
+.kit-section h3{font-size:.92rem;color:#F7F7F2;margin:1rem 0 .4rem}
+.kit-section p,.kit-section li{color:#b3b3b3;line-height:1.65;font-size:.94rem}
+.kit-section ul,.kit-section ol{margin:.4rem 0;padding-left:1.3rem}
+.kit-section .hint{color:#777;font-size:.85rem;font-style:italic}
+.check-list{list-style:none;padding-left:0}
+.check-list li{padding:.45rem 0;border-bottom:1px solid #1c1f24;display:flex;gap:.6rem;align-items:flex-start}
+.check-list li::before{content:"☐";color:#FF7A00;font-size:1.05rem;line-height:1.4}
+.fill{border-bottom:1px dotted #555;display:inline-block;min-width:180px}
+.say{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #28a745;border-radius:8px;padding:.9rem 1rem;color:#d8d8d2;font-style:italic;line-height:1.6;font-size:.93rem;margin:.5rem 0}
+.warn{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #f59e0b;border-radius:8px;padding:.9rem 1rem;color:#b3b3b3;line-height:1.6;font-size:.9rem;margin:.5rem 0}
+.toolbar{margin:1.5rem 0;text-align:center}
+.toolbar button,.toolbar a{display:inline-block;background:transparent;border:2px solid rgba(255,122,0,.45);color:#FF7A00;font-weight:700;border-radius:10px;padding:.55rem 1.2rem;cursor:pointer;font-size:.88rem;font-family:inherit;text-decoration:none;margin:.25rem}
+.kit-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem}
+.kit-footer a{color:#999}
+table.score{width:100%;border-collapse:collapse;font-size:.88rem}
+table.score th{text-align:left;padding:.5rem .6rem;border-bottom:2px solid #2a2a2a;color:#FF7A00}
+table.score td{padding:.5rem .6rem;border-bottom:1px solid #22262e;color:#b3b3b3;vertical-align:top}
+table.score select{background:#16181C;border:1px solid #2a2a2a;color:#F7F7F2;border-radius:6px;padding:.3rem}
+@media(max-width:600px){.kit-wrap{padding:1.25rem 1rem 3rem}}
+@media print{
+  body{background:#fff!important;color:#111!important}
+  .breadcrumb,.toolbar,.kit-footer{display:none!important}
+  .kit-section{background:#fff;border-color:#bbb;break-inside:avoid}
+  .kit-section p,.kit-section li,.say,.warn{color:#222!important}
+  .kit-section h2{color:#000}
+  .bsa-boundary-note{background:#fff!important;color:#333!important;border-color:#999!important}
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="kit-wrap" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/institutional/wealth-advisors/">For Professional Advisors</a> › <a href="/institutional/wealth-advisors/kit/">Advisor Kit</a> › <span>Meeting scripts</span></div>
+  <h1>Bitcoin-Aware Client Meeting Scripts</h1>
+  <p class="subtitle">Three meetings, each with a goal, a clock, and an exit criterion. The quoted lines are starting points to adapt, not lines to read.</p>
+<div class="kit-section"><h2>Meeting 1 — Discovery (30 minutes)</h2>
+<p class="hint">Goal: a complete, honest inventory. Exit when section A and B of the questionnaire are answered.</p>
+<ul><li><strong style="color:#F7F7F2">Open (2 min):</strong></li></ul>
+<div class="say">"Clients have started bringing Bitcoin into planning conversations, so I've added a few standing questions. Most people have never been asked these, and a few answers usually surprise both of us."</div>
+<ul><li><strong style="color:#F7F7F2">Work (25 min):</strong> run the <a href="/institutional/wealth-advisors/kit/client-discovery-questionnaire.html" style="color:#FF9A00;">discovery questionnaire</a>, sections A and B. Write answers down in front of the client.</li>
+<li><strong style="color:#F7F7F2">Close (3 min):</strong> name one gap, assign no blame, book the custody conversation.</li></ul></div>
+<div class="kit-section"><h2>Meeting 2 — The custody conversation (45 minutes)</h2>
+<p class="hint">Goal: client sees their own holdings in lanes and owns the follow-ups. Exit when the worksheet has an owner per row.</p>
+<ul><li><strong style="color:#F7F7F2">Open (5 min):</strong> recap the inventory, no judgment.</li>
+<li><strong style="color:#F7F7F2">Work (30 min):</strong> the <a href="/institutional/wealth-advisors/kit/custody-lanes-worksheet.html" style="color:#FF9A00;">custody lanes worksheet</a>, one holding at a time. Use "who controls access" and "who could help recover" on every row.</li>
+<li><strong style="color:#F7F7F2">Boundary (5 min):</strong></li></ul>
+<div class="say">"My job is to make sure every holding has a documented plan and the right professional attached. Designing the custody itself is specialist work, and I'll connect you when we get there."</div>
+<ul><li><strong style="color:#F7F7F2">Close (5 min):</strong> score the <a href="/institutional/wealth-advisors/kit/recovery-readiness-scorecard.html" style="color:#FF9A00;">scorecard</a> together; the two lowest dimensions become the agenda.</li></ul></div>
+<div class="kit-section"><h2>Meeting 3 — Annual checkpoint (20 minutes)</h2>
+<p class="hint">Goal: verify, not assume. Exit with a re-scored card and any changes routed.</p>
+<ul><li>Anything new, moved, sold, gifted, or inherited this year?</li>
+<li>Re-score the card; compare with last year in the file.</li>
+<li>Did anyone new see backups or key material? If yes, route to the red-flag protocol.</li>
+<li>Documents updated? Fiduciary still aware and willing?</li>
+<li>Confirm the specialist, CPA, and counsel contacts are current.</li></ul></div>
+  <div class="toolbar"><button type="button" onclick="window.print()">🖨 Print / Save as PDF</button><a href="/institutional/wealth-advisors/kit/">Back to the kit →</a></div>
+<aside class="bsa-boundary-note" role="note">
+  This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
+</aside>
+  <p class="kit-footer">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+
+</body></html>

--- a/institutional/wealth-advisors/kit/custody-lanes-worksheet.html
+++ b/institutional/wealth-advisors/kit/custody-lanes-worksheet.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Custody Lanes Worksheet | BSA Advisor Kit</title>
+<meta name="description" content="Map each client holding to a custody lane and capture who controls access and who can help recover. Education only.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/custody-lanes-worksheet.html">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>
+.kit-wrap{max-width:780px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.kit-wrap h1{color:var(--color-brand,#FF7A00);font-size:1.6rem;margin:0 0 .4rem}
+.kit-wrap .subtitle{color:#9aa4b2;font-size:.98rem;margin:0 0 1.5rem;line-height:1.6}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}
+.breadcrumb a:hover{color:#FF7A00}
+.kit-section{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.3rem 1.5rem;margin:0 0 1.1rem}
+.kit-section h2{font-size:1.05rem;color:#FF7A00;margin:0 0 .6rem}
+.kit-section h3{font-size:.92rem;color:#F7F7F2;margin:1rem 0 .4rem}
+.kit-section p,.kit-section li{color:#b3b3b3;line-height:1.65;font-size:.94rem}
+.kit-section ul,.kit-section ol{margin:.4rem 0;padding-left:1.3rem}
+.kit-section .hint{color:#777;font-size:.85rem;font-style:italic}
+.check-list{list-style:none;padding-left:0}
+.check-list li{padding:.45rem 0;border-bottom:1px solid #1c1f24;display:flex;gap:.6rem;align-items:flex-start}
+.check-list li::before{content:"☐";color:#FF7A00;font-size:1.05rem;line-height:1.4}
+.fill{border-bottom:1px dotted #555;display:inline-block;min-width:180px}
+.say{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #28a745;border-radius:8px;padding:.9rem 1rem;color:#d8d8d2;font-style:italic;line-height:1.6;font-size:.93rem;margin:.5rem 0}
+.warn{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #f59e0b;border-radius:8px;padding:.9rem 1rem;color:#b3b3b3;line-height:1.6;font-size:.9rem;margin:.5rem 0}
+.toolbar{margin:1.5rem 0;text-align:center}
+.toolbar button,.toolbar a{display:inline-block;background:transparent;border:2px solid rgba(255,122,0,.45);color:#FF7A00;font-weight:700;border-radius:10px;padding:.55rem 1.2rem;cursor:pointer;font-size:.88rem;font-family:inherit;text-decoration:none;margin:.25rem}
+.kit-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem}
+.kit-footer a{color:#999}
+table.score{width:100%;border-collapse:collapse;font-size:.88rem}
+table.score th{text-align:left;padding:.5rem .6rem;border-bottom:2px solid #2a2a2a;color:#FF7A00}
+table.score td{padding:.5rem .6rem;border-bottom:1px solid #22262e;color:#b3b3b3;vertical-align:top}
+table.score select{background:#16181C;border:1px solid #2a2a2a;color:#F7F7F2;border-radius:6px;padding:.3rem}
+@media(max-width:600px){.kit-wrap{padding:1.25rem 1rem 3rem}}
+@media print{
+  body{background:#fff!important;color:#111!important}
+  .breadcrumb,.toolbar,.kit-footer{display:none!important}
+  .kit-section{background:#fff;border-color:#bbb;break-inside:avoid}
+  .kit-section p,.kit-section li,.say,.warn{color:#222!important}
+  .kit-section h2{color:#000}
+  .bsa-boundary-note{background:#fff!important;color:#333!important;border-color:#999!important}
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="kit-wrap" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/institutional/wealth-advisors/">For Professional Advisors</a> › <a href="/institutional/wealth-advisors/kit/">Advisor Kit</a> › <span>Custody lanes</span></div>
+  <h1>Custody Lanes Worksheet</h1>
+  <p class="subtitle">A one-page mapping exercise to run with the client across the desk. "Who owns it" and "who can move it" get separate answers for every holding.</p>
+<div class="kit-section"><h2>How to use this worksheet</h2>
+<p>For each holding the discovery questionnaire surfaced, place it in a lane and answer the two questions that matter: who controls access, and who could help recover it. Then note the follow-up. The full comparison lives in the <a href="/institutional/wealth-advisors/bitcoin-advisor-certification/advisor-toolkit.html#custody-comparison-table" style="color:#FF9A00;">Custody Lanes at a Glance</a> table.</p></div>
+<div class="kit-section"><h2>The four lanes, one line each</h2>
+<ul>
+<li><strong style="color:#F7F7F2">Bitcoin ETF</strong> — exposure on brokerage rails; no direct coin access; counterparty and fund-structure risk.</li>
+<li><strong style="color:#F7F7F2">Exchange account</strong> — platform holds the keys; convenience with counterparty risk and a platform-dependent estate process.</li>
+<li><strong style="color:#F7F7F2">Self custody</strong> — client alone holds keys; maximum control, and no recovery if keys and backups are lost.</li>
+<li><strong style="color:#F7F7F2">Collaborative custody</strong> — client remains the legal owner and initiates transactions; signing authority is distributed across independent parties, designed to reduce single points of failure.</li>
+</ul></div>
+<div class="kit-section"><h2>Per-holding worksheet</h2><p class="hint">Print one block per holding.</p>
+<p>Holding / where: <span class="fill"></span>&nbsp;&nbsp;Lane: <span class="fill"></span></p>
+<p>Who controls access today: <span class="fill"></span></p>
+<p>Who could help recover it: <span class="fill"></span></p>
+<p>What worries the client most about it: <span class="fill"></span></p>
+<p>Documented anywhere? Where: <span class="fill"></span></p>
+<p>Follow-up owner (client / advisor / specialist / CPA / counsel): <span class="fill"></span></p></div>
+<div class="kit-section"><h2>Three discussion prompts that move the meeting</h2>
+<ul><li>"If this platform froze withdrawals for a month, what would change for you?"</li>
+<li>"Who would your family call first, and would that person know what to do?"</li>
+<li>"Is there a single person, device, or place that everything depends on?"</li></ul></div>
+  <div class="toolbar"><button type="button" onclick="window.print()">🖨 Print / Save as PDF</button><a href="/institutional/wealth-advisors/kit/">Back to the kit →</a></div>
+<aside class="bsa-boundary-note" role="note">
+  This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
+</aside>
+  <p class="kit-footer">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+
+</body></html>

--- a/institutional/wealth-advisors/kit/engagement-letter-language.html
+++ b/institutional/wealth-advisors/kit/engagement-letter-language.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Engagement-Letter and Boundary Language | BSA Advisor Kit</title>
+<meta name="description" content="Sample educational scope, key-material, and referral clauses for advisor engagement letters. Samples for counsel review, not legal advice.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/engagement-letter-language.html">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>
+.kit-wrap{max-width:780px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.kit-wrap h1{color:var(--color-brand,#FF7A00);font-size:1.6rem;margin:0 0 .4rem}
+.kit-wrap .subtitle{color:#9aa4b2;font-size:.98rem;margin:0 0 1.5rem;line-height:1.6}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}
+.breadcrumb a:hover{color:#FF7A00}
+.kit-section{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.3rem 1.5rem;margin:0 0 1.1rem}
+.kit-section h2{font-size:1.05rem;color:#FF7A00;margin:0 0 .6rem}
+.kit-section h3{font-size:.92rem;color:#F7F7F2;margin:1rem 0 .4rem}
+.kit-section p,.kit-section li{color:#b3b3b3;line-height:1.65;font-size:.94rem}
+.kit-section ul,.kit-section ol{margin:.4rem 0;padding-left:1.3rem}
+.kit-section .hint{color:#777;font-size:.85rem;font-style:italic}
+.check-list{list-style:none;padding-left:0}
+.check-list li{padding:.45rem 0;border-bottom:1px solid #1c1f24;display:flex;gap:.6rem;align-items:flex-start}
+.check-list li::before{content:"☐";color:#FF7A00;font-size:1.05rem;line-height:1.4}
+.fill{border-bottom:1px dotted #555;display:inline-block;min-width:180px}
+.say{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #28a745;border-radius:8px;padding:.9rem 1rem;color:#d8d8d2;font-style:italic;line-height:1.6;font-size:.93rem;margin:.5rem 0}
+.warn{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #f59e0b;border-radius:8px;padding:.9rem 1rem;color:#b3b3b3;line-height:1.6;font-size:.9rem;margin:.5rem 0}
+.toolbar{margin:1.5rem 0;text-align:center}
+.toolbar button,.toolbar a{display:inline-block;background:transparent;border:2px solid rgba(255,122,0,.45);color:#FF7A00;font-weight:700;border-radius:10px;padding:.55rem 1.2rem;cursor:pointer;font-size:.88rem;font-family:inherit;text-decoration:none;margin:.25rem}
+.kit-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem}
+.kit-footer a{color:#999}
+table.score{width:100%;border-collapse:collapse;font-size:.88rem}
+table.score th{text-align:left;padding:.5rem .6rem;border-bottom:2px solid #2a2a2a;color:#FF7A00}
+table.score td{padding:.5rem .6rem;border-bottom:1px solid #22262e;color:#b3b3b3;vertical-align:top}
+table.score select{background:#16181C;border:1px solid #2a2a2a;color:#F7F7F2;border-radius:6px;padding:.3rem}
+@media(max-width:600px){.kit-wrap{padding:1.25rem 1rem 3rem}}
+@media print{
+  body{background:#fff!important;color:#111!important}
+  .breadcrumb,.toolbar,.kit-footer{display:none!important}
+  .kit-section{background:#fff;border-color:#bbb;break-inside:avoid}
+  .kit-section p,.kit-section li,.say,.warn{color:#222!important}
+  .kit-section h2{color:#000}
+  .bsa-boundary-note{background:#fff!important;color:#333!important;border-color:#999!important}
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="kit-wrap" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/institutional/wealth-advisors/">For Professional Advisors</a> › <a href="/institutional/wealth-advisors/kit/">Advisor Kit</a> › <span>Engagement language</span></div>
+  <h1>Engagement-Letter and Boundary Language</h1>
+  <p class="subtitle">Four pieces of sample language that draw the educational boundary in writing. Every one of them goes through your counsel before use.</p>
+<div class="kit-section"><h2>How to use this page</h2>
+<div class="warn"><strong style="color:#F7F7F2">These are educational samples, not legal drafting.</strong> Bring them to your own counsel and compliance team and have them adapted to your firm, jurisdiction, and registration status before any client sees them.</div></div>
+<div class="kit-section"><h2>Sample clause: scope of Bitcoin-related work</h2>
+<div class="say">"Advisor may provide general educational information regarding Bitcoin, digital-asset custody models, and continuity planning considerations. Advisor does not provide custody, key-management, technical implementation, tax, or legal services with respect to digital assets, and nothing in this engagement shall be construed as a recommendation to purchase, sell, or hold any digital asset."</div></div>
+<div class="kit-section"><h2>Sample clause: key material</h2>
+<div class="say">"Client agrees that Advisor will not request, accept, view, or store private keys, seed phrases, wallet backups, or equivalent credentials under any circumstances. Client remains solely responsible for the safekeeping of such materials."</div></div>
+<div class="kit-section"><h2>Sample clause: referrals and coordination</h2>
+<div class="say">"Where Client requires custody design, recovery, inheritance implementation, or technical support for digital assets, Advisor may, with Client's consent, coordinate introductions to qualified third-party specialists. Such specialists are engaged directly by Client, and Advisor assumes no responsibility for their services."</div></div>
+<div class="kit-section"><h2>Sample file note (after any Bitcoin conversation)</h2>
+<div class="say">"Discussed [topic] in general educational terms. No recommendation made regarding purchase, sale, custody design, or movement of digital assets. Declined to [receive/store/view] [item], consistent with firm policy. Referred [matter] to [professional]."</div></div>
+  <div class="toolbar"><button type="button" onclick="window.print()">🖨 Print / Save as PDF</button><a href="/institutional/wealth-advisors/kit/">Back to the kit →</a></div>
+<aside class="bsa-boundary-note" role="note">
+  This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
+</aside>
+  <p class="kit-footer">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+
+</body></html>

--- a/institutional/wealth-advisors/kit/index.html
+++ b/institutional/wealth-advisors/kit/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Advisor Readiness Kit | BSA</title>
+<meta name="description" content="HTML-first templates for professional advisors: discovery questionnaire, custody lanes worksheet, recovery scorecard, red-flag protocol, handoff memo, meeting scripts, boundary checklist, engagement language.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>
+.kit-wrap{max-width:860px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.kit-wrap h1{color:var(--color-brand,#FF7A00);font-size:1.7rem;margin:0 0 .4rem}
+.kit-wrap .subtitle{color:#9aa4b2;font-size:1rem;margin:0 0 2rem;line-height:1.6}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}
+.kit-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem}
+.kit-card{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.2rem 1.3rem;text-decoration:none;display:block}
+.kit-card:hover{border-color:rgba(255,122,0,.5)}
+.kit-card h2{font-size:1rem;color:#FF7A00;margin:0 0 .4rem}
+.kit-card p{color:#b3b3b3;font-size:.9rem;line-height:1.55;margin:0}
+.kit-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem}
+.kit-footer a{color:#999}
+@media(max-width:600px){.kit-wrap{padding:1.25rem 1rem 3rem}}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="kit-wrap" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/institutional/wealth-advisors/">For Professional Advisors</a> › <span>Advisor Kit</span></div>
+  <h1>Advisor Readiness Kit</h1>
+  <p class="subtitle">Eight working templates for the advisor side of a Bitcoin client conversation. Every page is printable, copy-friendly, and built around one rule: advisors guide and document; specialists implement.</p>
+  <div class="kit-grid">
+  <a class="kit-card" href="/institutional/wealth-advisors/kit/client-discovery-questionnaire.html"><h2>Client Discovery Questionnaire</h2><p>Twenty intake questions across existence, custody, continuity, and records.</p></a>
+  <a class="kit-card" href="/institutional/wealth-advisors/kit/custody-lanes-worksheet.html"><h2>Custody Lanes Worksheet</h2><p>Map each holding: who controls access, who could help recover.</p></a>
+  <a class="kit-card" href="/institutional/wealth-advisors/kit/recovery-readiness-scorecard.html"><h2>Recovery-Readiness Scorecard</h2><p>Nine dimensions, 1 to 5, with honest anchors and next-step bands.</p></a>
+  <a class="kit-card" href="/institutional/wealth-advisors/kit/seed-phrase-red-flag-protocol.html"><h2>Seed Phrase Red-Flag Protocol</h2><p>The never-handle-keys rule, the warning signs, and the decline scripts.</p></a>
+  <a class="kit-card" href="/institutional/wealth-advisors/kit/specialist-handoff-memo.html"><h2>Specialist Handoff Memo</h2><p>A one-page referral memo that documents your boundary while briefing the specialist.</p></a>
+  <a class="kit-card" href="/institutional/wealth-advisors/kit/client-meeting-script.html"><h2>Client Meeting Scripts</h2><p>Three meetings with timing, talking points, and exit criteria.</p></a>
+  <a class="kit-card" href="/institutional/wealth-advisors/kit/advisor-role-boundary-checklist.html"><h2>Advisor Role-Boundary Checklist</h2><p>The do and do-not lists that resolve every uncomfortable moment.</p></a>
+  <a class="kit-card" href="/institutional/wealth-advisors/kit/engagement-letter-language.html"><h2>Engagement-Letter Language</h2><p>Sample boundary clauses for your counsel to adapt.</p></a>
+  </div>
+  <aside class="bsa-boundary-note" role="note">
+    This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
+  </aside>
+  <p class="kit-footer">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+</body></html>

--- a/institutional/wealth-advisors/kit/recovery-readiness-scorecard.html
+++ b/institutional/wealth-advisors/kit/recovery-readiness-scorecard.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Recovery-Readiness Scorecard | BSA Advisor Kit</title>
+<meta name="description" content="Score a client across nine recovery dimensions, 1 to 5 each, with honest anchors and band interpretations. Education only.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/recovery-readiness-scorecard.html">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>
+.kit-wrap{max-width:780px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.kit-wrap h1{color:var(--color-brand,#FF7A00);font-size:1.6rem;margin:0 0 .4rem}
+.kit-wrap .subtitle{color:#9aa4b2;font-size:.98rem;margin:0 0 1.5rem;line-height:1.6}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}
+.breadcrumb a:hover{color:#FF7A00}
+.kit-section{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.3rem 1.5rem;margin:0 0 1.1rem}
+.kit-section h2{font-size:1.05rem;color:#FF7A00;margin:0 0 .6rem}
+.kit-section h3{font-size:.92rem;color:#F7F7F2;margin:1rem 0 .4rem}
+.kit-section p,.kit-section li{color:#b3b3b3;line-height:1.65;font-size:.94rem}
+.kit-section ul,.kit-section ol{margin:.4rem 0;padding-left:1.3rem}
+.kit-section .hint{color:#777;font-size:.85rem;font-style:italic}
+.check-list{list-style:none;padding-left:0}
+.check-list li{padding:.45rem 0;border-bottom:1px solid #1c1f24;display:flex;gap:.6rem;align-items:flex-start}
+.check-list li::before{content:"☐";color:#FF7A00;font-size:1.05rem;line-height:1.4}
+.fill{border-bottom:1px dotted #555;display:inline-block;min-width:180px}
+.say{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #28a745;border-radius:8px;padding:.9rem 1rem;color:#d8d8d2;font-style:italic;line-height:1.6;font-size:.93rem;margin:.5rem 0}
+.warn{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #f59e0b;border-radius:8px;padding:.9rem 1rem;color:#b3b3b3;line-height:1.6;font-size:.9rem;margin:.5rem 0}
+.toolbar{margin:1.5rem 0;text-align:center}
+.toolbar button,.toolbar a{display:inline-block;background:transparent;border:2px solid rgba(255,122,0,.45);color:#FF7A00;font-weight:700;border-radius:10px;padding:.55rem 1.2rem;cursor:pointer;font-size:.88rem;font-family:inherit;text-decoration:none;margin:.25rem}
+.kit-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem}
+.kit-footer a{color:#999}
+table.score{width:100%;border-collapse:collapse;font-size:.88rem}
+table.score th{text-align:left;padding:.5rem .6rem;border-bottom:2px solid #2a2a2a;color:#FF7A00}
+table.score td{padding:.5rem .6rem;border-bottom:1px solid #22262e;color:#b3b3b3;vertical-align:top}
+table.score select{background:#16181C;border:1px solid #2a2a2a;color:#F7F7F2;border-radius:6px;padding:.3rem}
+@media(max-width:600px){.kit-wrap{padding:1.25rem 1rem 3rem}}
+@media print{
+  body{background:#fff!important;color:#111!important}
+  .breadcrumb,.toolbar,.kit-footer{display:none!important}
+  .kit-section{background:#fff;border-color:#bbb;break-inside:avoid}
+  .kit-section p,.kit-section li,.say,.warn{color:#222!important}
+  .kit-section h2{color:#000}
+  .bsa-boundary-note{background:#fff!important;color:#333!important;border-color:#999!important}
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="kit-wrap" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/institutional/wealth-advisors/">For Professional Advisors</a> › <a href="/institutional/wealth-advisors/kit/">Advisor Kit</a> › <span>Scorecard</span></div>
+  <h1>Recovery-Readiness Scorecard</h1>
+  <p class="subtitle">A defensible 1-to-5 score across nine recovery dimensions. One page for the client file; the bands tell you what to do next, not what to promise.</p>
+<div class="kit-section"><h2>Nine dimensions, scored 1 to 5</h2>
+<p>Score from the client's answers, not from optimism. The anchors describe a 1 and a 5; place the client honestly between them.</p>
+<div style="overflow-x:auto;"><table class="score"><thead><tr><th>Dimension</th><th>Anchors</th><th>Score</th></tr></thead><tbody><tr><td><strong style="color:#F7F7F2">Existence map</strong></td><td><span class="hint">1 = Nobody but the client knows what exists or where</span><br><span class="hint">5 = A current written inventory exists and a second person knows where it lives</span></td><td><select class="dim" aria-label="Existence map score"><option value="">–</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></td></tr><tr><td><strong style="color:#F7F7F2">Access continuity</strong></td><td><span class="hint">1 = Only the client can act; no plan for incapacity</span><br><span class="hint">5 = A defined path exists for incapacity that exposes no key material</span></td><td><select class="dim" aria-label="Access continuity score"><option value="">–</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></td></tr><tr><td><strong style="color:#F7F7F2">Backup integrity</strong></td><td><span class="hint">1 = Backups unverified or location unknown</span><br><span class="hint">5 = Backups exist, are separated from devices, and were tested within the year</span></td><td><select class="dim" aria-label="Backup integrity score"><option value="">–</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></td></tr><tr><td><strong style="color:#F7F7F2">Key exposure</strong></td><td><span class="hint">1 = Seed phrase has been seen, photographed, or stored by others</span><br><span class="hint">5 = No one but the client has ever seen key material</span></td><td><select class="dim" aria-label="Key exposure score"><option value="">–</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></td></tr><tr><td><strong style="color:#F7F7F2">Estate documents</strong></td><td><span class="hint">1 = Documents silent on digital assets, or worse, contain keys</span><br><span class="hint">5 = Documents grant authority and reference a process; zero key material</span></td><td><select class="dim" aria-label="Estate documents score"><option value="">–</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></td></tr><tr><td><strong style="color:#F7F7F2">Fiduciary readiness</strong></td><td><span class="hint">1 = Executor or trustee unaware Bitcoin exists</span><br><span class="hint">5 = Fiduciary knows the role, the contacts, and the first step</span></td><td><select class="dim" aria-label="Fiduciary readiness score"><option value="">–</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></td></tr><tr><td><strong style="color:#F7F7F2">Family preparedness</strong></td><td><span class="hint">1 = Heirs either know nothing or hold premature access</span><br><span class="hint">5 = Heirs understand roles and sequence without holding live access</span></td><td><select class="dim" aria-label="Family preparedness score"><option value="">–</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></td></tr><tr><td><strong style="color:#F7F7F2">Records and basis</strong></td><td><span class="hint">1 = No acquisition records; platforms forgotten</span><br><span class="hint">5 = Cost basis, dates, and statements organized for the tax professional</span></td><td><select class="dim" aria-label="Records and basis score"><option value="">–</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></td></tr><tr><td><strong style="color:#F7F7F2">Professional bench</strong></td><td><span class="hint">1 = No specialist, CPA, or counsel identified</span><br><span class="hint">5 = Named custody specialist, CPA, and counsel, and they know of each other</span></td><td><select class="dim" aria-label="Professional bench score"><option value="">–</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option></select></td></tr></tbody></table></div>
+<p style="margin-top:1rem;"><strong style="color:#F7F7F2">Total: <span id="total">–</span> / 45</strong> &nbsp; <span id="band" class="hint"></span></p></div>
+<div class="kit-section"><h2>Reading the bands</h2>
+<ul><li><strong style="color:#F7F7F2">9–18:</strong> fragile. One accident from loss. The kindest next step is a specialist conversation soon.</li>
+<li><strong style="color:#F7F7F2">19–32:</strong> partial. The usual profile. Pick the two lowest dimensions and assign owners.</li>
+<li><strong style="color:#F7F7F2">33–45:</strong> prepared. Maintain with an annual checkpoint; verify rather than assume.</li></ul>
+<p class="hint">The score is a conversation tool, not a certification, rating, or guarantee of any outcome.</p></div>
+  <div class="toolbar"><button type="button" onclick="window.print()">🖨 Print / Save as PDF</button><a href="/institutional/wealth-advisors/kit/">Back to the kit →</a></div>
+<aside class="bsa-boundary-note" role="note">
+  This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
+</aside>
+  <p class="kit-footer">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+<script>
+(function(){var sels=document.querySelectorAll('select.dim');
+function upd(){var vals=[].map.call(sels,function(s){return parseInt(s.value,10)||0});
+var done=[].every.call(sels,function(s){return s.value!==''});
+var t=vals.reduce(function(a,b){return a+b},0);
+document.getElementById('total').textContent = done ? t : '–';
+var band='';
+if(done){ band = t<=18 ? 'Fragile: prioritize a specialist conversation.' : t<=32 ? 'Partial: assign owners to the two lowest dimensions.' : 'Prepared: keep an annual checkpoint.'; }
+document.getElementById('band').textContent=band;}
+[].forEach.call(sels,function(s){s.addEventListener('change',upd)});})();
+</script>
+</body></html>

--- a/institutional/wealth-advisors/kit/seed-phrase-red-flag-protocol.html
+++ b/institutional/wealth-advisors/kit/seed-phrase-red-flag-protocol.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Seed Phrase Red-Flag Protocol | BSA Advisor Kit</title>
+<meta name="description" content="The never-handle-keys rule, the red flags that precede it, decline scripts, and the documentation step. Education only.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/seed-phrase-red-flag-protocol.html">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>
+.kit-wrap{max-width:780px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.kit-wrap h1{color:var(--color-brand,#FF7A00);font-size:1.6rem;margin:0 0 .4rem}
+.kit-wrap .subtitle{color:#9aa4b2;font-size:.98rem;margin:0 0 1.5rem;line-height:1.6}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}
+.breadcrumb a:hover{color:#FF7A00}
+.kit-section{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.3rem 1.5rem;margin:0 0 1.1rem}
+.kit-section h2{font-size:1.05rem;color:#FF7A00;margin:0 0 .6rem}
+.kit-section h3{font-size:.92rem;color:#F7F7F2;margin:1rem 0 .4rem}
+.kit-section p,.kit-section li{color:#b3b3b3;line-height:1.65;font-size:.94rem}
+.kit-section ul,.kit-section ol{margin:.4rem 0;padding-left:1.3rem}
+.kit-section .hint{color:#777;font-size:.85rem;font-style:italic}
+.check-list{list-style:none;padding-left:0}
+.check-list li{padding:.45rem 0;border-bottom:1px solid #1c1f24;display:flex;gap:.6rem;align-items:flex-start}
+.check-list li::before{content:"☐";color:#FF7A00;font-size:1.05rem;line-height:1.4}
+.fill{border-bottom:1px dotted #555;display:inline-block;min-width:180px}
+.say{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #28a745;border-radius:8px;padding:.9rem 1rem;color:#d8d8d2;font-style:italic;line-height:1.6;font-size:.93rem;margin:.5rem 0}
+.warn{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #f59e0b;border-radius:8px;padding:.9rem 1rem;color:#b3b3b3;line-height:1.6;font-size:.9rem;margin:.5rem 0}
+.toolbar{margin:1.5rem 0;text-align:center}
+.toolbar button,.toolbar a{display:inline-block;background:transparent;border:2px solid rgba(255,122,0,.45);color:#FF7A00;font-weight:700;border-radius:10px;padding:.55rem 1.2rem;cursor:pointer;font-size:.88rem;font-family:inherit;text-decoration:none;margin:.25rem}
+.kit-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem}
+.kit-footer a{color:#999}
+table.score{width:100%;border-collapse:collapse;font-size:.88rem}
+table.score th{text-align:left;padding:.5rem .6rem;border-bottom:2px solid #2a2a2a;color:#FF7A00}
+table.score td{padding:.5rem .6rem;border-bottom:1px solid #22262e;color:#b3b3b3;vertical-align:top}
+table.score select{background:#16181C;border:1px solid #2a2a2a;color:#F7F7F2;border-radius:6px;padding:.3rem}
+@media(max-width:600px){.kit-wrap{padding:1.25rem 1rem 3rem}}
+@media print{
+  body{background:#fff!important;color:#111!important}
+  .breadcrumb,.toolbar,.kit-footer{display:none!important}
+  .kit-section{background:#fff;border-color:#bbb;break-inside:avoid}
+  .kit-section p,.kit-section li,.say,.warn{color:#222!important}
+  .kit-section h2{color:#000}
+  .bsa-boundary-note{background:#fff!important;color:#333!important;border-color:#999!important}
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="kit-wrap" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/institutional/wealth-advisors/">For Professional Advisors</a> › <a href="/institutional/wealth-advisors/kit/">Advisor Kit</a> › <span>Red-flag protocol</span></div>
+  <h1>Seed Phrase Red-Flag Protocol</h1>
+  <p class="subtitle">Print this. The moment it covers arrives without warning, usually from a well-meaning client, and the prepared answer is always the same.</p>
+<div class="kit-section"><h2>The rule</h2>
+<p><strong style="color:#F7F7F2">A professional never asks for, accepts, reads, photographs, or stores a client's seed phrase or private keys.</strong> Not in a file, an estate binder, a sealed envelope, an email, a photo, or a phone call. No exceptions for size, trust, or urgency.</p></div>
+<div class="kit-section"><h2>Red flags that the line is approaching</h2>
+<ul class="check-list">
+<li>The client offers to share the words "so someone responsible has a copy"</li>
+<li>An estate draft wants the phrase appended "for the executor"</li>
+<li>Staff offer to photograph or scan a backup card "for the file"</li>
+<li>A family member asks you to walk them through access during a crisis</li>
+<li>A sealed "do not open" envelope is offered for the firm safe</li>
+<li>A screen-share where a wallet, QR code, or word list could appear</li>
+<li>A found device after a death, with pressure to "just move it somewhere safe"</li></ul></div>
+<div class="kit-section"><h2>Decline scripts</h2>
+<div class="say">"I'm going to stop you before you show me that. Anyone who has seen those words is a permanent risk to you, and that should never include me. Let's build you a recovery process that doesn't expose them to anyone."</div>
+<div class="say">"The binder should say what exists and who to call, never the words themselves. Documents get copied and read by more people than we will ever meet."</div>
+<div class="say">"Nobody touches the device and nobody types anything. We secure it physically, write down who has seen what, and bring in a custody specialist before anything moves."</div></div>
+<div class="kit-section"><h2>After declining: document it</h2>
+<ul><li>Date, what was offered or requested, and that you declined</li>
+<li>What you advised instead, in one sentence</li>
+<li>Which professional the matter was referred to, if any</li></ul>
+<div class="warn">The note protects the client and you. Practice the moment before it happens: the interactive version of this protocol is the <a href="/institutional/wealth-advisors/tools/seed-phrase-red-flags.html" style="color:#FF9A00;">Seed Phrase Red Flags activity</a>.</div></div>
+  <div class="toolbar"><button type="button" onclick="window.print()">🖨 Print / Save as PDF</button><a href="/institutional/wealth-advisors/kit/">Back to the kit →</a></div>
+<aside class="bsa-boundary-note" role="note">
+  This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
+</aside>
+  <p class="kit-footer">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+
+</body></html>

--- a/institutional/wealth-advisors/kit/specialist-handoff-memo.html
+++ b/institutional/wealth-advisors/kit/specialist-handoff-memo.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Specialist Handoff Memo | BSA Advisor Kit</title>
+<meta name="description" content="A one-page referral memo template: situation, what the advisor did and deliberately did not do, open questions, coordination. Education only.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/specialist-handoff-memo.html">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>
+.kit-wrap{max-width:780px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.kit-wrap h1{color:var(--color-brand,#FF7A00);font-size:1.6rem;margin:0 0 .4rem}
+.kit-wrap .subtitle{color:#9aa4b2;font-size:.98rem;margin:0 0 1.5rem;line-height:1.6}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}
+.breadcrumb a:hover{color:#FF7A00}
+.kit-section{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.3rem 1.5rem;margin:0 0 1.1rem}
+.kit-section h2{font-size:1.05rem;color:#FF7A00;margin:0 0 .6rem}
+.kit-section h3{font-size:.92rem;color:#F7F7F2;margin:1rem 0 .4rem}
+.kit-section p,.kit-section li{color:#b3b3b3;line-height:1.65;font-size:.94rem}
+.kit-section ul,.kit-section ol{margin:.4rem 0;padding-left:1.3rem}
+.kit-section .hint{color:#777;font-size:.85rem;font-style:italic}
+.check-list{list-style:none;padding-left:0}
+.check-list li{padding:.45rem 0;border-bottom:1px solid #1c1f24;display:flex;gap:.6rem;align-items:flex-start}
+.check-list li::before{content:"☐";color:#FF7A00;font-size:1.05rem;line-height:1.4}
+.fill{border-bottom:1px dotted #555;display:inline-block;min-width:180px}
+.say{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #28a745;border-radius:8px;padding:.9rem 1rem;color:#d8d8d2;font-style:italic;line-height:1.6;font-size:.93rem;margin:.5rem 0}
+.warn{background:#16181C;border:1px solid #2a2a2a;border-left:3px solid #f59e0b;border-radius:8px;padding:.9rem 1rem;color:#b3b3b3;line-height:1.6;font-size:.9rem;margin:.5rem 0}
+.toolbar{margin:1.5rem 0;text-align:center}
+.toolbar button,.toolbar a{display:inline-block;background:transparent;border:2px solid rgba(255,122,0,.45);color:#FF7A00;font-weight:700;border-radius:10px;padding:.55rem 1.2rem;cursor:pointer;font-size:.88rem;font-family:inherit;text-decoration:none;margin:.25rem}
+.kit-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem}
+.kit-footer a{color:#999}
+table.score{width:100%;border-collapse:collapse;font-size:.88rem}
+table.score th{text-align:left;padding:.5rem .6rem;border-bottom:2px solid #2a2a2a;color:#FF7A00}
+table.score td{padding:.5rem .6rem;border-bottom:1px solid #22262e;color:#b3b3b3;vertical-align:top}
+table.score select{background:#16181C;border:1px solid #2a2a2a;color:#F7F7F2;border-radius:6px;padding:.3rem}
+@media(max-width:600px){.kit-wrap{padding:1.25rem 1rem 3rem}}
+@media print{
+  body{background:#fff!important;color:#111!important}
+  .breadcrumb,.toolbar,.kit-footer{display:none!important}
+  .kit-section{background:#fff;border-color:#bbb;break-inside:avoid}
+  .kit-section p,.kit-section li,.say,.warn{color:#222!important}
+  .kit-section h2{color:#000}
+  .bsa-boundary-note{background:#fff!important;color:#333!important;border-color:#999!important}
+}
+</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="kit-wrap" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> › <a href="/institutional/wealth-advisors/">For Professional Advisors</a> › <a href="/institutional/wealth-advisors/kit/">Advisor Kit</a> › <span>Handoff memo</span></div>
+  <h1>Specialist Handoff Memo</h1>
+  <p class="subtitle">The clean handoff is the advisor's best work product. This template keeps your role documented and the specialist fully briefed without a single dangerous detail.</p>
+<div class="kit-section"><h2>When to send this memo</h2>
+<p>Real custody, inheritance, recovery, or technical setup work has entered the conversation. Your role is to frame the situation cleanly for the specialist and to document the boundary of what you did. One page, no key material, ever.</p></div>
+<div class="kit-section"><h2>Memo template</h2>
+<p>Date: <span class="fill"></span>&nbsp;&nbsp;From (advisor/firm): <span class="fill"></span></p>
+<p>To (specialist): <span class="fill"></span>&nbsp;&nbsp;Client (with consent): <span class="fill"></span></p>
+<h3>Situation in three sentences</h3>
+<p><span class="fill" style="min-width:100%"></span></p><p><span class="fill" style="min-width:100%"></span></p>
+<h3>What the advisor has done</h3>
+<ul><li>Discovery questionnaire completed on: <span class="fill"></span></li>
+<li>Recovery-readiness score and two lowest dimensions: <span class="fill"></span></li>
+<li>Education provided (topics, no recommendations): <span class="fill"></span></li></ul>
+<h3>What the advisor has deliberately not done</h3>
+<ul><li>No key material seen, held, or stored</li><li>No custody design or technical instructions given</li><li>No tax or legal conclusions offered</li></ul>
+<h3>Open questions for the specialist</h3>
+<p>1. <span class="fill" style="min-width:90%"></span></p>
+<p>2. <span class="fill" style="min-width:90%"></span></p>
+<h3>Coordination</h3>
+<p>Client's CPA: <span class="fill"></span>&nbsp;&nbsp;Client's counsel: <span class="fill"></span></p>
+<p>Preferred follow-up: <span class="fill"></span></p></div>
+<div class="warn">Send with the client's written consent. The memo states facts and questions; the specialist owns design and implementation.</div>
+  <div class="toolbar"><button type="button" onclick="window.print()">🖨 Print / Save as PDF</button><a href="/institutional/wealth-advisors/kit/">Back to the kit →</a></div>
+<aside class="bsa-boundary-note" role="note">
+  This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
+</aside>
+  <p class="kit-footer">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+
+</body></html>


### PR DESCRIPTION
Nine HTML-first kit pages (printable, disclaimered, static-only) + the story-driven LinkedIn content bank (21 cards, planning-only). Full verification in the commit message. One open decision: kit access model (public vs gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)