### PR TITLE
fix(sovereign): collaborative SECURITY not custody + soften SPOF absolutes (audit S2+S3)

### DIFF
--- a/paths/sovereign/stage-1/module-2.html
+++ b/paths/sovereign/stage-1/module-2.html
@@ -798,7 +798,7 @@
                     <ul>
                         <li><strong>Gnosis Safe:</strong> Multi-sig for Ethereum (adaptable patterns)</li>
                         <li><strong>Casa:</strong> Managed multi-sig service with institutional tier</li>
-                        <li><strong>Unchained Capital:</strong> Collaborative custody with legal support</li>
+                        <li><strong>Unchained Capital:</strong> Collaborative security with legal support</li>
                         <li><strong>Custom solutions:</strong> Bitcoin Core + Miniscript for complex policies</li>
                     </ul>
 
@@ -1271,7 +1271,7 @@
 
                 <h3>Vendor Lock-in: Open Standards Matter</h3>
 
-                <p>Some multi-sig services (like Casa, Unchained) offer managed multi-sig where they hold one key. This is called <strong>collaborative custody</strong>. Benefits:</p>
+                <p>Some multi-sig services (like Casa, Unchained) offer managed multi-sig where they hold one key. This is called <strong>collaborative security</strong> (often marketed as collaborative custody). Benefits:</p>
                 <ul>
                     <li>Simplified setup (they guide you)</li>
                     <li>They hold a key, so you only need to secure 2 (in 2-of-3)</li>
@@ -1433,7 +1433,7 @@
                 <p><strong>Pros:</strong> Simpler on-chain (looks like single-sig), no multi-sig fees.</p>
                 <p><strong>Cons:</strong> Less standardized, fewer wallet options, shares must be combined in one location (security risk).</p>
 
-                <h3>Time-Locked Multi-Sig (Collaborative Custody)</h3>
+                <h3>Time-Locked Multi-Sig (Collaborative Security)</h3>
                 <p>Some services (like Casa) offer multi-sig where one key is held by the company, but with a time-lock: if the company disappears or you don't log in for 6+ months, you can unilaterally recover with just your keys. This combines convenience with an emergency exit.</p>
 
                 <h3>Federated Multi-Sig</h3>

--- a/paths/sovereign/stage-1/module-3.html
+++ b/paths/sovereign/stage-1/module-3.html
@@ -1637,9 +1637,9 @@
                     (CSV) opcodes in Bitcoin Script. Requires advanced technical knowledge or use of services that implement this.
                 </p>
 
-                <h4>Collaborative Custody with Time-Locks</h4>
+                <h4>Collaborative Security with Time-Locks</h4>
                 <p>
-                    Services like <strong>Casa</strong> and <strong>Unchained Capital</strong> offer collaborative custody
+                    Services like <strong>Casa</strong> and <strong>Unchained Capital</strong> offer collaborative security
                     with time-locked recovery:
                 </p>
                 <ul>

--- a/paths/sovereign/stage-3/collaborative-security.html
+++ b/paths/sovereign/stage-3/collaborative-security.html
@@ -353,9 +353,9 @@
                 </div>
             </div>
 
-            <!-- Collaborative Custody Card -->
+            <!-- Collaborative Security Card -->
             <div class="model-card collaborative">
-                <h3 style="color: var(--accent-green);">🟢 Collaborative Custody</h3>
+                <h3 style="color: var(--accent-green);">🟢 Collaborative Security</h3>
                 <p style="margin-bottom: 1rem; color: var(--text-dim);">
                     <strong>Setup:</strong> Quorum model with documented processes, third-party key holders, and recovery procedures
                 </p>
@@ -363,7 +363,7 @@
                 <div style="margin: 1rem 0;">
                     <strong style="color: var(--accent-green);">✅ Advantages:</strong>
                     <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-dim);">
-                        <li>No single point of failure</li>
+                        <li>No single key is a point of failure</li>
                         <li>Documented recovery processes</li>
                         <li>Geographic distribution of keys</li>
                         <li>Estate planning integration</li>
@@ -404,7 +404,7 @@
             <div class="risk-item" style="font-weight: 600; background: rgba(212, 175, 55, 0.1);">
                 <div>Scenario</div>
                 <div>Assisted Multisig</div>
-                <div>Collaborative Custody</div>
+                <div>Collaborative Security</div>
             </div>
 
             <div class="risk-item">
@@ -669,7 +669,7 @@
         </div>
 
         <div style="background: var(--secondary-dark); border: 2px solid var(--border-color); border-radius: 1rem; padding: 2rem; margin: 2rem 0;">
