### PR TITLE
fix(offers): current-version pricing line on the $499 kit page

### DIFF
--- a/products/advisor-bitcoin-client-kit/index.html
+++ b/products/advisor-bitcoin-client-kit/index.html
@@ -84,7 +84,7 @@
   <button type="button" class="bsa-btn bsa-btn-card" data-kit="advisor-bitcoin-client-kit">Pay with card (USD)</button>
 
   <p class="kit-reassure">Delivered by email within the hour after payment confirms.</p>
-  <p class="bsa-meta" style="margin-top:14px;">Founding price; future v2 will go to $799 for new buyers — existing buyers get the upgrade free. Need a formal USD invoice? Email <a href="mailto:thesovereign.academy@proton.me">thesovereign.academy@proton.me</a>.</p>
+  <p class="bsa-meta" style="margin-top:14px;">Current version pricing. Includes the Advisor Readiness Kit and future refinements to this version. Need a formal USD invoice? Email <a href="mailto:thesovereign.academy@proton.me">thesovereign.academy@proton.me</a>.</p>
 </aside>
 
 </div><!-- /kit-grid -->


### PR DESCRIPTION
One buyer-facing line, Dalia's exact wording. Only $499 remains on the page; no scarcity framing; payment paths untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)