### PR TITLE
feat(blog): /blog launch + iris essay as post 1 + stance-essay dedup

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Blog | Bitcoin Sovereign Academy</title>
+<meta name="description" content="Essays by Dalia on Bitcoin, privacy, sovereignty, and the trade-offs we make in a permissioned world.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/blog/">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>.post{max-width:720px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.post h1{color:var(--color-brand,#FF7A00);font-size:1.9rem;line-height:1.2;margin:0 0 .4rem}
+.post .meta{color:#777;font-size:.9rem;margin:0 0 2rem}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}.breadcrumb a:hover{color:#FF7A00}
+.post p{color:#d8d8d2;line-height:1.75;font-size:1.05rem;margin:0 0 1.2rem}
+.post .lead{color:#F7F7F2}
+.post-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem;border-top:1px solid #2a2a2a;padding-top:1.5rem}
+.post-footer a{color:#999}
+@media(max-width:600px){.post{padding:1.25rem 1rem 3rem}.post h1{font-size:1.55rem}}
+.post-list{list-style:none;padding:0;margin:1.5rem 0 0}
+.post-list li{background:#101010;border:1px solid #2a2a2a;border-radius:10px;padding:1.3rem 1.5rem;margin:0 0 1rem}
+.post-list a{color:#FF7A00;font-weight:700;text-decoration:none;font-size:1.15rem}
+.post-list p{color:#b3b3b3;font-size:.95rem;line-height:1.6;margin:.4rem 0 0}</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="post" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> &rsaquo; <span>Blog</span></div>
+  <h1>Blog</h1>
+  <p class="meta">Essays by Dalia. First principles, written in public.</p>
+  <ul class="post-list">
+    <li>
+      <a href="/blog/the-day-i-traded-my-iris-for-30-seconds.html">The Day I Traded My Iris for 30 Seconds</a>
+      <p>A biometric line at a Colombian airport, and the quiet trade between convenience and control.</p>
+    </li>
+  </ul>
+  <p class="post-footer">Created by Dalia &middot; <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+</body></html>

--- a/blog/the-day-i-traded-my-iris-for-30-seconds.html
+++ b/blog/the-day-i-traded-my-iris-for-30-seconds.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The Day I Traded My Iris for 30 Seconds | Bitcoin Sovereign Academy</title>
+<meta name="description" content="A personal essay on the quiet trade between convenience and control, told from a biometric line at a Colombian airport.">
+<link rel="canonical" href="https://bitcoinsovereign.academy/blog/the-day-i-traded-my-iris-for-30-seconds.html">
+<link rel="stylesheet" href="/css/global.css">
+<link rel="stylesheet" href="/css/brand.css">
+<link rel="stylesheet" href="/css/brand-consistency.css">
+<style>.post{max-width:720px;margin:0 auto;padding:2rem 1.5rem 4rem}
+.post h1{color:var(--color-brand,#FF7A00);font-size:1.9rem;line-height:1.2;margin:0 0 .4rem}
+.post .meta{color:#777;font-size:.9rem;margin:0 0 2rem}
+.breadcrumb{font-size:.85rem;color:#9aa4b2;margin-bottom:1.5rem}
+.breadcrumb a{color:#9aa4b2;text-decoration:none}.breadcrumb a:hover{color:#FF7A00}
+.post p{color:#d8d8d2;line-height:1.75;font-size:1.05rem;margin:0 0 1.2rem}
+.post .lead{color:#F7F7F2}
+.post-footer{text-align:center;color:#777;font-size:.85rem;margin-top:3rem;border-top:1px solid #2a2a2a;padding-top:1.5rem}
+.post-footer a{color:#999}
+@media(max-width:600px){.post{padding:1.25rem 1rem 3rem}.post h1{font-size:1.55rem}}</style>
+</head>
+<body>
+<a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+<main class="post" id="main-content">
+  <div class="breadcrumb"><a href="/">Home</a> &rsaquo; <a href="/blog/">Blog</a> &rsaquo; <span>The Day I Traded My Iris for 30 Seconds</span></div>
+  <h1>The Day I Traded My Iris for 30 Seconds</h1>
+  <p class="meta">By Dalia</p>
+  <p class="lead">Every time I travel back to Colombia in the past years, the same scene plays out at immigration. Tourists in a line that can last four or five hours. Colombians in another, long and winding, full of exhausted faces. And then a third line. Short, quick and effortless: the biometric enrollment line.</p>
+  <p>For years, I refused. It didn't feel voluntary. Officials would say: “Colombianos, this way.” No explanation. No consent forms. Just a quiet expectation that I hand over my iris, my identity. In exchange? Efficiency.</p>
+  <p>I held out, until I didn't. After too many long trips, one day I caved. Thirty seconds later, I was through. Thirty seconds later, I regretted it.</p>
+  <p>Because I knew what I had done. I sold my privacy for speed. I told myself it was harmless, just a line at the airport. But deep down I knew it was more than that. I had reinforced the very system I mistrusted. Convenience was the bait. Control was the catch.</p>
+  <p>Governments are masters of branding. They wrap surveillance in words like “security” and “public good.” Who can argue against safety or shorter lines? But every scan, every fingerprint, every database entry builds an infrastructure that rarely rolls back. Once your body becomes your passport, you don't get to take it back.</p>
+  <p>And history shows what comes next. Political violence sparks fear. Leaders respond with promises of safety. But safety usually means more checkpoints, more monitoring, more trade-offs you don't remember agreeing to.</p>
+  <p>That's why Bitcoin matters. Not because it makes airports faster. But because it proves another system is possible. One where you don't need to trade your identity for permission. Self custody means you move your value without being watched, frozen, or categorized. Fixed supply means you don't need to trust the same people who can't balance a budget to protect your savings.</p>
+  <p>I regret stepping into that biometric line. I can't undo it. But I can use that regret as fuel. To remind myself and anyone listening: privacy isn't optional, it's survival. And maybe the real shortcut is building systems that don't demand we give up pieces of ourselves to just pass through.</p>
+  <p class="post-footer">Created by Dalia &middot; <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
+</main>
+</body></html>

--- a/docs/marketing/linkedin-drafts-2026-06.md
+++ b/docs/marketing/linkedin-drafts-2026-06.md
@@ -19,17 +19,11 @@ Discipline rules in force: Entry 0 leads; only one follow-up drafted (4.2, sourc
 ### Substack version
 
 Convenience Was the Bait. Control Was the Catch.
-*I used to think a little socialism made me a better person. A line at an airport, a switched-off AI, and a data leak taught me what I was really handing over.*
+*I used to think a little socialism made me a better person. A switched-off AI and a data leak taught me what I was really handing over.*
 
-Every time I fly back to Colombia, the same scene plays out at immigration. Tourists in a line that can run four or five hours. Colombians in another, long and tired. And then a third line, short and effortless. The biometric line.
+I once traded my iris for thirty seconds at an airport in Colombia, and I have written about the regret that followed ([The Day I Traded My Iris for 30 Seconds](/blog/the-day-i-traded-my-iris-for-30-seconds.html)). The short version: I sold my privacy for speed and fed the very system I claimed to mistrust. Convenience was the bait. Control was the catch.
 
-For years I refused it. It never felt voluntary. An official would wave us over. "Colombianos, this way." No explanation. No consent form. Just the quiet assumption that I would hand over my iris, my identity, in exchange for efficiency.
-
-I held out. Until one day, after too many long trips, I did not. Thirty seconds later I was through. Thirty seconds later I regretted it. (I wrote about that day here: [link to "The Day I Traded My Iris for 30 Seconds"].)
-
-Because I knew exactly what I had done. I sold my privacy for speed and told myself it was harmless. Just a line at an airport. But I had fed the very system I claimed to mistrust. Convenience was the bait. Control was the catch.
-
-I think about that moment more now, because the pattern is everywhere, and most of us walk into it the way I did. Someone says you have to enroll, so you enroll. Someone offers you something for free, so you open your arms. You skip the only two questions that matter. What is the catch. What am I trading for this.
+I keep coming back to that trade, because the pattern is everywhere, and most of us walk into it the way I did. Someone says you must enroll, so you enroll. Someone offers something free, so you open your arms. We skip the only two questions that matter. What is the catch. What am I trading for this.
 
 I used to be very good at not asking.
 
@@ -57,25 +51,17 @@ But I am not going to pretend it is a magic exit, because France is partly a Bit
 
 So the lesson is older and simpler than any slogan. Before you hand something over, ask whether you can take it back. A password I can change. A key I can rotate. My iris, I cannot. A record of what I own, once it is loose in the world, I cannot un-leak. The trades worth fearing are the ones with no undo.
 
-I cannot take back my iris. That door is closed. But I can stop assuming the shortest line is the one I want to be standing in.
-
 Question. Verify. Do not trust by default. Do not swallow anything whole, least of all when it is handed to you for free, and least of all when it is handed to you for your own good.
 
-Privacy is not optional. It is survival.
+I still believe what I wrote after that airport line. Privacy is not optional. It is survival. What I understand now is the harder half: how much of it we give away without noticing, and how little we can ever take back.
 
-### LinkedIn version (2978 characters, under the 3,000 limit)
+### LinkedIn version (2775 characters, under the 3,000 limit)
 
 Convenience Was the Bait. Control Was the Catch.
 
-Every time I fly back to Colombia, the same scene at immigration. Tourists in a line that runs hours. Colombians in another. And a third line, short and effortless. The biometric line.
+I once traded my iris for thirty seconds at an airport in Colombia, and I have written about the regret that followed. The short version: I sold my privacy for speed and fed the very system I claimed to mistrust.
 
-For years I refused it. It never felt voluntary. "Colombianos, this way." No explanation. No consent form. Just the assumption that I would hand over my iris for efficiency.
-
-I held out. Until one day, after too many trips, I did not. Thirty seconds later I was through. Thirty seconds later I regretted it.
-
-I knew exactly what I had done. I sold my privacy for speed and told myself it was harmless. Just a line at an airport. But I had fed the very system I claimed to mistrust. Convenience was the bait. Control was the catch.
-
-The pattern is everywhere, and most of us walk into it the way I did. We skip the only two questions that matter. What is the catch. What am I trading for this.
+I keep coming back to that trade, because the pattern is everywhere, and most of us walk into it the way I did. Someone says you must enroll, so you enroll. Someone offers something free, so you open your arms. We skip the only two questions that matter. What is the catch. What am I trading for this.
 
 I used to be very good at not asking. I grew up watching a currency lose its meaning and a state fail the people it promised to protect, and my answer was still to trust it more and feel virtuous about it. I had confused trust with goodness.
 
@@ -97,7 +83,7 @@ So the lesson is older than any slogan. Before you hand something over, ask whet
 
 Question. Verify. Do not swallow anything whole, least of all when it is free, and least of all when it is for your own good.
 
-Privacy is not optional. It is survival.
+I still believe what I wrote after that airport line. Privacy is not optional. It is survival. I just understand now how much of it we give away without noticing, and how little we can ever take back.
 
 ### First comment (options)
 1. Personal (recommended): "I write about where convenience quietly turns into dependency, usually from my own mistakes. More at [Substack]."
@@ -105,7 +91,7 @@ Privacy is not optional. It is survival.
 3. None.
 
 ### TODO before publishing
-- Drop the real URL into the iris-article placeholder in the Substack version (and/or first comment).
+- The iris story now LINKS to /blog/the-day-i-traded-my-iris-for-30-seconds.html (no longer retold in full — dedup vs the published article).
 - Pick title + first-comment option.
 
 ### Source notes (verify; both confirmed 2026-06-13)

--- a/index.html
+++ b/index.html
@@ -4137,6 +4137,7 @@
                     <!-- Membership demoted from buyer path — spine-repair A1 (reversible). File kept at /membership.html; still reachable from /account.html. (earn-back-terms.html now redirects here — program parked 2026-06-11.)
                     <li><a href="/membership.html">Membership</a></li>
                     -->
+                    <li><a href="/blog/">Blog</a></li>
                     <li><a href="https://sovereigndwp.substack.com" target="_blank" rel="noopener" aria-describedby="new-tab-hint">Newsletter</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
New on-site blog with Dalia's iris essay as the first post; the LinkedIn stance essay de-duplicated to link the blog post instead of re-telling it. Homepage footer gains a Blog link. One overclaim flagged in the article for Dalia's decision (left verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)