-            <h3 style="margin-top: 0;">If You Choose Collaborative Custody:</h3>
+            <h3 style="margin-top: 0;">If You Choose Collaborative Security:</h3>
             <ul style="margin: 1rem 0 0 1.5rem; color: var(--text-dim);">
                 <li>Research providers: TBA by Choice, Onramp, or attorney-based solutions</li>
                 <li>Understand quorum requirements (typically 2-of-3 or 3-of-5)</li>
@@ -724,7 +724,7 @@
 
             if (collaborativeScore >= 8) {
                 recommendation = `
-                    <h3 style="color: var(--accent-green); margin-bottom: 1rem;">✅ Collaborative Custody Recommended</h3>
+                    <h3 style="color: var(--accent-green); margin-bottom: 1rem;">✅ Collaborative Security Recommended</h3>
                     <p style="margin-bottom: 1rem;">
                         Based on your answers, collaborative security is the best fit for your situation. Your holdings, time horizon, and risk profile justify the added complexity.
                     </p>

--- a/paths/sovereign/stage-4/module-1.html
+++ b/paths/sovereign/stage-4/module-1.html
@@ -474,14 +474,14 @@
             </section>
 
             <section class="content-section">
-                <h2><span data-icon="handshake"></span> Collaborative Custody: A Middle Path</h2>
+                <h2><span data-icon="handshake"></span> Collaborative Security: A Middle Path</h2>
                 <p>
                     Between full self-custody and complete exchange custody lies <strong>collaborative security</strong> (often marketed as collaborative custody)—
                     a model where you hold most keys but partner with a service provider who holds one or more keys
                     in your multi-sig setup. This can be a practical solution for many Bitcoiners.
                 </p>
 
-                <h3>How Collaborative Custody Works</h3>
+                <h3>How Collaborative Security Works</h3>
                 <p>
                     In a typical collaborative security arrangement (e.g., 2-of-3 multi-sig):
                 </p>
@@ -492,11 +492,11 @@
                 </ul>
                 <p>
                     For normal transactions, you use your two keys. The provider's key only comes into play if you
-                    lose one of yours, enabling recovery without single points of failure.
+                    lose one of yours, enabling recovery while reducing single points of failure.
                 </p>
 
                 <div class="config-card">
-                    <h3>Collaborative Custody Providers</h3>
+                    <h3>Collaborative Security Providers</h3>
                     <p>Several companies offer collaborative security services:</p>
                     <ul>
                         <li><strong>Theya:</strong> 2-of-3 multi-sig with mobile key + hardware wallet + company key. Mobile key uses iPhone Secure Enclave.</li>
@@ -506,7 +506,7 @@
                     </ul>
                 </div>
 
-                <h3>Full Self-Custody vs. Collaborative Custody</h3>
+                <h3>Full Self-Custody vs. Collaborative Security</h3>
                 <div class="config-card">
                     <h4>Choose Full Self-Custody If:</h4>
                     <ul>
@@ -519,7 +519,7 @@
                 </div>
 
                 <div class="config-card">
-                    <h4>Choose Collaborative Custody If:</h4>
+                    <h4>Choose Collaborative Security If:</h4>
                     <ul>
                         <li>You want multi-sig security without managing all keys yourself</li>
                         <li>You need a reliable recovery option if you lose a key</li>


### PR DESCRIPTION
## What
Correctness pass on the **sovereign** learning path from the Paths-group site-coherence audit (items **S2** + **S3**). 4 files, +17/−17.

## S2 — "collaborative custody" → "collaborative security"
Enforces the locked rule: with The Bitcoin Adviser the user holds keys — it is **collaborative security**, never a custody service. Renamed the model label across **16** heading/table/recommendation uses in 4 files.

**Kept the 3 accurate glosses** — "collaborative security (often marketed as collaborative custody)" — because the industry term is real and worth teaching once. The stage-1/module-2 teaching line was converted into that same gloss form.

Verified: every remaining "collaborative custody" string in `paths/sovereign/` is a gloss (0 bare label uses).

## S3 — softened 2 absolute "single point of failure" claims
Multisig *reduces*, never *eliminates*:
- `collaborative-security.html:366` "No single point of failure" → "No single key is a point of failure"
- `stage-4/module-1.html:495` "recovery without single points of failure" → "...while reducing single points of failure"

**Deliberately left intact** (accurate, not overclaims): network-decentralization statements ("no single point of failure or control"), the already-qualified "no single point of failure for theft", and the many exemplary "reduce single points of failure *when designed and maintained correctly*" lines.

## Not in this PR (flagged for authoring)
- **S4 TBA-boundary framing** on `collaborative-security.html` — TBA is currently listed as one vendor beside Onramp/Casa, with no calendar-first CTA and no free-inclusion disclosure. Needs your direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)