### PR TITLE
fix(top-level): mechanical coherence fixes (homepage + top-level audit)

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -153,7 +153,7 @@
                 <div class="contact-icon">🐦</div>
                 <h3>Twitter / X</h3>
                 <p>Follow us for updates, tips, and Bitcoin education content.</p>
-                <a href="https://twitter.com/BitcoinSovAcad" target="_blank" rel="noopener">
+                <a href="https://twitter.com/BTCSovereignEdu" target="_blank" rel="noopener">
                     Follow Us →
                 </a>
             </div>

--- a/contact.html
+++ b/contact.html
@@ -153,7 +153,7 @@
                 <div class="contact-icon">🐦</div>
                 <h3>Twitter / X</h3>
                 <p>Follow us for updates, tips, and Bitcoin education content.</p>
-                <a href="https://twitter.com/BTCSovereignEdu" target="_blank" rel="noopener">
+                <a href="https://twitter.com/dalia_platt" target="_blank" rel="noopener">
                     Follow Us →
                 </a>
             </div>

--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
               "name": "What is Bitcoin Sovereign Academy?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Bitcoin Sovereign Academy is a free, open-source educational platform that teaches Bitcoin through 44 interactive demos and 6 structured learning paths. Users learn by doing, not just reading."
+                "text": "Bitcoin Sovereign Academy is a free, open-source educational platform that teaches Bitcoin through interactive demos and 6 structured learning paths. Users learn by doing, not just reading."
               }
             },
             {
@@ -211,7 +211,7 @@
               "name": "Is Bitcoin Sovereign Academy free?",
               "acceptedAnswer": {
                 "@type": "Answer",
-                "text": "Yes, all 44 interactive demos and learning paths are free. Premium tiers (Apprentice and Sovereign) offer additional features like AI tutoring and premium deep-dive content."
+                "text": "Yes, all interactive demos and learning paths are free. Premium tiers (Apprentice and Sovereign) offer additional features like AI tutoring and premium deep-dive content."
               }
             },
             {
@@ -3112,13 +3112,6 @@
         </linearGradient>
       </defs>
     </svg>
-    <!-- Skip Links for Accessibility (WCAG 2.4.1) -->
-    <div class="skip-links">
-        
-        
-        
-    </div>
-
     <!-- Loading Screen -->
     <div class="loading" id="loading" role="status" aria-live="polite" aria-label="Loading page">
         <div class="loading-spinner" aria-hidden="true"></div>
@@ -3626,7 +3619,7 @@
             <div class="section-tag">Find Your Path</div>
             <div class="choose-path-grid">
                 <h2 class="choose-path-title">Pick the path that fits how you learn.</h2>
-                <p class="choose-path-subtitle">Answer one question and we'll route you to the path that fits your goals. Or browse all 7 paths below.</p>
+                <p class="choose-path-subtitle">Answer one question and we'll route you to the path that fits your goals. Or browse all 6 paths below.</p>
             </div>
 
             <!-- Progressive Path Discovery -->
@@ -4163,7 +4156,7 @@
         </div>
 
         <div class="footer-bottom">
-            <p>Created by Dalia · <a href="https://thesovereign.academy">thesovereign.academy</a></p>
+            <p>Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
             <p style="margin-top: 0.5rem; font-size: 0.85rem; color: var(--text-dim);">Not sure where to start? <a href="/start/" style="color: var(--primary-orange);">Take the path assessment →</a></p>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Bitcoin Sovereign Academy - Free Interactive Bitcoin Education">
     <meta name="twitter:description" content="Bitcoin custody and inheritance for families and advisors. Bilingual. LATAM-fluent. Hands-on demos and learning paths from monetary curiosity to sovereignty.">
-    <meta name="twitter:site" content="@BTCSovereignEdu">
-    <meta name="twitter:creator" content="@BTCSovereignEdu">
+    <meta name="twitter:site" content="@dalia_platt">
+    <meta name="twitter:creator" content="@dalia_platt">
     <meta name="twitter:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg">
     <meta name="twitter:image:alt" content="Bitcoin Sovereign Academy Logo">
     
@@ -87,7 +87,7 @@
           },
           "description": "Bitcoin custody and inheritance for families and advisors. Bilingual. LATAM-fluent. Hands-on demos and learning paths from monetary curiosity to sovereignty.",
           "sameAs": [
-            "https://twitter.com/BTCSovereignEdu",
+            "https://twitter.com/dalia_platt",
             "https://github.com/Sovereigndwp/bitcoin-sovereign-academy",
 "https://sovereigndwp.substack.com/",
             "https://thesovereign.academy",
@@ -276,7 +276,7 @@
       "sameAs": [
         "https://sovereigndwp.substack.com/",
         "https://github.com/Sovereigndwp",
-        "https://twitter.com/BTCSovereignEdu",
+        "https://twitter.com/dalia_platt",
         "https://thesovereign.academy"
       ],
       "worksFor": {

--- a/membership-success.html
+++ b/membership-success.html
@@ -188,7 +188,7 @@
             <h3>Your Sovereign Benefits</h3>
             <ul>
                 <li><span class="check">✓</span> Unlimited AI Tutor access (we cover the API)</li>
-                <li><span class="check">✓</span> All 44 interactive demos unlocked</li>
+                <li><span class="check">✓</span> All interactive demos unlocked</li>
                 <li><span class="check">✓</span> Premium deep-dive content</li>
                 <li><span class="check">✓</span> All future updates included</li>
                 <li><span class="check">✓</span> Private community access</li>

--- a/membership.html
+++ b/membership.html
@@ -172,7 +172,7 @@
                 <div class="price">Free</div>
                 <p class="price-detail">Forever</p>
                 <ul>
-                    <li><span class="check">✓</span> All 44 interactive demos</li>
+                    <li><span class="check">✓</span> All interactive demos</li>
                     <li><span class="check">✓</span> Free preview modules across the learning paths</li>
                     <li><span class="check">✓</span> AI Tutor (bring your own API key)</li>
                     <li><span class="check">✓</span> Glossary &amp; resources</li>
@@ -246,7 +246,7 @@
         </section>
         <div class="value-props">
             <div class="value-prop"><div class="icon">🔐</div><h4>Privacy-Respecting</h4><p>No accounts required to learn. No personal data collected.</p></div>
-            <div class="value-prop"><div class="icon">📚</div><h4>Learn by Doing</h4><p>44 interactive demos. Understand Bitcoin, don't just read about it.</p></div>
+            <div class="value-prop"><div class="icon">📚</div><h4>Learn by Doing</h4><p>Interactive demos. Understand Bitcoin, don't just read about it.</p></div>
             <div class="value-prop"><div class="icon">🎯</div><h4>Skin in the Game</h4><p>Putting something real behind your learning changes incentives.</p></div>
             <div class="value-prop"><div class="icon">♾️</div><h4>No Subscriptions</h4><p>One payment, lifetime value. We practice what we preach.</p></div>
         </div>


### PR DESCRIPTION
## What

Mechanical batch (M1–M5) from a read-only 9-dimension **site-coherence audit** of the homepage + top-level page group. All fixes are truthful, verified, and low-risk — no design/token or copy-authoring changes.

| | Fix | Files |
|---|---|---|
| **M1** | Footer domain `thesovereign.academy` → `bitcoinsovereign.academy` (locked footer convention) | `index.html` |
| **M2** | "browse all **7** paths" → "**6** paths" — only 6 path-card blocks render (curious, hurried, pragmatist, principled, skeptic, sovereign) | `index.html` |
| **M3** | Contact X handle `BitcoinSovAcad` → `BTCSovereignEdu` — canonicalize to the homepage handle (used 4× in structured data); one was dead | `contact.html` |
| **M4** | Remove dead empty `.skip-links` block — real skip link is inline at top of `<body>` | `index.html` |
| **M5** | De-number stale demo count "44 interactive demos" → "interactive demos" — filesystem has 47 demo dirs, copy said 44, memory says 50+; de-numbering ends the drift | `index.html` (schema ×2), `membership.html` ×2, `membership-success.html` |

Diff: **4 files, +8/−15**. Branch is based on `origin/main` and is independent of unmerged WIP on other branches.

## ⚠️ One truth-check for the author
**M3 direction:** canonicalized to `@BTCSovereignEdu` because it's in the homepage structured data 4×, but **which X account is actually live should be confirmed**. If `BitcoinSovAcad` is the real one, flip the fix.

## Not in this PR (queued behind sign-off)
- `dashboard.html` is a non-BSA "Productivity" tool that would deploy to `/dashboard.html` (untrack/remove)
- Site-wide green/purple drift (token-level; purple is a primary CTA on membership/success)
- One-time-vs-subscription contradiction (membership "no subscriptions" vs account.html subscription dashboard)
- Identity/tagline/bilingual absent from visible copy; TBA-boundary leak (community/support sold as paid); footer convention missing sitewide

🤖 Generated with [Claude Code](https://claude.com/claude-code)