### PR TITLE
fix(paths): correct reflect-widget data-path + dedupe <main> landmark (S6+S8)

### DIFF
--- a/paths/hurried/index.html
+++ b/paths/hurried/index.html
@@ -270,14 +270,14 @@
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <header class="hero-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <h1><span data-icon="rocket"></span> The Hurried: Zero to Secured in 70 Minutes</h1>
             <p class="hero-tagline">No fluff. No theory. Just 7 action steps to Bitcoin sovereignty.</p>
             <div class="time-badge"><span data-icon="lightning"></span> Total Time: 68 minutes</div>
         </div>
     </header>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <!-- Progress Indicator -->
         <div class="progress-indicator">
             <div class="progress-text" id="progress-text">0 / 6 Steps Completed</div>
@@ -473,7 +473,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="curious"
+             data-path="hurried"
              data-title="Reflect: What is the most important thing to remember?">
         </div>
     </div>

--- a/paths/hurried/stage-1/module-1.html
+++ b/paths/hurried/stage-1/module-1.html
@@ -793,7 +793,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="curious"
+             data-path="hurried"
              data-title="Reflect: What is the most important thing to remember?">
         </div>
     </div>

--- a/paths/hurried/stage-1/module-2.html
+++ b/paths/hurried/stage-1/module-2.html
@@ -636,7 +636,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="curious"
+             data-path="hurried"
              data-title="Reflect: What is the most important thing to remember?">
         </div>
     </div>

--- a/paths/hurried/stage-1/module-3.html
+++ b/paths/hurried/stage-1/module-3.html
@@ -541,7 +541,7 @@
     </div>
         <div class="reflect-widget"
              data-topic="money"
-             data-path="curious"
+             data-path="hurried"
              data-title="Reflect: What is the most important thing to remember?">
         </div>
     </div>

--- a/paths/hurried/stage-2/module-4.html
+++ b/paths/hurried/stage-2/module-4.html
@@ -548,7 +548,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="curious"
+             data-path="hurried"
              data-title="Reflect: What is the most important thing to remember?">
         </div>
     </div>

--- a/paths/hurried/stage-2/module-5.html
+++ b/paths/hurried/stage-2/module-5.html
@@ -545,7 +545,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="curious"
+             data-path="hurried"
              data-title="Reflect: What is the most important thing to remember?">
         </div>
     </div>

--- a/paths/hurried/stage-3/module-6.html
+++ b/paths/hurried/stage-3/module-6.html
@@ -474,7 +474,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="curious"
+             data-path="hurried"
              data-title="Reflect: What is the most important thing to remember?">
         </div>
     </div>

--- a/paths/hurried/stage-3/module-7.html
+++ b/paths/hurried/stage-3/module-7.html
@@ -488,7 +488,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="curious"
+             data-path="hurried"
              data-title="Reflect: What is the most important thing to remember?">
         </div>
     </div>

--- a/paths/pragmatist/index.html
+++ b/paths/pragmatist/index.html
@@ -909,7 +909,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-1/module-1.html
+++ b/paths/pragmatist/stage-1/module-1.html
@@ -1583,7 +1583,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-1/module-2.html
+++ b/paths/pragmatist/stage-1/module-2.html
@@ -39,7 +39,7 @@
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/paths/pragmatist/">← Back to Pragmatist Path</a> / Stage 1 / Module 2
             </div>
@@ -54,7 +54,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <!-- Introduction -->
         <section class="content-section">
             <h2><span data-icon="tool"></span> Your Control Panel for the Bitcoin Network</h2>
@@ -848,7 +848,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-1/module-3.html
+++ b/paths/pragmatist/stage-1/module-3.html
@@ -39,7 +39,7 @@
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/paths/pragmatist/">← Back to Pragmatist Path</a> / Stage 1 / Module 3
             </div>
@@ -54,7 +54,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <!-- Introduction -->
         <section class="content-section">
             <h2>📡 How Value Moves</h2>
@@ -853,7 +853,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-1/module-4.html
+++ b/paths/pragmatist/stage-1/module-4.html
@@ -39,7 +39,7 @@
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/paths/pragmatist/">← Back to Pragmatist Path</a> / Stage 1 / Module 4
             </div>
@@ -54,7 +54,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <!-- Introduction -->
         <section class="content-section">
             <h2><span data-icon="target"></span> Your First Bitcoin Purchase</h2>
@@ -735,7 +735,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-2/bank-friction.html
+++ b/paths/pragmatist/stage-2/bank-friction.html
@@ -374,7 +374,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-2/module-5-security.html
+++ b/paths/pragmatist/stage-2/module-5-security.html
@@ -39,7 +39,7 @@
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/paths/pragmatist/">← Back to Pragmatist Path</a> / Stage 2 / Module 5
             </div>
@@ -54,7 +54,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <!-- Introduction -->
         <div class="content-section">
             <h2>Bitcoin Security: Your Responsibility</h2>
@@ -851,7 +851,7 @@
     </div>
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-2/module-6-lightning.html
+++ b/paths/pragmatist/stage-2/module-6-lightning.html
@@ -39,7 +39,7 @@
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Module Header -->
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/paths/pragmatist/">← Back to Pragmatist Path</a> / Stage 2 / Module 6
             </div>
@@ -54,7 +54,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <!-- Introduction -->
         <section class="content-section">
             <h2><span data-icon="lightning"></span> Why Lightning Matters for Pragmatists</h2>
