### PR TITLE
docs(marketing): first two polished LinkedIn posts

### DIFF
--- a/docs/marketing/linkedin-drafts-2026-06.md
+++ b/docs/marketing/linkedin-drafts-2026-06.md
@@ -1,0 +1,105 @@
+# LinkedIn Drafts — June 2026 (polished, awaiting Dalia's publish)
+
+Discipline rules in force: Entry 0 leads; only one follow-up drafted (4.2, source-verified); no new bank cards until both posts ship; CTAs use the free 10 Questions resource or the advisor preview hub only, never the $499 kit; CTAs live in the first comment, not the post body.
+
+---
+
+## Post 1 — Entry 0: "The Shortcut Always Has a Cost"
+
+### Substack title options
+1. **The Shortcut Always Has a Cost** (recommended; Dalia's original)
+2. Thirty Seconds Through the Fast Line
+3. What the Fast Line Asks For
+4. The Line I Regret Skipping
+
+### Substack version
+Dalia's full essay, verbatim, with exactly two changes (logged below). Canonical text = her original with:
+- "Long lines. Confusion. Travelers being asked for fingerprints and facial scans." → "Three-hour lines in Lisbon. Dover pausing extra checks. Travelers being asked for fingerprints and facial scans."
+- "A digital wallet that works everywhere." → "A payment wallet that works everywhere."
+
+### LinkedIn version (~2,600 characters, under the 3,000 limit)
+
+The Shortcut Always Has a Cost
+
+Every time a new "faster" system appears, I pay attention to what it asks for in return.
+
+The promise is almost always simple. Less waiting. Less paperwork. Less friction.
+
+A few years ago, I gave in at immigration in Colombia. I had avoided the biometric line for a long time because something about it felt wrong. Not dramatic. Not paranoid. Just wrong. I did not like how casual the whole thing felt. As if handing over part of your body to a government database was just another travel step, like taking off your shoes.
+
+Then one day I was tired. The regular line was long. I saw the short line and made the choice I had been resisting.
+
+Thirty seconds later, I was through.
+
+And almost immediately, I regretted it.
+
+That memory came back to me this week, reading about Europe's new biometric border system. Three-hour lines in Lisbon. Dover pausing extra checks. Travelers discovering, in real time, that convenience is rarely just convenience.
+
+At first this seems unrelated to Bitcoin advisory, but I do not think it is.
+
+Most people do not lose privacy in one dramatic moment. They lose it through small trades that feel reasonable at the time. A faster line. An easier login. A payment wallet that works everywhere. Each trade may be defensible on its own. That is what makes it hard.
+
+Bitcoin matters because it forces a different question: what should a person be able to own, move, and protect without needing permission every time?
+
+For advisors, this question is becoming harder to avoid. Clients are not only asking, "Should I own Bitcoin?" They are starting to ask:
+
+Where should it sit?
+What happens if I die?
+What happens if the exchange freezes withdrawals?
+What happens if my family knows I own it but cannot access it?
+
+A client does not need their advisor to become a custody engineer. They need a process.
+
+That process should know the difference between exposure and control. An ETF, an exchange account, a single hardware wallet, and a collaborative custody setup may all give someone "Bitcoin exposure." They do not give the same rights, risks, or responsibilities.
+
+Because the shortcut always has a cost. Sometimes it is obvious. A fee. A spread. Other times it is quieter. More data shared. More dependence on one institution. More systems that work beautifully until the day they do not.
+
+I still use airports. I still use banks. The point is not to pretend we can live outside every system. The point is to notice which parts of our lives should not depend entirely on systems we do not control.
+
+For many families, Bitcoin is becoming one of those parts.
+
+And for advisors, the opportunity is not to sound clever about Bitcoin. It is to help clients build a sane, documented, recoverable plan before the next shortcut becomes the only road left.
+
+### First comment (Entry 0)
+
+I keep a working list of ten questions advisors can ask before any of this gets hard. Free to read, no signup needed: https://bitcoinsovereign.academy/guides/advisor-10-questions/
+
+### Source note (EES story)
+
+The EU Entry/Exit System became fully operational April 10, 2026. May and June 2026 coverage documents queues up to three hours (Lisbon the most cited), missed connections, and Dover temporarily suspending extra EES checks on May 23, 2026. Sources: travelpirates.com (EES biometric border delays, summer 2026), travelandtourworld.com (EES queue coverage), etias.com (rollout glitches), ec.europa.eu (official EES page). The post's claims stay within these verified facts.
+
+### Changed sentences log (complete)
+1. "That memory came back to me this week while reading about the problems around Europe's new biometric border system. Long lines. Confusion." → "...this week, reading about Europe's new biometric border system. Three-hour lines in Lisbon. Dover pausing extra checks." Why: concrete, verifiable details age into credibility; vague ones age into filler.
+2. "A digital wallet that works everywhere." → "A payment wallet that works everywhere." Why: removes the chance a reader hears "crypto wallet" in a list about everyday convenience trades.
+3. LinkedIn version only: cuts for the 3,000-character limit (the stablecoin/tokenization paragraph, two client-question list items, the "advisors need a clearer map" passage, "showing your boarding pass," "as the financial system becomes more digital" bridge). All cut whole; no sentences rewritten. The Substack version keeps everything.
+
+---
+
+## Post 2 — 4.2: The Betterment fake crypto offer
+
+**Source verification (2026-06-12): STRONG — proceed.** TechCrunch 2026-01-12 (Betterment confirms breach after fake crypto scam notification), The Register 2026-02-05 (1.4M scope; vishing of third-party vendor IT support), American Banker, Have I Been Pwned (1.4M emails, names, geo; subset DOB/phone/address), betterment.com/customer-update (no account access, no passwords). Confirmed scam mechanics: in-brand promotion promising to triple Bitcoin or Ethereum deposits within a three-hour window.
+
+### LinkedIn post (~1,900 characters)
+
+The message looked like it came from the right place.
+
+In January, customers of Betterment, one of the largest robo-advisors, received what looked like an official promotion. Deposit Bitcoin or Ethereum within three hours and the platform would triple it. Real names, plausible timing, trusted branding. Attackers had talked a third-party vendor's support staff out of login codes and walked away with contact data for about 1.4 million customers. Betterment confirmed the breach in January.
+
+No accounts were drained. No passwords leaked. The attackers did not need any of that. They had the one thing a scam actually runs on: borrowed trust.
+
+I keep coming back to what that message means for advisors.
+
+Your clients now receive crypto outreach wearing brands they already use. Not strangers with bad grammar. Familiar logos, personal details that check out, and a clock. The deposit is irreversible the moment it sends.
+
+There is a simple service hiding in this story, and it costs nothing to offer: be the person your client calls before they act. Say it in those words at the next review. If you ever get an offer involving Bitcoin or crypto, call me before you do anything. Even if it looks official. Especially if it is urgent.
+
+The three-hour window is the tell. Real institutions do not need your money before lunch.
+
+An advisor does not have to become a security expert to be useful here. It takes a standing sentence, said early, repeated occasionally, documented once. Most of the damage from messages like this happens in the gap where that sentence was never said.
+
+### First comment (4.2)
+
+Ten questions worth asking about a client's Bitcoin before anything gets urgent. Free: https://bitcoinsovereign.academy/guides/advisor-10-questions/
+
+### Compliance check (both posts)
+No em dashes. No invented claims or memories. No banned words. No CTA in post bodies. CTAs target the free 10 Questions resource only. Betterment numbers traceable to primary disclosure and three independent outlets.


### PR DESCRIPTION
Entry 0 (Substack + LinkedIn cut) and the verified Betterment follow-up. Docs-only; publishing remains Dalia's manual act.

🤖 Generated with [Claude Code](https://claude.com/claude-code)