### PR TITLE
fix(sovereign): collaborative security = self-custody with guardrails (not a middle path)

### DIFF
--- a/paths/sovereign/stage-4/module-1.html
+++ b/paths/sovereign/stage-4/module-1.html
@@ -474,12 +474,37 @@
             </section>
 
             <section class="content-section">
-                <h2><span data-icon="handshake"></span> Collaborative Security: A Middle Path</h2>
+                <h2><span data-icon="handshake"></span> Collaborative Security: Self-Custody With Guardrails</h2>
                 <p>
-                    Between full self-custody and complete exchange custody lies <strong>collaborative security</strong> (often marketed as collaborative custody)—
-                    a model where you hold most keys but partner with a service provider who holds one or more keys
-                    in your multi-sig setup. This can be a practical solution for many Bitcoiners.
+                    <strong>Collaborative security is self-custody with guardrails</strong> (the industry often
+                    markets it as "collaborative custody," but that name is misleading). The client stays in
+                    self-custody — they own the bitcoin and they hold a key — but they don't carry every
+                    operational burden alone. It keeps the client in self-custody while adding a recovery path
+                    if something goes wrong.
                 </p>
+
+                <div class="config-card">
+                    <h4>Full Self-Custody</h4>
+                    <p>The person controls all signing authority. This gives maximum independence, but also
+                    maximum personal responsibility. If the person loses access, dies without instructions,
+                    stores backups poorly, or makes a signing mistake, there may be no support path.</p>
+                </div>
+
+                <div class="config-card">
+                    <h4>Collaborative Security (e.g. The Bitcoin Adviser)</h4>
+                    <p>The person remains in a self-custody structure, but does not carry every operational
+                    burden alone. The client holds one key, The Bitcoin Adviser holds one key, and the wallet
+                    provider holds one key. No single party can move funds alone — and holding one key in a
+                    2-of-3 is not custody, so neither The Bitcoin Adviser nor the wallet provider is a custodian.
+                    This makes the model much closer to self-custody than custody, while allowing room for
+                    recovery, inheritance support, and mistake resistance.</p>
+                </div>
+
+                <div style="background: rgba(212,175,55,0.08); border-left: 4px solid var(--sovereign-gold); padding: 1rem 1.25rem; border-radius: 0.25rem; margin: 1.5rem 0;">
+                    <p style="margin:0;"><strong>The key point:</strong> this is not halfway to custody. It is
+                    self-custody designed for real humans — it avoids the most dangerous version of self-custody:
+                    one person, one memory, one backup mistake, one inheritance failure, or one bad day.</p>
+                </div>
 
                 <h3>How Collaborative Security Works</h3>
                 <p>


### PR DESCRIPTION
## What
Corrects the framing of collaborative security in `paths/sovereign/stage-4/module-1.html`.

**The problem (per Dalia):** calling collaborative security a "middle path / middle ground between full self-custody and exchange custody" is misleading. The client never gives up custody. TBA's model is much *closer to self-custody* — the client owns the bitcoin and holds a key, no single party can move funds alone, and holding one key in a 2-of-3 is not custody (neither TBA nor the wallet provider is a custodian).

## Changes
- **Title:** "Collaborative Security: A Middle Path" → **"Self-Custody With Guardrails"**
- **Intro:** replaced "between full self-custody and complete exchange custody lies…" with the **self-custody-with-guardrails** framing
- **Added** an explicit Full-Self-Custody vs TBA-Collaborative-Security distinction (client / TBA / wallet-provider each hold one key; no single party can move funds alone)
- **Added** the key teaching callout: *"This is not halfway to custody. It is self-custody designed for real humans — it avoids the most dangerous version of self-custody: one person, one memory, one backup mistake, one inheritance failure, or one bad day."*

Verified: no "middle path / middle ground / halfway to custody" framing remains anywhere in the site (the only match is the new line that *negates* it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)