@@ -587,7 +587,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-2/module-7-economics.html
+++ b/paths/pragmatist/stage-2/module-7-economics.html
@@ -35,7 +35,7 @@
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/paths/pragmatist/">← Back to Pragmatist Path</a> / Stage 2 / Module 7
             </div>
@@ -50,7 +50,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <!-- DCA vs Lump Sum -->
         <section class="content-section">
             <h2><span data-icon="money"></span> Buying Strategy: DCA vs Lump Sum</h2>
@@ -364,7 +364,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-3/module-8-privacy-tax.html
+++ b/paths/pragmatist/stage-3/module-8-privacy-tax.html
@@ -35,7 +35,7 @@
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/paths/pragmatist/">← Back to Pragmatist Path</a> / Stage 3 / Module 8
             </div>
@@ -50,7 +50,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <!-- Privacy Basics -->
         <section class="content-section">
             <h2><span data-icon="search"></span> Bitcoin Privacy: What You Need to Know</h2>
@@ -448,7 +448,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/pragmatist/stage-3/module-9-real-life.html
+++ b/paths/pragmatist/stage-3/module-9-real-life.html
@@ -35,7 +35,7 @@
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/paths/pragmatist/">← Back to Pragmatist Path</a> / Stage 3 / Module 9
             </div>
@@ -50,7 +50,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <!-- Integration Strategy -->
         <section class="content-section">
             <h2>🔗 Integrating Bitcoin with Your Financial Life</h2>
@@ -473,7 +473,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="wallets"
-             data-path="curious"
+             data-path="pragmatist"
              data-title="Reflect: How will you apply this practically?">
         </div>
     </div>

--- a/paths/skeptic/index.html
+++ b/paths/skeptic/index.html
@@ -676,7 +676,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="principled"
+             data-path="skeptic"
              data-title="Reflect: What convinced you — or didn&#39;t?">
         </div>
     </div>

--- a/paths/skeptic/stage-1/index.html
+++ b/paths/skeptic/stage-1/index.html
@@ -428,7 +428,7 @@
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/">Home</a> &gt; <a href="/paths/skeptic/">The Skeptic Path</a> &gt; Stage 1
             </div>
@@ -436,7 +436,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <div class="intro">
             <p><strong>What's your biggest concern about Bitcoin?</strong></p>
             <p>Select the objections you want addressed. We'll show you data-driven rebuttals—no hype, no preaching.</p>
@@ -936,7 +936,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="principled"
+             data-path="skeptic"
              data-title="Reflect: What convinced you — or didn&#39;t?">
         </div>
     </div>

--- a/paths/skeptic/stage-2/index.html
+++ b/paths/skeptic/stage-2/index.html
@@ -266,7 +266,7 @@
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <div class="module-header">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="breadcrumb">
                 <a href="/">Home</a> &gt; <a href="/paths/skeptic/">The Skeptic Path</a> &gt; Stage 2
             </div>
@@ -274,7 +274,7 @@
         </div>
     </div>
 
-    <main id="main-content-2" class="container">
+    <main id="main-content" class="container">
         <div class="intro">
             <h2>You Made It</h2>
             <p>You've challenged every major objection. Now it's time to understand <strong>how</strong> Bitcoin actually works.</p>
@@ -327,7 +327,7 @@
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
-             data-path="principled"
+             data-path="skeptic"
              data-title="Reflect: What convinced you — or didn&#39;t?">
         </div>
     </div>


### PR DESCRIPTION
Mechanical audit batch from the site-coherence audit (Paths group). **No copy or design changes** — purely metadata + HTML structure. Verified in-browser.

## S6 — reflect-widget `data-path` mis-attribution (22 files)
The Socratic reflect widget passes `data-path` to the tutor as learner-path context (`js/reflect-widget.js:840`). It was wrong on three paths:

| Path | Was | Now | Files |
|------|-----|-----|-------|
| `paths/hurried/*` | `curious` | `hurried` | 8 |
| `paths/pragmatist/*` | `curious` | `pragmatist` | 11 |
| `paths/skeptic/*` | `principled` | `skeptic` | 3 |

`data-path` is free-form, so the new values are safe. **`data-topic` is intentionally left unchanged** — picking per-module topics is authoring, not mechanical, and is flagged as a follow-up.

## S8 — double `<main>` / landmark bug (11 files)
Affected pages had a header wrapper coded as `<main id="main-content" class="container">` but closed by `</div>`, followed by the real `<main id="main-content-2">` — i.e. **two `<main>` landmarks per page** plus a mismatched tag (WCAG: one `<main>` per page).

Fix per file:
- header wrapper `<main id="main-content" class="container">` → `<div class="container">` (now matched by its existing `</div>`)
- content region `<main id="main-content-2" class="container">` → `<main id="main-content" class="container">` (the single landmark, and the `#main-content` skip-link target)

`.container` class preserved; the only `main{}` CSS rule lives in `css/interactive-demos.css` and isn't linked by path pages → **visually inert**.

Covers both wrapper variants: `hurried/index.html` uses `<header class="hero-header">`; pragmatist/skeptic use `<div class="module-header">`.

## Verification
Served the worktree and checked rendered DOM on both variants:
- `mainCount: 1`, `mainIds: ["main-content"]`, `#main-content-2` gone
- skip-link `#main-content` resolves to the `<main>`
- header `<h1>` still renders; `data-path` correct
- no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)