### PR TITLE
fix(advisor): TBA disclosure + precise ownership wording + attribution

### DIFF
--- a/guides/advisor-pre-discovery/index.html
+++ b/guides/advisor-pre-discovery/index.html
@@ -68,4 +68,7 @@
 <script src="/js/demo-cta-footer.js" defer></script>
 <script src="/js/email-capture.js" defer></script>
 <script src="/js/analytics.js" defer></script>
+<aside class="bsa-boundary-note" role="note">
+  <strong>Disclosure:</strong> I advise at The Bitcoin Adviser. When BSA refers to TBA, it is referring to a firm where I have an advisory relationship. Advisors should still evaluate TBA against other qualified Bitcoin custody and collaborative security providers before making a client recommendation.
+</aside>
 </body></html>

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/advisor-toolkit.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/advisor-toolkit.html
@@ -1665,7 +1665,7 @@
                 specialistGuidance = 'If the client moves ahead with self custody, the advisor should pause before implementation and confirm whether technical support is needed.';
             }
             if (recommendedKey === 'collaborative') {
-                specialistGuidance = 'Collaborative security is a specialist lane. Advisors often involve a firm such as The Bitcoin Adviser, which is not a custodian: the client\'s Bitcoin remains in self custody, and no single party can move funds alone. The specialist\'s job is turning multisig from a technical setup into a continuity plan.';
+                specialistGuidance = 'Collaborative security is a specialist lane. Advisors often involve a firm such as The Bitcoin Adviser, which is not a custodian: the Bitcoin remains the client\'s property, the client must initiate any movement, and no single person, including the client, can move funds alone. The specialist\'s job is turning multisig from a technical setup into a continuity plan.';
             }
 
             const controlLabel = controlPriority === 'high' ? 'High client control' : controlPriority === 'balanced' ? 'Balanced control' : 'Lower direct control preference';
@@ -1825,6 +1825,9 @@
                     </div>
                     <div class="content">${report.html}</div>
                 <aside class="bsa-boundary-note" role="note">
+  <strong>Disclosure:</strong> I advise at The Bitcoin Adviser. When BSA refers to TBA, it is referring to a firm where I have an advisory relationship. Advisors should still evaluate TBA against other qualified Bitcoin custody and collaborative security providers before making a client recommendation.
+</aside>
+<aside class="bsa-boundary-note" role="note">
   This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
 </aside>
 </body>

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-13-working-with-bitcoin-specialists.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-13-working-with-bitcoin-specialists.html
@@ -652,7 +652,8 @@
         <div class="specialist-spotlight">
             <div class="spotlight-badge">FEATURED SPECIALIST PARTNER</div>
             <h2 class="spotlight-title">The Bitcoin Adviser</h2>
-            <p class="spotlight-description">TBA's model is collaborative security, not custody. The client's Bitcoin remains in self custody, and no single party can move funds alone. The point is not to make custody more complicated. The point is to make it survivable. That is where TBA's work matters: turning multisig from a technical setup into a continuity plan for real life. Since 2016, zero satoshis lost, including through probates.</p>
+            <p class="spotlight-description">TBA's model is collaborative security, not custody. The Bitcoin remains the client's property, and the client must initiate any movement of funds. TBA cannot move funds unilaterally. At the same time, no single person, including the client, can move funds alone. That is the point of the 2-of-3 design: it reduces single points of failure while preserving client ownership and requiring client participation. The point is not to make custody more complicated. The point is to make it survivable: turning multisig from a technical setup into a continuity plan for real life. TBA reports zero satoshis lost since 2016, including through probates.</p>
+            <p class="spotlight-description">This model is not "one person controls everything." It is structured self-custody with collaborative security around it. The client remains the owner and required participant, while the recovery and signing process is designed so that death, incapacity, loss, divorce, or jurisdictional problems do not turn one person into the only point of failure.</p>
             
             <div class="spotlight-features">
                 <div class="spotlight-feature">
@@ -823,5 +824,8 @@
         });
     </script>
 <script src="/js/analytics.js" defer></script>
+<aside class="bsa-boundary-note" role="note">
+  <strong>Disclosure:</strong> I advise at The Bitcoin Adviser. When BSA refers to TBA, it is referring to a firm where I have an advisory relationship. Advisors should still evaluate TBA against other qualified Bitcoin custody and collaborative security providers before making a client recommendation.
+</aside>
 </body>
 </html>

--- a/institutional/wealth-advisors/index.html
+++ b/institutional/wealth-advisors/index.html
@@ -1088,6 +1088,9 @@
     </section>
 
     <aside class="bsa-boundary-note" role="note">
+  <strong>Disclosure:</strong> I advise at The Bitcoin Adviser. When BSA refers to TBA, it is referring to a firm where I have an advisory relationship. Advisors should still evaluate TBA against other qualified Bitcoin custody and collaborative security providers before making a client recommendation.
+</aside>
+<aside class="bsa-boundary-note" role="note">
   This program provides Bitcoin education and advisor-readiness support. It is not legal, tax, investment, custody, or accounting advice. Advisors remain responsible for their own professional duties and should coordinate with qualified counsel, tax professionals, custodians, and compliance teams as needed.
 </aside>
 <footer>

--- a/interactive-demos/security-dojo-enhanced/index.html
+++ b/interactive-demos/security-dojo-enhanced/index.html
@@ -2073,7 +2073,7 @@ Failure to verify within 24 hours will result in permanent account closure.<br/>
 
             <div class="simulator-box">
               <h4><span data-icon="game"></span> Interactive 3-Key Collaborative Custody Model</h4>
-              <p style="margin-bottom: 1.5rem;">The Bitcoin Adviser's proven 2-of-3 setup ($1B+ AUM, zero satoshis lost since 2016):</p>
+              <p style="margin-bottom: 1.5rem;">The Bitcoin Adviser's 2-of-3 model (the firm reports $1B+ under management and zero satoshis lost since 2016):</p>
 
               <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-bottom: 2rem;">
                 <div id="key-1" style="padding: 1.5rem; background: var(--color-surface); border-radius: 12px; text-align: center; border: 2px solid var(--color-border); cursor: pointer;" onclick="toggleKey(1)">
@@ -2137,7 +2137,7 @@ Failure to verify within 24 hours will result in permanent account closure.<br/>
             <h3><span data-icon="books"></span> The Bitcoin Adviser Advantage</h3>
             <div style="background: var(--color-surface); padding: 2rem; border-radius: 12px; margin: 2rem 0;">
               <ul style="line-height: 2.5;">
-                <li>✅ <strong>Zero satoshis lost</strong> since founding in 2016</li>
+                <li>✅ <strong>Zero satoshis lost</strong> since founding in 2016 (as reported by the firm)</li>
                 <li>✅ <strong>$1 billion+</strong> in assets under management</li>
                 <li>✅ <strong>Beneficiary education</strong> - trains your heirs before inheritance</li>
                 <li>✅ <strong>1% annual fee</strong> (decreasing to 0.5% after year 9)</li>


### PR DESCRIPTION
Dalia's corrections from the pushback round: dual-role disclosure on all TBA-naming advisor pages, the precise ownership/initiator model (self custody ≠ unilateral control), and firm-reported attribution on track-record claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)