### PR TITLE
feat(pragmatist): de-gamify the path — unbounded-mode pilot

### DIFF
--- a/paths/pragmatist/index.html
+++ b/paths/pragmatist/index.html
@@ -76,48 +76,6 @@
             color: var(--text-dim);
         }
 
-        .path-stats {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 1.5rem;
-            margin-top: 2rem;
-        }
-
-        .stat-card {
-            background: rgba(255, 122, 0, 0.08);
-            border: 2px solid #FF7A00;
-            border-radius: 0.75rem;
-            padding: 1.5rem;
-            text-align: center;
-        }
-
-        .stat-value {
-            font-size: 2rem;
-            font-weight: 700;
-            color: #FF7A00;
-            margin-bottom: 0.5rem;
-        }
-
-        .stat-label {
-            font-size: 0.9rem;
-            color: var(--text-dim);
-        }
-
-        .progress-bar-header {
-            width: 100%;
-            height: 10px;
-            background: rgba(255, 122, 0, 0.15);
-            border-radius: 5px;
-            overflow: hidden;
-            margin-top: 2rem;
-        }
-
-        .progress-fill-header {
-            height: 100%;
-            background: #FF7A00;
-            transition: width 0.3s ease;
-        }
-
         /* Main Content */
         .main-content {
             padding: 3rem 0;
@@ -291,7 +249,7 @@
             pointer-events: none;
         }
 
-        /* Gamification Preview */
+        /* What's Inside note */
         .gamification-note {
             background: rgba(255, 122, 0, 0.06);
             border: 2px solid #FF7A00;
@@ -359,10 +317,6 @@
                 font-size: 2rem;
             }
 
-            .path-stats {
-                grid-template-columns: 1fr;
-            }
-
             .stage-header {
                 flex-direction: column;
                 gap: 1rem;
@@ -413,28 +367,6 @@
                 <p class="path-subtitle">Practical Bitcoin learning for action-oriented minds</p>
             </div>
 
-            <div class="path-stats">
-                <div class="stat-card">
-                    <div class="stat-value" id="modules-completed">0/9</div>
-                    <div class="stat-label">Modules Completed</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="knowledge-score">0</div>
-                    <div class="stat-label">Knowledge Points</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="achievements-earned">0/10</div>
-                    <div class="stat-label">Achievements</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="completion-percent">0%</div>
-                    <div class="stat-label">Path Completion</div>
-                </div>
-            </div>
-
-            <div class="progress-bar-header">
-                <div class="progress-fill-header" style="width: 0%" id="overall-progress"></div>
-            </div>
         </div>
     </header>
 
@@ -463,7 +395,6 @@
                             <div class="stage-meta">
                                 <span><span data-icon="timer"></span> 1.5-2 hours</span>
                                 <span><span data-icon="books"></span> 4 modules</span>
-                                <span><span data-icon="target"></span> 70 points</span>
                             </div>
                         </div>
                         <div class="stage-badge">Start Here</div>
@@ -476,10 +407,10 @@
                     <div class="modules-preview">
                         <h4><span data-icon="book"></span> What You'll Do:</h4>
                         <div class="module-list">
-                            <div class="module-item">Module 1: What is Bitcoin? (20 min, 15 points)</div>
-                            <div class="module-item">Module 2: Bitcoin Wallets (20 min, 15 points)</div>
-                            <div class="module-item">Module 3: Bitcoin Transactions (25 min, 20 points)</div>
-                            <div class="module-item">Module 4: How to Buy Bitcoin (25 min, 20 points)</div>
+                            <div class="module-item">Module 1: What is Bitcoin? (20 min)</div>
+                            <div class="module-item">Module 2: Bitcoin Wallets (20 min)</div>
+                            <div class="module-item">Module 3: Bitcoin Transactions (25 min)</div>
+                            <div class="module-item">Module 4: How to Buy Bitcoin (25 min)</div>
                         </div>
                     </div>
 
@@ -489,7 +420,7 @@
                 </div>
 
                 <!-- Stage 2 -->
-                <div class="stage-card locked" id="stage-2">
+                <div class="stage-card" id="stage-2">
                     <div class="stage-header">
                         <div class="stage-title">
                             <div class="stage-icon"><span data-icon="lightning"></span> </div>
@@ -497,10 +428,9 @@
                             <div class="stage-meta">
                                 <span><span data-icon="timer"></span> 1-1.5 hours</span>
                                 <span><span data-icon="books"></span> 3 modules</span>
-                                <span><span data-icon="target"></span> 60 points</span>
                             </div>
                         </div>
-                        <div class="stage-badge"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-badge">Open</div>
                     </div>
 
                     <p class="stage-description">
@@ -510,9 +440,9 @@
                     <div class="modules-preview">
                         <h4><span data-icon="book"></span> What You'll Do:</h4>
                         <div class="module-list">
-                            <div class="module-item">Module 5: Security &amp; Best Practices (30 min, 20 points)</div>
-                            <div class="module-item">Module 6: Lightning for Daily Use (30 min, 20 points)</div>
-                            <div class="module-item">Module 7: Economics &amp; Strategy (20 min, 20 points)</div>
+                            <div class="module-item">Module 5: Security &amp; Best Practices (30 min)</div>
+                            <div class="module-item">Module 6: Lightning for Daily Use (30 min)</div>
+                            <div class="module-item">Module 7: Economics &amp; Strategy (20 min)</div>
                         </div>
                     </div>
 
@@ -537,7 +467,7 @@
                 </div>
 
                 <!-- Stage 3 -->
-                <div class="stage-card locked" id="stage-3">
+                <div class="stage-card" id="stage-3">
                     <div class="stage-header">
                         <div class="stage-title">
                             <div class="stage-icon"><span data-icon="globe"></span> </div>
@@ -545,10 +475,9 @@
                             <div class="stage-meta">
                                 <span><span data-icon="timer"></span> 50 minutes</span>
                                 <span><span data-icon="books"></span> 2 modules</span>
-                                <span><span data-icon="target"></span> 40 points</span>
                             </div>
                         </div>
-                        <div class="stage-badge"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-badge">Open</div>
                     </div>
 
                     <p class="stage-description">
@@ -558,8 +487,8 @@
                     <div class="modules-preview">
                         <h4><span data-icon="book"></span> What You'll Do:</h4>
                         <div class="module-list">
-                            <div class="module-item">Module 8: Privacy &amp; Tax Essentials (25 min, 20 points)</div>
-                            <div class="module-item">Module 9: Bitcoin in Your Life (25 min, 20 points)</div>
+                            <div class="module-item">Module 8: Privacy &amp; Tax Essentials (25 min)</div>
+                            <div class="module-item">Module 9: Bitcoin in Your Life (25 min)</div>
                         </div>
                     </div>
 
@@ -569,11 +498,10 @@
                 </div>
             </div>
 
-            <!-- Gamification Note -->
+            <!-- What's Inside -->
             <div class="gamification-note">
-                <h3><span data-icon="trophy"></span> Gamified Learning Experience</h3>
+                <h3><span data-icon="book"></span> What's Inside</h3>
                 <p>
-                    Unlock 10 achievements, earn up to 170 knowledge points, and track your progress as you master Bitcoin.
                     Each module includes interactive reflection questions and hands-on demos to cement your understanding.
                 </p>
             </div>
@@ -621,8 +549,6 @@
                 if (!data || typeof data !== 'object') {
                     data = {
                         completedModules: [],
-                        knowledgeScore: 0,
-                        achievements: [],
                         startTime: Date.now()
                     };
                 }
@@ -639,36 +565,6 @@
                         data.completedModules = unique;
                         modified = true;
                     }
-                }
-
-                if (typeof data.knowledgeScore !== 'number' || !Number.isFinite(data.knowledgeScore)) {
-                    data.knowledgeScore = 0;
-                    modified = true;
-                }
-
-                if (!Array.isArray(data.achievements)) {
-                    data.achievements = [];
-                    modified = true;
-                }
-
-                // Keep achievements list aligned to the IDs displayed on this page
-                const allowedAchievements = new Set([
-                    'first-steps',
-                    'wallet-master',
-                    'transaction-pro',
-                    'security-expert',
-                    'lightning-pro',
-                    'economics-guru',
-                    'privacy-master',
-                    'integration-complete',
-                    'bitcoin-graduate',
-                    'pragmatist-master'
-                ]);
-
-                const filteredAchievements = data.achievements.filter(id => allowedAchievements.has(id));
-                if (filteredAchievements.length !== data.achievements.length) {
-                    data.achievements = filteredAchievements;
-                    modified = true;
                 }
 
                 if (typeof data.startTime !== 'number' || !Number.isFinite(data.startTime)) {
@@ -701,111 +597,17 @@
 
             init() {
                 this.updateUI();
-                this.checkAchievements();
             }
 
             updateUI() {
-                // Update progress stats
-                const totalModules = 9;
-                const completed = this.getUniqueCompletedModules().length;
-                const percentage = Math.round((completed / totalModules) * 100);
-
-                document.getElementById('modules-completed').textContent = `${completed}/${totalModules}`;
-                document.getElementById('knowledge-score').textContent = this.data.knowledgeScore;
-                document.getElementById('achievements-earned').textContent = `${this.data.achievements.length}/10`;
-                document.getElementById('completion-percent').textContent = `${percentage}%`;
-                document.getElementById('overall-progress').style.width = `${percentage}%`;
-
-                // Update stage states
+                // Update stage states (resume help: which stage to continue)
                 this.updateStageStates();
             }
 
             updateStageStates() {
-                const stage1Completed = this.getStageCompletionCount('1-');
-                const stage2Completed = this.getStageCompletionCount('2-');
-                const stage3Completed = this.getStageCompletionCount('3-');
-
-                // Stage 1 updates
-                const stage1Card = document.getElementById('stage-1');
-                if (stage1Completed >= 4) {
-                    stage1Card.classList.remove('current');
-                    stage1Card.classList.add('completed');
-                    const badge = stage1Card.querySelector('.stage-badge');
-                    if (badge) badge.textContent = '✓ Completed';
-                    const btn = stage1Card.querySelector('.stage-btn');
-                    if (btn) btn.textContent = '✓ Review Stage';
-
-                    // Unlock Stage 2
-                    const stage2Card = document.getElementById('stage-2');
-                    stage2Card.classList.remove('locked');
-                    stage2Card.classList.add('current');
-                    const badge2 = stage2Card.querySelector('.stage-badge');
-                    if (badge2) {
-                        badge2.textContent = 'Continue';
-                        badge2.style.background = 'rgba(255, 122, 0, 0.2)';
-                        badge2.style.color = '#FF7A00';
-                    }
-                }
-
-                // Stage 2 complete
-                if (stage2Completed >= 3) {
-                    const stage2Card = document.getElementById('stage-2');
-                    stage2Card.classList.remove('current');
-                    stage2Card.classList.add('completed');
-                    const badge = stage2Card.querySelector('.stage-badge');
-                    if (badge) badge.textContent = '✓ Completed';
-                    const btn = stage2Card.querySelector('.stage-btn');
-                    if (btn) btn.textContent = '✓ Review Stage';
-
-                    // Unlock Stage 3
-                    const stage3Card = document.getElementById('stage-3');
-                    stage3Card.classList.remove('locked');
-                    stage3Card.classList.add('current');
-                    const badge3 = stage3Card.querySelector('.stage-badge');
-                    if (badge3) {
-                        badge3.textContent = 'Continue';
-                        badge3.style.background = 'rgba(255, 122, 0, 0.2)';
-                        badge3.style.color = '#FF7A00';
-                    }
-                }
-
-                // Stage 3 complete
-                if (stage3Completed >= 2) {
-                    const stage3Card = document.getElementById('stage-3');
-                    stage3Card.classList.remove('current');
-                    stage3Card.classList.add('completed');
-                    const badge = stage3Card.querySelector('.stage-badge');
-                    if (badge) badge.textContent = '✓ Completed';
-                    const btn = stage3Card.querySelector('.stage-btn');
-                    if (btn) btn.textContent = '✓ Path Complete!';
-                }
-            }
-
-            checkAchievements() {
-                const completedModules = this.getUniqueCompletedModules();
-                const completedSet = new Set(completedModules);
-                const completedCount = completedModules.length;
-
-                // Check for various achievement conditions
-                const achievements = {
-                    'first-steps': completedCount >= 1,
-                    'wallet-master': completedSet.has('1-2'),
-                    'transaction-pro': completedSet.has('1-3'),
-                    'security-expert': completedSet.has('2-1'),
-                    'lightning-pro': completedSet.has('2-2'),
-                    'economics-guru': completedSet.has('2-3'),
-                    'privacy-master': completedSet.has('3-1'),
-                    'integration-complete': completedSet.has('3-2'),
-                    'bitcoin-graduate': completedCount === 9,
-                    'pragmatist-master': completedCount === 9 && this.data.knowledgeScore >= 170
-                };
-
-                Object.entries(achievements).forEach(([id, condition]) => {
-                    if (condition && !this.data.achievements.includes(id)) {
-                        this.data.achievements.push(id);
-                        this.save();
-                    }
-                });
+                // Unbounded mode: all stages stay open. No locking, no completion
+                // scoring or relabeling — the path is an open learning map, not a
+                // gated course dashboard. (Per-module answers still persist for resume.)
             }
         }
 

--- a/paths/pragmatist/stage-1/module-1.html
+++ b/paths/pragmatist/stage-1/module-1.html
@@ -349,42 +349,6 @@
             box-shadow: 0 5px 20px rgba(255, 122, 0, 0.25);
         }
 
-        /* Achievement Notification */
-        .achievement-notification {
-            position: fixed;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%) scale(0);
-            background: linear-gradient(135deg, var(--pragmatist-teal), var(--pragmatist-cyan));
-            padding: 2rem;
-            border-radius: 1rem;
-            text-align: center;
-            z-index: 1000;
-            box-shadow: 0 10px 50px rgba(0, 0, 0, 0.5);
-            opacity: 0;
-            transition: all 0.3s ease;
-        }
-
-        .achievement-notification.show {
-            transform: translate(-50%, -50%) scale(1);
-            opacity: 1;
-        }
-
-        .achievement-notification .icon {
-            font-size: 4rem;
-            margin-bottom: 1rem;
-        }
-
-        .achievement-notification h3 {
-            color: #fff;
-            margin-bottom: 0.5rem;
-        }
-
-        .achievement-notification p {
-            color: #fff;
-            opacity: 0.9;
-        }
-
         /* Live Ticker */
         .live-ticker-container {
             background: linear-gradient(90deg, #1a1a1a 0%, #2d2d2d 50%, #1a1a1a 100%);
@@ -517,13 +481,6 @@
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
-    <!-- Achievement Notification -->
-    <div class="achievement-notification" id="achievement-notification">
-        <div class="icon"><span data-icon="trophy"></span> </div>
-        <h3 id="achievement-title"></h3>
-        <p id="achievement-description"></p>
-    </div>
-
     <!-- Module Header -->
     <header class="module-header">
         <div class="container">
@@ -538,8 +495,6 @@
             </div>
             <div class="module-meta">
                 <span><span data-icon="timer"></span> 20 minutes</span>
-                <span><span data-icon="target"></span> 15 knowledge points</span>
-                <span><span data-icon="chart"></span> 3 quiz questions</span>
             </div>
         </div>
     </header>
@@ -960,11 +915,11 @@
             </p>
         </section>
 
-        <!-- Complete Module -->
+        <!-- Continue -->
         <section class="complete-section">
-            <button class="complete-btn" id="complete-btn" onclick="completeModule()" disabled="">
-                ✅ Complete Module &amp; Continue →
-            </button>
+            <a class="complete-btn" href="/paths/pragmatist/stage-1/module-2.html">
+                Continue to Module 2 →
+            </a>
         </section>
     
 <!-- Lab Cards — Try It Now -->
@@ -1151,68 +1106,9 @@
             setInterval(updateTicker, 60000);
         };
 
-        // Complete module
-        function completeModule() {
-            // Save completion to localStorage (legacy)
-            localStorage.setItem('pragmatist-m1-complete', 'true');
-            localStorage.setItem('pragmatist-m1-completed-at', new Date().toISOString());
-
-            // Also update global Pragmatist path progress
-            const storageKey = 'pragmatist-progress';
-            let data;
-            try {
-                data = JSON.parse(localStorage.getItem(storageKey));
-            } catch (e) {
-                data = null;
-            }
-
-            if (!data || typeof data !== 'object') {
-                data = {
-                    completedModules: [],
-                    knowledgeScore: 0,
-                    achievements: [],
-                    startTime: Date.now()
-                };
-            }
-
-            if (!Array.isArray(data.completedModules)) data.completedModules = [];
-            if (!Array.isArray(data.achievements)) data.achievements = [];
-            if (typeof data.knowledgeScore !== 'number' || !Number.isFinite(data.knowledgeScore)) data.knowledgeScore = 0;
-            if (typeof data.startTime !== 'number' || !Number.isFinite(data.startTime)) data.startTime = Date.now();
-
-            if (!data.completedModules.includes('1-1')) {
-                data.completedModules.push('1-1');
-                data.knowledgeScore += 15;
-            }
-
-            try {
-                localStorage.setItem(storageKey, JSON.stringify(data));
-            } catch (e) {
-                // Ignore write errors (private mode / quota)
-            }
-
-            // Show achievement
-            showAchievement('Module 1 Complete', 'You understand Bitcoin as infrastructure!', '✅');
-
-            // Redirect to next module
-            setTimeout(() => {
-                window.location.href = '/paths/pragmatist/stage-1/module-2.html';
-            }, 2000);
-        }
-
-        // Show achievement notification
-        function showAchievement(title, description, icon) {
-            const notification = document.getElementById('achievement-notification');
-            document.getElementById('achievement-title').textContent = title;
-            document.getElementById('achievement-description').textContent = description;
-            notification.querySelector('.icon').textContent = icon;
-
-            notification.classList.add('show');
-
-            setTimeout(() => {
-                notification.classList.remove('show');
-            }, 2500);
-        }
+        // Gamification removed (unbounded mode): module completion is now a plain
+        // navigation link — no scoring, knowledge points, achievement popups, or
+        // step-gating. Reflection answers still persist via saveResponse/loadResponses.
     </script>
 
     <!-- Interactive Reflection JavaScript -->
@@ -1245,14 +1141,14 @@
             }
 
             if (choice === 'neutral') {
-                feedbackDiv.innerHTML = `<h5>✓ Exactly Right!</h5><p>Just like electricity is <strong>neutral infrastructure</strong> that powers devices, Bitcoin is neutral infrastructure that moves value.<br><br>Both are accessible networks that operate <strong>24/7 without requiring permission</strong>. Electricity doesn't care who you are—it just works. Bitcoin is the same.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Just like electricity is <strong>neutral infrastructure</strong> that powers devices, Bitcoin is neutral infrastructure that moves value.<br><br>Both are accessible networks that operate <strong>24/7 without requiring permission</strong>. Electricity doesn't care who you are—it just works. Bitcoin is the same.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q1');
             } else if (choice === 'energy') {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Partial Understanding</h5><p>Bitcoin does use energy for mining, but that's not why it's compared to electricity. The comparison is about <strong>neutral, accessible infrastructure</strong> that anyone can plug into—not the energy consumption itself.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Bitcoin does use energy for mining, but that's not why it's compared to electricity. The comparison is about <strong>neutral, accessible infrastructure</strong> that anyone can plug into—not the energy consumption itself.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Not Quite</h5><p>Think bigger. The electricity analogy is about Bitcoin being <strong>neutral infrastructure</strong> that transmits value globally, continuously, and without discrimination—just like electricity powers devices 24/7 for anyone.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Think bigger. The electricity analogy is about Bitcoin being <strong>neutral infrastructure</strong> that transmits value globally, continuously, and without discrimination—just like electricity powers devices 24/7 for anyone.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -1281,14 +1177,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Comprehensive Understanding!</h5><p>You identified ${score} key concepts:<br><br><strong>Neutral infrastructure</strong> that's <strong>accessible to anyone</strong>, operates <strong>24/7</strong>, and requires no permission. This is exactly why Bitcoin is compared to electricity—both democratize access to essential services.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You identified ${score} key concepts:<br><br><strong>Neutral infrastructure</strong> that's <strong>accessible to anyone</strong>, operates <strong>24/7</strong>, and requires no permission. This is exactly why Bitcoin is compared to electricity—both democratize access to essential services.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q1');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Start (${score}/4 concepts)</h5><p>Consider adding: neutral access, 24/7 operation, infrastructure model. The analogy emphasizes Bitcoin as <strong>reliable, always-on infrastructure</strong> anyone can use—like plugging into an electrical socket.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Consider adding: neutral access, 24/7 operation, infrastructure model. The analogy emphasizes Bitcoin as <strong>reliable, always-on infrastructure</strong> anyone can use—like plugging into an electrical socket.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Keep Developing</h5><p>The electricity analogy highlights: <strong>neutral infrastructure</strong> + <strong>universal access</strong> + <strong>24/7 availability</strong> + <strong>no permissions required</strong>. Try incorporating these themes!</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>The electricity analogy highlights: <strong>neutral infrastructure</strong> + <strong>universal access</strong> + <strong>24/7 availability</strong> + <strong>no permissions required</strong>. Try incorporating these themes!</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -1306,14 +1202,14 @@
             }
 
             if (choice === '21million') {
-                feedbackDiv.innerHTML = `<h5>✓ Perfect!</h5><p>Bitcoin has a hard cap of <strong>21 million coins</strong>, programmed into the protocol. This predictable supply is <strong>algorithmic, not political</strong>—no one can change it.<br><br>This fixed scarcity is fundamental to Bitcoin's value proposition.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Bitcoin has a hard cap of <strong>21 million coins</strong>, programmed into the protocol. This predictable supply is <strong>algorithmic, not political</strong>—no one can change it.<br><br>This fixed scarcity is fundamental to Bitcoin's value proposition.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q2');
             } else if (choice === 'unlimited') {
-                feedbackDiv.innerHTML = `<h5>⚠️ Opposite of Bitcoin's Design</h5><p>Unlike fiat currencies that can be printed endlessly, Bitcoin has a <strong>fixed cap of 21 million coins</strong>. No one—not miners, not developers, not governments—can create more.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Unlike fiat currencies that can be printed endlessly, Bitcoin has a <strong>fixed cap of 21 million coins</strong>. No one—not miners, not developers, not governments—can create more.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Fixed, Not Flexible</h5><p>Bitcoin's supply is <strong>21 million forever</strong>—it's coded into the protocol and cannot be changed by miners, developers, or governments. This predictability is a key feature.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Bitcoin's supply is <strong>21 million forever</strong>—it's coded into the protocol and cannot be changed by miners, developers, or governments. This predictability is a key feature.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -1342,14 +1238,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Excellent Analysis! (${score}/4 concepts)</h5><p>You grasped the core implications:<br><br>Fixed supply means <strong>no inflation</strong>, <strong>predictable scarcity</strong>, and <strong>zero political discretion</strong>. If Bitcoin's supply could change, it would lose its value proposition as <strong>hard, sound money</strong>.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You grasped the core implications:<br><br>Fixed supply means <strong>no inflation</strong>, <strong>predictable scarcity</strong>, and <strong>zero political discretion</strong>. If Bitcoin's supply could change, it would lose its value proposition as <strong>hard, sound money</strong>.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q2');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Points (${score}/4 concepts)</h5><p>Also consider: no inflation, predictability, removal of political discretion. A flexible supply would make Bitcoin just another fiat currency—subject to devaluation and manipulation.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Also consider: no inflation, predictability, removal of political discretion. A flexible supply would make Bitcoin just another fiat currency—subject to devaluation and manipulation.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Think Deeper</h5><p>Key themes: <strong>prevents inflation</strong>, <strong>predictable scarcity</strong>, <strong>removes political control</strong>, <strong>preserves value</strong>. A changeable supply would destroy Bitcoin's core advantage over fiat money.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key themes: <strong>prevents inflation</strong>, <strong>predictable scarcity</strong>, <strong>removes political control</strong>, <strong>preserves value</strong>. A changeable supply would destroy Bitcoin's core advantage over fiat money.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -1367,11 +1263,11 @@
             }
 
             if (choice === 'false') {
-                feedbackDiv.innerHTML = `<h5>✓ Correct!</h5><p>No one can shut down Bitcoin. It's <strong>decentralized across thousands of nodes globally</strong>, like the internet itself.<br><br>There's no central switch or server to turn off. This is why censorship resistance is one of Bitcoin's core properties.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>No one can shut down Bitcoin. It's <strong>decentralized across thousands of nodes globally</strong>, like the internet itself.<br><br>There's no central switch or server to turn off. This is why censorship resistance is one of Bitcoin's core properties.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q3');
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ False</h5><p>Bitcoin <strong>cannot be shut down</strong>. It runs on thousands of independent nodes in 100+ countries. There's no CEO, no central server, no single point of failure. As long as one node exists, the network persists.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Bitcoin <strong>cannot be shut down</strong>. It runs on thousands of independent nodes in 100+ countries. There's no CEO, no central server, no single point of failure. As long as one node exists, the network persists.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -1400,14 +1296,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Perfect Explanation! (${score}/4 concepts)</h5><p>You identified the core resilience factors:<br><br><strong>Thousands of nodes</strong> distributed <strong>globally</strong> with <strong>no central server</strong> or company. Bitcoin is <strong>peer-to-peer infrastructure</strong>—as resilient as the internet itself.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You identified the core resilience factors:<br><br><strong>Thousands of nodes</strong> distributed <strong>globally</strong> with <strong>no central server</strong> or company. Bitcoin is <strong>peer-to-peer infrastructure</strong>—as resilient as the internet itself.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q3');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Understanding (${score}/4 concepts)</h5><p>Strengthen your explanation by emphasizing: <strong>thousands of independent nodes</strong>, <strong>global distribution</strong>, <strong>no central point of control</strong>. This makes Bitcoin unstoppable.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Strengthen your explanation by emphasizing: <strong>thousands of independent nodes</strong>, <strong>global distribution</strong>, <strong>no central point of control</strong>. This makes Bitcoin unstoppable.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Expand Your Answer</h5><p>Key points: <strong>15,000+ nodes worldwide</strong>, <strong>fully decentralized</strong>, <strong>no CEO/company/server</strong>, <strong>peer-to-peer network</strong>. As long as one node exists, Bitcoin survives.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key points: <strong>15,000+ nodes worldwide</strong>, <strong>fully decentralized</strong>, <strong>no CEO/company/server</strong>, <strong>peer-to-peer network</strong>. As long as one node exists, Bitcoin survives.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -1425,17 +1321,17 @@
             }
 
             if (choice === '247') {
-                feedbackDiv.innerHTML = `<h5>✓ Exactly Right!</h5><p>Bitcoin operates <strong>continuously without business hours, weekends, or holidays</strong>.<br><br>Traditional banks have operating hours and settlement delays (3-5 business days), while Bitcoin settles in <strong>10-60 minutes, anytime</strong>. This is infrastructure, not a service with office hours.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Bitcoin operates <strong>continuously without business hours, weekends, or holidays</strong>.<br><br>Traditional banks have operating hours and settlement delays (3-5 business days), while Bitcoin settles in <strong>10-60 minutes, anytime</strong>. This is infrastructure, not a service with office hours.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q4');
             } else if (choice === 'profit') {
-                feedbackDiv.innerHTML = `<h5>⚠️ No Guarantees</h5><p>Bitcoin doesn't guarantee profit—price is volatile. The actual advantage is <strong>24/7/365 operation</strong> with no business hours or settlement delays. It's infrastructure, not an investment product.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Bitcoin doesn't guarantee profit—price is volatile. The actual advantage is <strong>24/7/365 operation</strong> with no business hours or settlement delays. It's infrastructure, not an investment product.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else if (choice === 'free') {
-                feedbackDiv.innerHTML = `<h5>⚠️ Not Free</h5><p>Bitcoin transactions have fees (paid to miners). The real advantage is <strong>24/7 availability</strong>—no business hours, weekends, or settlement delays like banks have.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Bitcoin transactions have fees (paid to miners). The real advantage is <strong>24/7 availability</strong>—no business hours, weekends, or settlement delays like banks have.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Opposite Approach</h5><p>Bitcoin has <strong>no government insurance</strong>—you're responsible for your own security. The advantage is <strong>24/7/365 operation</strong> with instant global access and no business hours.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Bitcoin has <strong>no government insurance</strong>—you're responsible for your own security. The advantage is <strong>24/7/365 operation</strong> with instant global access and no business hours.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -1465,14 +1361,14 @@
             }
 
             if (score >= 4) {
-                feedbackDiv.innerHTML = `<h5>✓ Comprehensive List! (${score}/5 advantages)</h5><p>You identified multiple key advantages:<br><br><strong>24/7 operation</strong>, <strong>open access</strong>, <strong>fast settlement</strong>, <strong>censorship resistance</strong>, and <strong>borderless</strong> design. Bitcoin is infrastructure built for a global, always-on world.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You identified multiple key advantages:<br><br><strong>24/7 operation</strong>, <strong>open access</strong>, <strong>fast settlement</strong>, <strong>censorship resistance</strong>, and <strong>borderless</strong> design. Bitcoin is infrastructure built for a global, always-on world.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q4');
             } else if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Start (${score}/5 advantages)</h5><p>Also consider: 24/7 operation, open access, fast settlement (10-60 min vs 3-5 days), censorship resistance, borderless design. Each eliminates a friction point of traditional banking.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Also consider: 24/7 operation, open access, fast settlement (10-60 min vs 3-5 days), censorship resistance, borderless design. Each eliminates a friction point of traditional banking.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Expand Your List</h5><p>Key advantages: <strong>24/7 availability</strong> (no business hours), <strong>open access</strong> (no applications), <strong>fast settlement</strong> (~10 min), <strong>censorship-resistant</strong> (can't be frozen), <strong>borderless</strong> (global by default). Try listing 3+ with explanations!</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key advantages: <strong>24/7 availability</strong> (no business hours), <strong>open access</strong> (no applications), <strong>fast settlement</strong> (~10 min), <strong>censorship-resistant</strong> (can't be frozen), <strong>borderless</strong> (global by default). Try listing 3+ with explanations!</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -1483,28 +1379,10 @@
         const completedQuestions = new Set();
 
         function updateProgress(questionId) {
+            // Track answered reflections for the learner's own benefit (resume).
+            // No step-gating: the Continue link is always available.
             completedQuestions.add(questionId);
-            console.log(`Question ${questionId} completed. Total: ${completedQuestions.size}/4`);
-
-            // Enable button after answering at least 2 questions (Pragmatist-friendly)
-            if (completedQuestions.size >= 2) {
-                document.getElementById('complete-btn').disabled = false;
-                document.getElementById('complete-btn').textContent = '✅ Complete Module & Continue →';
-                console.log('Complete button enabled!');
-            }
         }
-
-        // Enable button on page load (allow learners to skip quiz if revisiting)
-        document.addEventListener('DOMContentLoaded', function() {
-            setTimeout(() => {
-                const hasVisited = localStorage.getItem('pragmatist-m1-visited');
-                if (hasVisited) {
-                    document.getElementById('complete-btn').disabled = false;
-                    console.log('Returning visitor - button auto-enabled');
-                }
-                localStorage.setItem('pragmatist-m1-visited', 'true');
-            }, 1000);
-        });
 
         // Save/load functions
         function saveResponse(key, value) {
@@ -1543,8 +1421,8 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
-        .feedback-box.positive { background: rgba(40, 167, 69, 0.08); border-color: #4caf50; color: var(--text-light); }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #ff9800; color: var(--text-light); }
+        .feedback-box.positive { background: rgba(255, 255, 255, 0.04); border-color: rgba(255, 255, 255, 0.18); color: var(--text-light); }
+        .feedback-box.hint { background: rgba(255, 255, 255, 0.04); border-color: rgba(255, 255, 255, 0.18); color: var(--text-light); }
         @media (max-width: 768px) {
             .reflection-tabs { flex-direction: column; }
             .reflection-tab { border-radius: 0.5rem; }

--- a/paths/pragmatist/stage-1/module-2.html
+++ b/paths/pragmatist/stage-1/module-2.html
@@ -48,7 +48,6 @@
                 <div class="module-meta">
                     <span><span data-icon="timer"></span> 20 minutes</span>
                     <span><span data-icon="chart"></span> Difficulty: Beginner</span>
-                    <span><span data-icon="target"></span> 15 Knowledge Points</span>
                 </div>
             </div>
         </div>
@@ -316,7 +315,7 @@
 
                 <!-- Quick Tab -->
                 <div id="q1-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                    <p style="margin-bottom: 1rem; color: var(--text-dim);">Select the correct answer:</p>
+                    <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                     <select id="q1-quick-choice" class="choice-select" onchange="checkWalletStores()">
                         <option value="">-- Choose one --</option>
                         <option value="bitcoins">The actual bitcoins themselves</option>
@@ -374,7 +373,7 @@
 
                 <!-- Quick Tab -->
                 <div id="q3-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                    <p style="margin-bottom: 1rem; color: var(--text-dim);">Choose the correct trade-off:</p>
+                    <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                     <select id="q3-quick-choice" class="choice-select" onchange="checkHotCold()">
                         <option value="">-- Choose one --</option>
                         <option value="correct">Hot is faster but less secure; cold is slower but more secure</option>
@@ -403,7 +402,7 @@
 
                 <!-- Quick Tab -->
                 <div id="q4-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                    <p style="margin-bottom: 1rem; color: var(--text-dim);">Choose your answer:</p>
+                    <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                     <select id="q4-quick-choice" class="choice-select" onchange="checkCloudBackup()">
                         <option value="">-- Choose one --</option>
                         <option value="true">True — cloud backup is convenient</option>
@@ -423,10 +422,7 @@
 
         <!-- Complete Module Button -->
         <div style="text-align: center; margin: 3rem 0;">
-            <button id="complete-btn" class="btn" disabled="" onclick="completeModule()">
-                <span data-icon="lock"></span> Complete Quiz First
-            </button>
-            <p style="margin-top: 1rem; color: var(--text-dim);">Answer all quiz questions correctly to unlock</p>
+            <a class="btn" href="/paths/pragmatist/stage-1/module-3.html">Continue to Module 3 →</a>
         </div>
     </div>
 
@@ -474,14 +470,14 @@
             }
 
             if (choice === 'keys') {
-                feedbackDiv.innerHTML = `<h5>✓ Exactly Right!</h5><p>Your wallet doesn't hold coins inside — it holds the <strong>keys that unlock your specific vaults on the Bitcoin ledger</strong>.<br><br>Whoever has those keys has the power to move the funds. This is why key management is everything in Bitcoin.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Your wallet doesn't hold coins inside — it holds the <strong>keys that unlock your specific vaults on the Bitcoin ledger</strong>.<br><br>Whoever has those keys has the power to move the funds. This is why key management is everything in Bitcoin.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q1');
             } else if (choice === 'bitcoins') {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Common Misconception</h5><p>Bitcoins don't live "in" your wallet. They exist on the blockchain. Your wallet stores the <strong>private keys</strong> that prove ownership and allow you to move those bitcoins. Think: keys to a vault, not the vault itself.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Bitcoins don't live "in" your wallet. They exist on the blockchain. Your wallet stores the <strong>private keys</strong> that prove ownership and allow you to move those bitcoins. Think: keys to a vault, not the vault itself.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Not Quite</h5><p>Wallets store your <strong>private keys</strong>—the cryptographic proof that you own specific bitcoins on the blockchain. The coins themselves live on the ledger, distributed across thousands of nodes.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Wallets store your <strong>private keys</strong>—the cryptographic proof that you own specific bitcoins on the blockchain. The coins themselves live on the ledger, distributed across thousands of nodes.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -510,14 +506,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Comprehensive Understanding! (${score}/4 concepts)</h5><p>You grasped the critical distinction:<br><br>Bitcoins exist on the <strong>distributed ledger</strong>. Your wallet stores <strong>private keys</strong> that prove <strong>ownership and authorize</strong> transactions. <strong>Lose the keys = lose access forever</strong>. There's no "account recovery"—you ARE the bank.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You grasped the critical distinction:<br><br>Bitcoins exist on the <strong>distributed ledger</strong>. Your wallet stores <strong>private keys</strong> that prove <strong>ownership and authorize</strong> transactions. <strong>Lose the keys = lose access forever</strong>. There's no "account recovery"—you ARE the bank.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q1');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Start (${score}/4 concepts)</h5><p>Strengthen your explanation: bitcoins live on the <strong>blockchain ledger</strong>, wallets store <strong>private keys</strong>, keys grant <strong>control/access</strong>, and <strong>lost keys = lost funds forever</strong>. This is why "Get your Bitcoin off exchanges."</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Strengthen your explanation: bitcoins live on the <strong>blockchain ledger</strong>, wallets store <strong>private keys</strong>, keys grant <strong>control/access</strong>, and <strong>lost keys = lost funds forever</strong>. This is why "Get your Bitcoin off exchanges."</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Expand Your Answer</h5><p>Key themes: <strong>private keys vs coins</strong>, <strong>blockchain as ledger</strong>, <strong>keys = control</strong>, <strong>no recovery if lost</strong>. Wallets are keychains, not vaults!</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key themes: <strong>private keys vs coins</strong>, <strong>blockchain as ledger</strong>, <strong>keys = control</strong>, <strong>no recovery if lost</strong>. Wallets are keychains, not vaults!</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -535,14 +531,14 @@
             }
 
             if (choice === 'rebuild') {
-                feedbackDiv.innerHTML = `<h5>✓ Perfect!</h5><p>Think of the seed phrase like the <strong>blueprint of your vault keys</strong>. It can rebuild your entire wallet, even if your phone or device disappears.<br><br>There's no 'forgot password'—this is your <strong>master backup</strong>. Protect it like your life depends on it.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Think of the seed phrase like the <strong>blueprint of your vault keys</strong>. It can rebuild your entire wallet, even if your phone or device disappears.<br><br>There's no 'forgot password'—this is your <strong>master backup</strong>. Protect it like your life depends on it.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q2');
             } else if (choice === 'password') {
-                feedbackDiv.innerHTML = `<h5>⚠️ No Password Resets</h5><p>There's no "forgot password" in Bitcoin—it's decentralized. The seed phrase doesn't reset anything; it <strong>IS your wallet</strong>. It can regenerate all your keys on any device. This is both power and responsibility.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>There's no "forgot password" in Bitcoin—it's decentralized. The seed phrase doesn't reset anything; it <strong>IS your wallet</strong>. It can regenerate all your keys on any device. This is both power and responsibility.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Not Its Function</h5><p>The seed phrase is your <strong>wallet recovery mechanism</strong>. It can rebuild your entire wallet (all keys, all addresses) on any device. Lose it = permanent loss of access. Protect it = you can always recover.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>The seed phrase is your <strong>wallet recovery mechanism</strong>. It can rebuild your entire wallet (all keys, all addresses) on any device. Lose it = permanent loss of access. Protect it = you can always recover.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -571,14 +567,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Excellent Analysis! (${score}/4 themes)</h5><p>You understand the stakes:<br><br>(a) <strong>Lose phone + have seed</strong> = fully recoverable. Buy new device, restore wallet.<br>(b) <strong>Lose seed</strong> = funds locked forever. No customer service, no password reset.<br><br>Bitcoin gives you control. The cost is <strong>personal responsibility</strong>.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You understand the stakes:<br><br>(a) <strong>Lose phone + have seed</strong> = fully recoverable. Buy new device, restore wallet.<br>(b) <strong>Lose seed</strong> = funds locked forever. No customer service, no password reset.<br><br>Bitcoin gives you control. The cost is <strong>personal responsibility</strong>.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q2');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Understanding (${score}/4 themes)</h5><p>Add: <strong>seed = recovery</strong>, <strong>no seed = permanent loss</strong>, <strong>no password reset exists</strong>, <strong>you're the bank now</strong>. This isn't a bug—it's the feature. Full control = full responsibility.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Add: <strong>seed = recovery</strong>, <strong>no seed = permanent loss</strong>, <strong>no password reset exists</strong>, <strong>you're the bank now</strong>. This isn't a bug—it's the feature. Full control = full responsibility.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Think Through Scenarios</h5><p>Scenario (a): <strong>Phone lost, seed safe → recover wallet</strong>. Scenario (b): <strong>Seed lost → funds gone forever</strong>. Why no reset? <strong>Decentralized = no company to call</strong>. You are your own bank.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Scenario (a): <strong>Phone lost, seed safe → recover wallet</strong>. Scenario (b): <strong>Seed lost → funds gone forever</strong>. Why no reset? <strong>Decentralized = no company to call</strong>. You are your own bank.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -596,14 +592,14 @@
             }
 
             if (choice === 'correct') {
-                feedbackDiv.innerHTML = `<h5>✓ Exactly Right!</h5><p>Treat Bitcoin storage like cybersecurity: separate <strong>"hot" (daily use, convenient but more exposed)</strong> from <strong>"cold" (long-term savings, offline and more secure)</strong>.<br><br>Pragmatists optimize <strong>both</strong> convenience and security—not one at the expense of the other.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Treat Bitcoin storage like cybersecurity: separate <strong>"hot" (daily use, convenient but more exposed)</strong> from <strong>"cold" (long-term savings, offline and more secure)</strong>.<br><br>Pragmatists optimize <strong>both</strong> convenience and security—not one at the expense of the other.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q3');
             } else if (choice === 'amounts') {
-                feedbackDiv.innerHTML = `<h5>⚠️ Backwards</h5><p>It's the opposite: <strong>hot wallets for small amounts</strong> (daily spending), <strong>cold wallets for large amounts</strong> (long-term savings). Hot = convenient but riskier. Cold = secure but slower access.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>It's the opposite: <strong>hot wallets for small amounts</strong> (daily spending), <strong>cold wallets for large amounts</strong> (long-term savings). Hot = convenient but riskier. Cold = secure but slower access.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Close, But Not Quite</h5><p>The core trade-off is <strong>speed/convenience vs security</strong>. Hot wallets (connected to internet) are fast but exposed. Cold wallets (offline) are secure but require more steps. Choose based on amount and use case.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>The core trade-off is <strong>speed/convenience vs security</strong>. Hot wallets (connected to internet) are fast but exposed. Cold wallets (offline) are secure but require more steps. Choose based on amount and use case.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -632,14 +628,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Strategic Thinking! (${score}/4 factors)</h5><p>You're applying the right framework:<br><br><strong>Hot = daily spending</strong> (small amounts, frequent access)<br><strong>Cold = long-term savings</strong> (large amounts, rare access)<br><strong>Risk tolerance + amount thresholds</strong> determine the split<br><br>Rule of thumb: <$1k hot, >$10k cold, balance for middle amounts.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You're applying the right framework:<br><br><strong>Hot = daily spending</strong> (small amounts, frequent access)<br><strong>Cold = long-term savings</strong> (large amounts, rare access)<br><strong>Risk tolerance + amount thresholds</strong> determine the split<br><br>Rule of thumb: <$1k hot, >$10k cold, balance for middle amounts.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q3');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Start (${score}/4 factors)</h5><p>Also consider: <strong>hot for daily spending</strong>, <strong>cold for long-term savings</strong>, <strong>risk tolerance</strong>, and <strong>amount-based thresholds</strong> (e.g., <$1k mobile, >$10k hardware). Optimize for both security AND usability.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Also consider: <strong>hot for daily spending</strong>, <strong>cold for long-term savings</strong>, <strong>risk tolerance</strong>, and <strong>amount-based thresholds</strong> (e.g., <$1k mobile, >$10k hardware). Optimize for both security AND usability.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Expand Your Strategy</h5><p>Key factors: <strong>hot = daily spending</strong>, <strong>cold = long-term savings</strong>, <strong>your risk tolerance</strong>, <strong>amount thresholds</strong>. Most pragmatists: small amounts hot, large amounts cold. Balance security with accessibility.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key factors: <strong>hot = daily spending</strong>, <strong>cold = long-term savings</strong>, <strong>your risk tolerance</strong>, <strong>amount thresholds</strong>. Most pragmatists: small amounts hot, large amounts cold. Balance security with accessibility.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -657,11 +653,11 @@
             }
 
             if (choice === 'false') {
-                feedbackDiv.innerHTML = `<h5>✓ Correct!</h5><p><strong>NEVER type your seed phrase online</strong>—that's like emailing your house keys.<br><br>Write it once on paper or metal, protect it always, and keep <strong>multiple backups in different physical locations</strong>. Digital = hackable. Physical = your responsibility.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p><strong>NEVER type your seed phrase online</strong>—that's like emailing your house keys.<br><br>Write it once on paper or metal, protect it always, and keep <strong>multiple backups in different physical locations</strong>. Digital = hackable. Physical = your responsibility.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q4');
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ CRITICAL ERROR</h5><p>This is how people lose everything. <strong>NEVER store seed phrases digitally</strong>: no photos, no screenshots, no cloud storage, no password managers.<br><br>Once it touches the internet, it's compromised. Use <strong>paper or metal backups</strong> in secure physical locations.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>This is how people lose everything. <strong>NEVER store seed phrases digitally</strong>: no photos, no screenshots, no cloud storage, no password managers.<br><br>Once it touches the internet, it's compromised. Use <strong>paper or metal backups</strong> in secure physical locations.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -690,14 +686,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Security-Conscious! (${score}/4 threats identified)</h5><p>You understand the attack vectors:<br><br><strong>Hacking/breaches</strong>, <strong>keyloggers/malware</strong>, <strong>cloud vulnerabilities</strong>—all real threats to digital storage.<br><br><strong>Proper method:</strong> Write on <strong>paper or metal</strong>, store in multiple <strong>physical locations</strong> (fireproof safe, safety deposit box). Never digital.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You understand the attack vectors:<br><br><strong>Hacking/breaches</strong>, <strong>keyloggers/malware</strong>, <strong>cloud vulnerabilities</strong>—all real threats to digital storage.<br><br><strong>Proper method:</strong> Write on <strong>paper or metal</strong>, store in multiple <strong>physical locations</strong> (fireproof safe, safety deposit box). Never digital.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q4');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Awareness (${score}/4 threats)</h5><p>Also consider: <strong>hacking</strong>, <strong>keyloggers</strong>, <strong>cloud breaches</strong>. Proper backup: <strong>paper or metal plates</strong> stored in multiple secure locations. Digital convenience = digital vulnerability.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Also consider: <strong>hacking</strong>, <strong>keyloggers</strong>, <strong>cloud breaches</strong>. Proper backup: <strong>paper or metal plates</strong> stored in multiple secure locations. Digital convenience = digital vulnerability.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> List More Threats</h5><p>Digital risks: <strong>hacking</strong>, <strong>keyloggers/malware</strong>, <strong>cloud provider breaches</strong>, <strong>device theft</strong>. Proper method: <strong>paper/metal backups</strong> in fireproof safes, safety deposit boxes. 3+ reasons = comprehensive understanding!</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Digital risks: <strong>hacking</strong>, <strong>keyloggers/malware</strong>, <strong>cloud provider breaches</strong>, <strong>device theft</strong>. Proper method: <strong>paper/metal backups</strong> in fireproof safes, safety deposit boxes. 3+ reasons = comprehensive understanding!</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -709,10 +705,6 @@
 
         function updateProgress(questionId) {
             completedQuestions.add(questionId);
-            if (completedQuestions.size >= 4) {
-                document.getElementById('complete-btn').disabled = false;
-                document.getElementById('complete-btn').textContent = '✅ Complete Module & Continue →';
-            }
         }
 
         // Save/load
@@ -731,35 +723,6 @@
             });
         }
 
-        // Complete module
-        function completeModule() {
-            if (!window.pragmatistProgress.data.completedModules.includes('1-2')) {
-                window.pragmatistProgress.data.completedModules.push('1-2');
-                window.pragmatistProgress.data.knowledgeScore += 15;
-                if (!window.pragmatistProgress.data.achievements.includes('wallet-wisdom')) {
-                    window.pragmatistProgress.data.achievements.push('wallet-wisdom');
-                }
-                window.pragmatistProgress.save();
-                showAchievement('Wallet Wisdom', 'Mastered Bitcoin wallet security!', '💼');
-                setTimeout(() => {
-                    window.location.href = '/paths/pragmatist/stage-1/module-3.html';
-                }, 2000);
-            }
-        }
-
-        function showAchievement(title, description, icon) {
-            const notification = document.createElement('div');
-            notification.className = 'achievement-notification';
-            notification.innerHTML = `
-                <div class="achievement-icon">${icon}</div>
-                <div class="achievement-title">${title}</div>
-                <div style="color: var(--text-gray); font-size: 1.2rem;">${description}</div>
-                <div style="margin-top: 1rem; color: var(--bright-orange); font-weight: bold;">+15 Knowledge Points</div>
-            `;
-            document.body.appendChild(notification);
-            setTimeout(() => notification.remove(), 3000);
-        }
-
         document.addEventListener('DOMContentLoaded', loadResponses);
     </script>
 
@@ -772,8 +735,8 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
-        .feedback-box.positive { background: rgba(40, 167, 69, 0.08); border-color: #4caf50; color: var(--text-light); }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #ff9800; color: var(--text-light); }
+        .feedback-box.positive { background: rgba(255, 255, 255, 0.04); border-color: rgba(255, 255, 255, 0.18); color: var(--text-light); }
+        .feedback-box.hint { background: rgba(255, 255, 255, 0.04); border-color: rgba(255, 255, 255, 0.18); color: var(--text-light); }
         @media (max-width: 768px) {
             .reflection-tabs { flex-direction: column; }
             .reflection-tab { border-radius: 0.5rem; }

--- a/paths/pragmatist/stage-1/module-3.html
+++ b/paths/pragmatist/stage-1/module-3.html
@@ -48,7 +48,6 @@
                 <div class="module-meta">
                     <span><span data-icon="timer"></span> 25 minutes</span>
                     <span><span data-icon="chart"></span> Difficulty: Beginner</span>
-                    <span><span data-icon="target"></span> 20 Knowledge Points</span>
                 </div>
             </div>
         </div>
@@ -395,7 +394,7 @@
 
                 <!-- Quick Tab -->
                 <div id="q1-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                    <p style="margin-bottom: 1rem; color: var(--text-dim);">Select the correct answer:</p>
+                    <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                     <select id="q1-quick-choice" class="choice-select" onchange="checkFees()">
                         <option value="">-- Choose one --</option>
                         <option value="amount">The amount of Bitcoin being sent</option>
@@ -424,7 +423,7 @@
 
                 <!-- Quick Tab -->
                 <div id="q2-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                    <p style="margin-bottom: 1rem; color: var(--text-dim);">Select the best answer:</p>
+                    <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                     <select id="q2-quick-choice" class="choice-select" onchange="checkFinality()">
                         <option value="">-- Choose one --</option>
                         <option value="banks">Because banks verify it</option>
@@ -453,7 +452,7 @@
 
                 <!-- Quick Tab -->
                 <div id="q3-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                    <p style="margin-bottom: 1rem; color: var(--text-dim);">Choose the best use case:</p>
+                    <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                     <select id="q3-quick-choice" class="choice-select" onchange="checkLightning()">
                         <option value="">-- Choose one --</option>
                         <option value="storage">For storing large amounts long-term</option>
@@ -475,10 +474,7 @@
 
         <!-- Complete Module Button -->
         <div style="text-align: center; margin: 3rem 0;">
-            <button id="complete-btn" class="btn" disabled="" onclick="completeModule()">
-                <span data-icon="lock"></span> Complete Quiz First
-            </button>
-            <p style="margin-top: 1rem; color: var(--text-dim);">Answer all quiz questions correctly to unlock</p>
+            <a class="btn" href="/paths/pragmatist/stage-1/module-4.html">Continue to Module 4 →</a>
         </div>
     </div>
 
@@ -526,17 +522,17 @@
             }
 
             if (choice === 'datasize') {
-                feedbackDiv.innerHTML = `<h5>✓ Exactly Right!</h5><p>Fees depend on <strong>data size + network demand</strong>, not on the amount sent.<br><br>You're <strong>bidding for space in the next block</strong>. A $1M transaction can cost the same as a $10 transaction if they use the same block space.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Fees depend on <strong>data size + network demand</strong>, not on the amount sent.<br><br>You're <strong>bidding for space in the next block</strong>. A $1M transaction can cost the same as a $10 transaction if they use the same block space.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q1');
             } else if (choice === 'amount') {
-                feedbackDiv.innerHTML = `<h5>⚠️ Common Misconception</h5><p>Bitcoin fees are NOT based on value sent. A $1M transaction costs the same as a $10 transaction if they use the same <strong>data size (bytes)</strong>. You're paying for block space, not percentage of value.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Bitcoin fees are NOT based on value sent. A $1M transaction costs the same as a $10 transaction if they use the same <strong>data size (bytes)</strong>. You're paying for block space, not percentage of value.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else if (choice === 'fixed') {
-                feedbackDiv.innerHTML = `<h5>⚠️ No Fixed Fees</h5><p>There's no fixed fee—you're <strong>bidding in a free market</strong> for block space. Higher fee = faster confirmation. Lower fee = longer wait. It's an auction system based on supply (block space) and demand (pending transactions).</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>There's no fixed fee—you're <strong>bidding in a free market</strong> for block space. Higher fee = faster confirmation. Lower fee = longer wait. It's an auction system based on supply (block space) and demand (pending transactions).</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Not Related</h5><p>Confirmations don't determine fees. Fees are based on <strong>transaction data size (bytes)</strong> + <strong>network congestion</strong>. You bid for space in the next block. More demand = higher fees needed.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Confirmations don't determine fees. Fees are based on <strong>transaction data size (bytes)</strong> + <strong>network congestion</strong>. You bid for space in the next block. More demand = higher fees needed.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -565,14 +561,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Economic Understanding! (${score}/4 concepts)</h5><p>You grasped the incentive design:<br><br><strong>Block space is scarce</strong> → fees create an <strong>auction market</strong>. Fees are <strong>independent of value sent</strong> (you pay for bytes, not bitcoin). This <strong>prevents spam</strong>—attackers can't flood the network cheaply.<br><br>Smart economics: align cost with resource consumption (block space), not transaction value.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You grasped the incentive design:<br><br><strong>Block space is scarce</strong> → fees create an <strong>auction market</strong>. Fees are <strong>independent of value sent</strong> (you pay for bytes, not bitcoin). This <strong>prevents spam</strong>—attackers can't flood the network cheaply.<br><br>Smart economics: align cost with resource consumption (block space), not transaction value.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q1');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Start (${score}/4 concepts)</h5><p>Strengthen your explanation: <strong>block space is limited</strong>, <strong>auction/bidding system</strong>, <strong>independent of value</strong>, <strong>spam prevention</strong>. This design makes network abuse expensive while keeping value transfer cheap.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Strengthen your explanation: <strong>block space is limited</strong>, <strong>auction/bidding system</strong>, <strong>independent of value</strong>, <strong>spam prevention</strong>. This design makes network abuse expensive while keeping value transfer cheap.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Expand Your Analysis</h5><p>Key themes: <strong>scarce block space</strong>, <strong>free market auction</strong>, <strong>size matters not value</strong>, <strong>prevents spam attacks</strong>. Why bytes? Because that's what consumes the limited resource (block space).</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key themes: <strong>scarce block space</strong>, <strong>free market auction</strong>, <strong>size matters not value</strong>, <strong>prevents spam attacks</strong>. Why bytes? Because that's what consumes the limited resource (block space).</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -590,17 +586,17 @@
             }
 
             if (choice === 'math') {
-                feedbackDiv.innerHTML = `<h5>✓ Perfect Understanding!</h5><p>To undo six confirmations, an attacker would need <strong>more computational power than the entire network</strong>—mathematically impossible in practice.<br><br>Each block adds ~10 minutes of global hash power as a security layer. 6 blocks = ~1 hour of irreversible proof-of-work.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>To undo six confirmations, an attacker would need <strong>more computational power than the entire network</strong>—mathematically impossible in practice.<br><br>Each block adds ~10 minutes of global hash power as a security layer. 6 blocks = ~1 hour of irreversible proof-of-work.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q2');
             } else if (choice === 'banks') {
-                feedbackDiv.innerHTML = `<h5>⚠️ No Banks Involved</h5><p>Bitcoin is <strong>peer-to-peer</strong>—no banks verify anything. Finality comes from <strong>proof-of-work</strong>: each block requires massive computational energy. Reversing 6+ blocks would cost hundreds of millions in electricity.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Bitcoin is <strong>peer-to-peer</strong>—no banks verify anything. Finality comes from <strong>proof-of-work</strong>: each block requires massive computational energy. Reversing 6+ blocks would cost hundreds of millions in electricity.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else if (choice === 'government') {
-                feedbackDiv.innerHTML = `<h5>⚠️ Decentralized, Not Government</h5><p>No government approves Bitcoin transactions. Finality is <strong>mathematical</strong>: proof-of-work makes reversal prohibitively expensive. Attack cost grows exponentially with each confirmation.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>No government approves Bitcoin transactions. Finality is <strong>mathematical</strong>: proof-of-work makes reversal prohibitively expensive. Attack cost grows exponentially with each confirmation.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Encryption Isn't Finality</h5><p>Encryption secures transactions in transit, but <strong>proof-of-work creates finality</strong>. Each confirmation = a block built on top, requiring massive energy to reverse. 6 confirmations = practically irreversible.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Encryption secures transactions in transit, but <strong>proof-of-work creates finality</strong>. Each confirmation = a block built on top, requiring massive energy to reverse. 6 confirmations = practically irreversible.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -629,14 +625,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Security Expert! (${score}/4 concepts)</h5><p>You understand the economic security model:<br><br>Each <strong>confirmation adds a proof-of-work layer</strong>. To reverse, an attacker needs <strong>majority hash power</strong> + massive <strong>energy cost</strong> (millions in electricity). With 6+ confirmations, this becomes <strong>economically irrational</strong>.<br><br>Bitcoin doesn't prevent attacks—it makes them unprofitable.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You understand the economic security model:<br><br>Each <strong>confirmation adds a proof-of-work layer</strong>. To reverse, an attacker needs <strong>majority hash power</strong> + massive <strong>energy cost</strong> (millions in electricity). With 6+ confirmations, this becomes <strong>economically irrational</strong>.<br><br>Bitcoin doesn't prevent attacks—it makes them unprofitable.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q2');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Understanding (${score}/4 concepts)</h5><p>Also consider: <strong>confirmations stack security</strong>, <strong>requires majority hash power</strong>, <strong>prohibitively expensive</strong> (energy + hardware), <strong>51% attack impractical</strong>. More confirmations = exponentially harder to reverse.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Also consider: <strong>confirmations stack security</strong>, <strong>requires majority hash power</strong>, <strong>prohibitively expensive</strong> (energy + hardware), <strong>51% attack impractical</strong>. More confirmations = exponentially harder to reverse.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Dig Deeper</h5><p>Key factors: <strong>each confirmation = security layer</strong>, <strong>needs >51% network hash power</strong>, <strong>costs millions in energy</strong>, <strong>attack is economically impossible</strong>. Proof-of-work converts energy into irreversibility.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key factors: <strong>each confirmation = security layer</strong>, <strong>needs >51% network hash power</strong>, <strong>costs millions in energy</strong>, <strong>attack is economically impossible</strong>. Proof-of-work converts energy into irreversibility.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -654,17 +650,17 @@
             }
 
             if (choice === 'instant') {
-                feedbackDiv.innerHTML = `<h5>✓ Perfect Use Case!</h5><p>Use <strong>on-chain for reliability</strong>, <strong>Lightning for speed</strong>—just as you'd balance main power vs. backup generators.<br><br>Lightning is ideal for <strong>daily use and micro-transactions</strong>: instant settlement, near-zero fees. Think: coffee purchases, streaming payments, frequent transfers.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Use <strong>on-chain for reliability</strong>, <strong>Lightning for speed</strong>—just as you'd balance main power vs. backup generators.<br><br>Lightning is ideal for <strong>daily use and micro-transactions</strong>: instant settlement, near-zero fees. Think: coffee purchases, streaming payments, frequent transfers.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q3');
             } else if (choice === 'storage') {
-                feedbackDiv.innerHTML = `<h5>⚠️ Opposite Use Case</h5><p>Use <strong>on-chain for long-term storage</strong> (maximum security, final settlement). Use <strong>Lightning for daily spending</strong> (instant, cheap). Don't store large amounts on Lightning—it's optimized for velocity, not vaults.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Use <strong>on-chain for long-term storage</strong> (maximum security, final settlement). Use <strong>Lightning for daily spending</strong> (instant, cheap). Don't store large amounts on Lightning—it's optimized for velocity, not vaults.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else if (choice === 'security') {
-                feedbackDiv.innerHTML = `<h5>⚠️ On-Chain for Maximum Security</h5><p>For maximum security and final settlement, use <strong>on-chain transactions</strong> with multiple confirmations. Lightning trades some security for speed—it's perfect for <strong>small, frequent payments</strong>, not large value storage.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>For maximum security and final settlement, use <strong>on-chain transactions</strong> with multiple confirmations. Lightning trades some security for speed—it's perfect for <strong>small, frequent payments</strong>, not large value storage.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Close, But More Specific</h5><p>Lightning works for cross-border, but it's optimized for <strong>small, frequent, instant payments</strong>—think daily spending, not occasional wire transfers. On-chain is better for large cross-border settlements requiring maximum finality.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Lightning works for cross-border, but it's optimized for <strong>small, frequent, instant payments</strong>—think daily spending, not occasional wire transfers. On-chain is better for large cross-border settlements requiring maximum finality.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -693,14 +689,14 @@
             }
 
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Strategic Choice! (${score}/4 factors)</h5><p>You understand the layer trade-offs:<br><br><strong>On-chain:</strong> slow (~10 min), variable fees, maximum security → use for savings/large amounts<br><strong>Lightning:</strong> instant, near-zero fees, channel-dependent security → use for daily spending/small frequent payments<br><br>Pragmatists use both: on-chain as main grid, Lightning as local circuit.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You understand the layer trade-offs:<br><br><strong>On-chain:</strong> slow (~10 min), variable fees, maximum security → use for savings/large amounts<br><strong>Lightning:</strong> instant, near-zero fees, channel-dependent security → use for daily spending/small frequent payments<br><br>Pragmatists use both: on-chain as main grid, Lightning as local circuit.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q3');
             } else if (score >= 2) {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Good Comparison (${score}/4 factors)</h5><p>Strengthen your analysis: <strong>Lightning = instant + cheap</strong>, <strong>on-chain = secure + final</strong>, <strong>Lightning for daily spending</strong>, <strong>on-chain for savings</strong>. Each layer optimizes for different needs.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Strengthen your analysis: <strong>Lightning = instant + cheap</strong>, <strong>on-chain = secure + final</strong>, <strong>Lightning for daily spending</strong>, <strong>on-chain for savings</strong>. Each layer optimizes for different needs.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Compare Both Layers</h5><p>Key factors: <strong>speed</strong> (Lightning instant, on-chain ~10 min), <strong>cost</strong> (Lightning near-zero, on-chain variable), <strong>security</strong> (on-chain maximum, Lightning channel-based), <strong>use cases</strong> (Lightning daily, on-chain savings). Compare trade-offs!</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key factors: <strong>speed</strong> (Lightning instant, on-chain ~10 min), <strong>cost</strong> (Lightning near-zero, on-chain variable), <strong>security</strong> (on-chain maximum, Lightning channel-based), <strong>use cases</strong> (Lightning daily, on-chain savings). Compare trade-offs!</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -712,10 +708,6 @@
 
         function updateProgress(questionId) {
             completedQuestions.add(questionId);
-            if (completedQuestions.size >= 3) {
-                document.getElementById('complete-btn').disabled = false;
-                document.getElementById('complete-btn').textContent = '✅ Complete Module & Continue →';
-            }
         }
 
         // Save/load
@@ -734,37 +726,6 @@
             });
         }
 
-        // Complete module
-        function completeModule() {
-            if (!window.pragmatistProgress.data.completedModules.includes('1-3')) {
-                window.pragmatistProgress.data.completedModules.push('1-3');
-                window.pragmatistProgress.data.knowledgeScore += 20;
-                if (window.pragmatistProgress.data.completedModules.filter(m => m.startsWith('1-')).length === 3) {
-                    if (!window.pragmatistProgress.data.achievements.includes('stage-1-complete')) {
-                        window.pragmatistProgress.data.achievements.push('stage-1-complete');
-                    }
-                }
-                window.pragmatistProgress.save();
-                showAchievement('Transaction Master', 'Mastered Bitcoin transactions!', '⚡');
-                setTimeout(() => {
-                    window.location.href = '/paths/pragmatist/stage-1/module-4.html';
-                }, 2000);
-            }
-        }
-
-        function showAchievement(title, description, icon) {
-            const notification = document.createElement('div');
-            notification.className = 'achievement-notification';
-            notification.innerHTML = `
-                <div class="achievement-icon">${icon}</div>
-                <div class="achievement-title">${title}</div>
-                <div style="color: var(--text-gray); font-size: 1.2rem;">${description}</div>
-                <div style="margin-top: 1rem; color: var(--bright-orange); font-weight: bold;">+20 Knowledge Points</div>
-            `;
-            document.body.appendChild(notification);
-            setTimeout(() => notification.remove(), 3000);
-        }
-
         document.addEventListener('DOMContentLoaded', loadResponses);
     </script>
 
@@ -777,8 +738,8 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
-        .feedback-box.positive { background: rgba(40, 167, 69, 0.08); border-color: #4caf50; color: var(--text-light); }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #ff9800; color: var(--text-light); }
+        .feedback-box.positive { background: rgba(255, 255, 255, 0.04); border-color: rgba(255, 255, 255, 0.18); color: var(--text-light); }
+        .feedback-box.hint { background: rgba(255, 255, 255, 0.04); border-color: rgba(255, 255, 255, 0.18); color: var(--text-light); }
         @media (max-width: 768px) {
             .reflection-tabs { flex-direction: column; }
             .reflection-tab { border-radius: 0.5rem; }

--- a/paths/pragmatist/stage-1/module-4.html
+++ b/paths/pragmatist/stage-1/module-4.html
@@ -48,7 +48,6 @@
                 <div class="module-meta">
                     <span><span data-icon="timer"></span> 25 minutes</span>
                     <span><span data-icon="chart"></span> Difficulty: Beginner</span>
-                    <span><span data-icon="target"></span> 20 Knowledge Points</span>
                 </div>
             </div>
         </div>

--- a/paths/pragmatist/stage-2/module-5-security.html
+++ b/paths/pragmatist/stage-2/module-5-security.html
@@ -48,7 +48,6 @@
                 <div class="module-meta">
                     <span><span data-icon="timer"></span> 30 minutes</span>
                     <span><span data-icon="chart"></span> Difficulty: Intermediate</span>
-                    <span><span data-icon="target"></span> 20 Knowledge Points</span>
                 </div>
             </div>
         </div>
@@ -375,7 +374,7 @@
                     </div>
 
                     <div id="q1-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                        <p style="margin-bottom: 1rem; color: var(--text-dim);">Select the most critical practice:</p>
+                        <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                         <select id="q1-quick-choice" class="choice-select" onchange="checkSecurity()">
                             <option value="">-- Choose one --</option>
                             <option value="exchange">Using a strong exchange account password</option>
@@ -401,7 +400,7 @@
                     </div>
 
                     <div id="q2-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                        <p style="margin-bottom: 1rem; color: var(--text-dim);">Identify the dangerous practice:</p>
+                        <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                         <select id="q2-quick-choice" class="choice-select" onchange="checkStorage()">
                             <option value="">-- Choose one --</option>
                             <option value="paper">Write it down on paper</option>
@@ -427,7 +426,7 @@
                     </div>
 
                     <div id="q3-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                        <p style="margin-bottom: 1rem; color: var(--text-dim);">Choose the safest option:</p>
+                        <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                         <select id="q3-quick-choice" class="choice-select" onchange="checkHardware()">
                             <option value="">-- Choose one --</option>
                             <option value="exchange">Exchange web wallet</option>
@@ -453,7 +452,7 @@
                     </div>
 
                     <div id="q4-quick" class="reflection-panel active" role="tabpanel" aria-hidden="false">
-                        <p style="margin-bottom: 1rem; color: var(--text-dim);">Select the best practice:</p>
+                        <p style="margin-bottom: 1rem; color: var(--text-dim);">What do you think?</p>
                         <select id="q4-quick-choice" class="choice-select" onchange="checkTest()">
                             <option value="">-- Choose one --</option>
                             <option value="verify">Verify the address carefully and send a test transaction first</option>
@@ -474,10 +473,7 @@
 
         <!-- Complete Module Button -->
         <div style="text-align: center; margin: 3rem 0;">
-            <button id="complete-btn" class="btn" disabled="" onclick="completeModule()">
-                <span data-icon="lock"></span> Complete Quiz First
-            </button>
-            <p style="margin-top: 1rem; color: var(--text-dim);">Answer all quiz questions correctly to complete the Pragmatist!</p>
+            <a class="btn" href="/paths/pragmatist/stage-2/module-6-lightning.html">Continue to Module 6 →</a>
         </div>
     </div>
 
@@ -521,14 +517,14 @@
                 return;
             }
             if (choice === 'seedphrase') {
-                feedbackDiv.innerHTML = `<h5>✓ Correct!</h5><p><strong>Seed phrase security is everything.</strong><br><br>It's your master key—lose it = lose access forever. Someone steals it = they steal your Bitcoin.<br><br>No password reset. No customer support. You are the bank. Protect it like your life savings depend on it.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p><strong>Seed phrase security is everything.</strong><br><br>It's your master key—lose it = lose access forever. Someone steals it = they steal your Bitcoin.<br><br>No password reset. No customer support. You are the bank. Protect it like your life savings depend on it.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q1');
             } else if (choice === 'exchange') {
-                feedbackDiv.innerHTML = `<h5>⚠️ Exchange ≠ Self-Custody</h5><p>Exchange passwords matter, but you don't control the keys. The real foundation is <strong>seed phrase security for self-custody</strong>. "Get your Bitcoin off exchanges."</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Exchange passwords matter, but you don't control the keys. The real foundation is <strong>seed phrase security for self-custody</strong>. "Get your Bitcoin off exchanges."</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Dangerous Practice</h5><p>Keeping Bitcoin on exchanges means <strong>you don't own it</strong>—they do. Exchanges get hacked, frozen, or go bankrupt. Self-custody with secure seed phrases is the foundation of Bitcoin security.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Keeping Bitcoin on exchanges means <strong>you don't own it</strong>—they do. Exchanges get hacked, frozen, or go bankrupt. Self-custody with secure seed phrases is the foundation of Bitcoin security.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -548,11 +544,11 @@
             if (/(steal|theft|compromise)/.test(text)) score++;
             if (/(no reset|no support|no password)/.test(text)) score++;
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Complete Understanding! (${score}/4)</h5><p><strong>Lose seed:</strong> Funds locked forever (no reset)<br><strong>Stolen seed:</strong> Attacker drains wallet (irreversible)<br><br>This is the trade-off: <strong>full control = full responsibility</strong>. Bitcoin gives you sovereignty—the cost is personal security discipline.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p><strong>Lose seed:</strong> Funds locked forever (no reset)<br><strong>Stolen seed:</strong> Attacker drains wallet (irreversible)<br><br>This is the trade-off: <strong>full control = full responsibility</strong>. Bitcoin gives you sovereignty—the cost is personal security discipline.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q1');
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Expand Scenarios (${score}/4)</h5><p>Cover: <strong>master key control</strong>, <strong>lose = permanent loss</strong>, <strong>steal = funds gone</strong>, <strong>no password reset</strong>. Seed phrase IS your wallet.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Cover: <strong>master key control</strong>, <strong>lose = permanent loss</strong>, <strong>steal = funds gone</strong>, <strong>no password reset</strong>. Seed phrase IS your wallet.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -568,14 +564,14 @@
                 return;
             }
             if (choice === 'digital') {
-                feedbackDiv.innerHTML = `<h5>✓ CRITICAL Security Rule!</h5><p><strong>NEVER store seed phrases digitally:</strong><br>• No screenshots<br>• No photos<br>• No cloud storage<br>• No password managers<br>• No computer files<br><br>Once digital, it can be hacked. Use <strong>paper or metal, stored physically in multiple secure locations</strong>.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p><strong>NEVER store seed phrases digitally:</strong><br>• No screenshots<br>• No photos<br>• No cloud storage<br>• No password managers<br>• No computer files<br><br>Once digital, it can be hacked. Use <strong>paper or metal, stored physically in multiple secure locations</strong>.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q2');
             } else if (choice === 'paper') {
-                feedbackDiv.innerHTML = `<h5>⚠️ Paper Is GOOD!</h5><p>Writing seed phrases on paper is <strong>proper security practice</strong> (as long as it's stored safely). The danger is <strong>digital storage</strong>—screenshots, photos, cloud, files. Digital = hackable.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Writing seed phrases on paper is <strong>proper security practice</strong> (as long as it's stored safely). The danger is <strong>digital storage</strong>—screenshots, photos, cloud, files. Digital = hackable.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Safes Are GOOD!</h5><p>Fireproof safes are excellent for storing seed phrases. The danger is <strong>digital storage</strong> (computers, phones, cloud). Physical + offline = secure. Digital = vulnerable.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Fireproof safes are excellent for storing seed phrases. The danger is <strong>digital storage</strong> (computers, phones, cloud). Physical + offline = secure. Digital = vulnerable.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -595,11 +591,11 @@
             if (/(cloud|server|icloud|google)/.test(text)) score++;
             if (/(paper|metal|physical|offline|steel)/.test(text)) score++;
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Security Expert! (${score}/4 risks)</h5><p>Digital threats: <strong>hacking</strong>, <strong>malware/keyloggers</strong>, <strong>cloud breaches</strong>.<br><br><strong>Proper method:</strong> <strong>Paper or metal backups</strong> in fireproof safe, safety deposit box. Never digital. 3+ physical copies in separate locations.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Digital threats: <strong>hacking</strong>, <strong>malware/keyloggers</strong>, <strong>cloud breaches</strong>.<br><br><strong>Proper method:</strong> <strong>Paper or metal backups</strong> in fireproof safe, safety deposit box. Never digital. 3+ physical copies in separate locations.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q2');
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> List More Threats (${score}/4)</h5><p>Risks: <strong>hacking</strong>, <strong>malware/keyloggers</strong>, <strong>cloud provider breaches</strong>. Solution: <strong>paper/metal backups</strong> stored physically. Digital convenience = digital vulnerability.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Risks: <strong>hacking</strong>, <strong>malware/keyloggers</strong>, <strong>cloud provider breaches</strong>. Solution: <strong>paper/metal backups</strong> stored physically. Digital convenience = digital vulnerability.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -615,14 +611,14 @@
                 return;
             }
             if (choice === 'hardware') {
-                feedbackDiv.innerHTML = `<h5>✓ Gold Standard!</h5><p><strong>Hardware wallets</strong> (Ledger, Trezor, Coldcard) are the safest option for large amounts:<br><br>• Keys never leave the device<br>• Immune to computer malware<br>• Offline cold storage<br>• Transaction signing isolated<br><br>For $10K+, hardware wallets are non-negotiable.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p><strong>Hardware wallets</strong> (Ledger, Trezor, Coldcard) are the safest option for large amounts:<br><br>• Keys never leave the device<br>• Immune to computer malware<br>• Offline cold storage<br>• Transaction signing isolated<br><br>For $10K+, hardware wallets are non-negotiable.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q3');
             } else if (choice === 'exchange') {
-                feedbackDiv.innerHTML = `<h5>⚠️ High Risk!</h5><p>Exchanges are the <strong>least secure option</strong>: hacks, freezes, bankruptcy. You don't control the keys. For large amounts, use <strong>hardware wallets</strong> (Ledger, Trezor, Coldcard) for maximum security.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Exchanges are the <strong>least secure option</strong>: hacks, freezes, bankruptcy. You don't control the keys. For large amounts, use <strong>hardware wallets</strong> (Ledger, Trezor, Coldcard) for maximum security.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Too Vulnerable</h5><p>Mobile wallets are convenient but vulnerable to malware, phone theft, and hacking. For $10K+, use <strong>hardware wallets</strong>—keys stay offline, immune to digital attacks.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Mobile wallets are convenient but vulnerable to malware, phone theft, and hacking. For $10K+, use <strong>hardware wallets</strong>—keys stay offline, immune to digital attacks.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -642,11 +638,11 @@
             if (/(malware|virus|attack|hack)/.test(text)) score++;
             if (/(sign|transaction|verify)/.test(text)) score++;
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Technical Excellence! (${score}/4 features)</h5><p>Hardware wallet advantages:<br><br><strong>Offline keys</strong> (never exposed), <strong>secure element chip</strong> (tamper-resistant), <strong>malware immunity</strong> (isolated signing), <strong>transaction verification</strong> (on-device screen).<br><br>For serious amounts, hardware wallets are mandatory—not optional.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>Hardware wallet advantages:<br><br><strong>Offline keys</strong> (never exposed), <strong>secure element chip</strong> (tamper-resistant), <strong>malware immunity</strong> (isolated signing), <strong>transaction verification</strong> (on-device screen).<br><br>For serious amounts, hardware wallets are mandatory—not optional.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q3');
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Add More Features (${score}/4)</h5><p>Key benefits: <strong>offline key storage</strong>, <strong>secure element chip</strong>, <strong>malware immunity</strong>, <strong>isolated transaction signing</strong>. These layers make hardware wallets the gold standard.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key benefits: <strong>offline key storage</strong>, <strong>secure element chip</strong>, <strong>malware immunity</strong>, <strong>isolated transaction signing</strong>. These layers make hardware wallets the gold standard.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -662,14 +658,14 @@
                 return;
             }
             if (choice === 'verify') {
-                feedbackDiv.innerHTML = `<h5>✓ Best Practice!</h5><p><strong>Test transaction workflow:</strong><br><br>1. Triple-check address (malware can swap addresses)<br>2. Send small test amount first<br>3. Verify it arrives correctly<br>4. Send remaining amount<br><br>Cost: ~$2 extra fee. Benefit: Prevents $10,000+ mistakes. Bitcoin transactions are <strong>irreversible</strong>.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p><strong>Test transaction workflow:</strong><br><br>1. Triple-check address (malware can swap addresses)<br>2. Send small test amount first<br>3. Verify it arrives correctly<br>4. Send remaining amount<br><br>Cost: ~$2 extra fee. Benefit: Prevents $10,000+ mistakes. Bitcoin transactions are <strong>irreversible</strong>.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q4');
             } else if (choice === 'quick') {
-                feedbackDiv.innerHTML = `<h5>⚠️ Reckless Approach</h5><p>Price changes are temporary. <strong>Sending to wrong address is permanent</strong>. Always verify and test first. Bitcoin transactions are irreversible—no "undo" button.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Price changes are temporary. <strong>Sending to wrong address is permanent</strong>. Always verify and test first. Bitcoin transactions are irreversible—no "undo" button.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             } else {
-                feedbackDiv.innerHTML = `<h5>⚠️ Never Trust, Always Verify</h5><p>Malware can silently change addresses. Always <strong>verify carefully + send test transaction</strong> for large amounts. $2 test fee prevents $10K+ mistakes. Irreversibility means one error = permanent loss.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Malware can silently change addresses. Always <strong>verify carefully + send test transaction</strong> for large amounts. $2 test fee prevents $10K+ mistakes. Irreversibility means one error = permanent loss.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -689,11 +685,11 @@
             if (/(malware|swap|change|attack)/.test(text)) score++;
             if (/(cost|fee|benefit|worth)/.test(text)) score++;
             if (score >= 3) {
-                feedbackDiv.innerHTML = `<h5>✓ Risk Management Mastery! (${score}/4)</h5><p>You understand the economics:<br><br><strong>Irreversible</strong> transactions mean one mistake is permanent. <strong>Address verification</strong> prevents malware attacks. <strong>Test transactions</strong> ($2 fee) vs. <strong>total loss risk</strong> ($10K+) = obvious choice.<br><br>Pragmatic security: small insurance cost, massive downside protection.</p>`;
+                feedbackDiv.innerHTML = `<h5>How to think about it</h5><p>You understand the economics:<br><br><strong>Irreversible</strong> transactions mean one mistake is permanent. <strong>Address verification</strong> prevents malware attacks. <strong>Test transactions</strong> ($2 fee) vs. <strong>total loss risk</strong> ($10K+) = obvious choice.<br><br>Pragmatic security: small insurance cost, massive downside protection.</p>`;
                 feedbackDiv.className = 'feedback-box positive';
                 updateProgress('q4');
             } else {
-                feedbackDiv.innerHTML = `<h5><span data-icon="lightbulb"></span> Analyze Trade-Offs (${score}/4)</h5><p>Key points: <strong>irreversible finality</strong>, <strong>address verification critical</strong>, <strong>malware can swap addresses</strong>, <strong>cost vs. benefit analysis</strong>. Test transactions are risk management 101.</p>`;
+                feedbackDiv.innerHTML = `<h5>Worth reconsidering</h5><p>Key points: <strong>irreversible finality</strong>, <strong>address verification critical</strong>, <strong>malware can swap addresses</strong>, <strong>cost vs. benefit analysis</strong>. Test transactions are risk management 101.</p>`;
                 feedbackDiv.className = 'feedback-box hint';
             }
             feedbackDiv.style.display = 'block';
@@ -703,10 +699,6 @@
         const completedQuestions = new Set();
         function updateProgress(questionId) {
             completedQuestions.add(questionId);
-            if (completedQuestions.size >= 4) {
-                document.getElementById('complete-btn').disabled = false;
-                document.getElementById('complete-btn').textContent = '✅ Complete Module & Continue →';
-            }
         }
 
         function saveResponse(key, value) {
@@ -724,39 +716,6 @@
             });
         }
 
-        function completeModule() {
-            if (!window.pragmatistProgress.data.completedModules.includes('2-1')) {
-                window.pragmatistProgress.data.completedModules.push('2-1');
-                window.pragmatistProgress.data.knowledgeScore += 20;
-
-                // Add achievements
-                if (!window.pragmatistProgress.data.achievements.includes('security-expert')) {
-                    window.pragmatistProgress.data.achievements.push('security-expert');
-                }
-
-                window.pragmatistProgress.save();
-
-                showAchievement('Security Complete', 'You can self-custody more safely now.', '🛡️');
-
-                setTimeout(() => {
-                    window.location.href = '/paths/pragmatist/stage-2/module-6-lightning.html';
-                }, 2000);
-            }
-        }
-
-        function showAchievement(title, description, icon) {
-            const notification = document.createElement('div');
-            notification.className = 'achievement-notification';
-            notification.innerHTML = `
-                <div class="achievement-icon">${icon}</div>
-                <div class="achievement-title">${title}</div>
-                <div style="color: var(--text-gray); font-size: 1.2rem;">${description}</div>
-                <div style="margin-top: 1rem; color: var(--bright-orange); font-weight: bold;">+20 Knowledge Points</div>
-            `;
-            document.body.appendChild(notification);
-            setTimeout(() => notification.remove(), 3500);
-        }
-
         document.addEventListener('DOMContentLoaded', loadResponses);
     </script>
 
@@ -769,8 +728,8 @@
         .reflection-panel.active { display: block; }
         .choice-select { width: 100%; padding: 1rem; background: rgba(0, 0, 0, 0.3); border: 2px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; cursor: pointer; }
         .feedback-box { margin-top: 1.5rem; padding: 1.5rem; border-radius: 0.5rem; border: 2px solid; display: none; }
-        .feedback-box.positive { background: rgba(40, 167, 69, 0.08); border-color: #4caf50; color: var(--text-light); }
-        .feedback-box.hint { background: rgba(255, 152, 0, 0.1); border-color: #ff9800; color: var(--text-light); }
+        .feedback-box.positive { background: rgba(255, 255, 255, 0.04); border-color: rgba(255, 255, 255, 0.18); color: var(--text-light); }
+        .feedback-box.hint { background: rgba(255, 255, 255, 0.04); border-color: rgba(255, 255, 255, 0.18); color: var(--text-light); }
         @media (max-width: 768px) {
             .reflection-tabs { flex-direction: column; }
             .reflection-tab { border-radius: 0.5rem; }

--- a/paths/pragmatist/stage-2/module-6-lightning.html
+++ b/paths/pragmatist/stage-2/module-6-lightning.html
@@ -48,7 +48,6 @@
                 <div class="module-meta">
                     <span><span data-icon="timer"></span> 30 minutes</span>
                     <span><span data-icon="chart"></span> Difficulty: Intermediate</span>
-                    <span><span data-icon="target"></span> 20 Knowledge Points</span>
                 </div>
             </div>
         </div>

--- a/paths/pragmatist/stage-2/module-7-economics.html
+++ b/paths/pragmatist/stage-2/module-7-economics.html
@@ -44,7 +44,6 @@
                 <div class="module-meta">
                     <span><span data-icon="timer"></span> 20 minutes</span>
                     <span><span data-icon="chart"></span> Difficulty: Intermediate</span>
-                    <span><span data-icon="target"></span> 20 Knowledge Points</span>
                 </div>
             </div>
         </div>

--- a/paths/pragmatist/stage-3/module-8-privacy-tax.html
+++ b/paths/pragmatist/stage-3/module-8-privacy-tax.html
@@ -44,7 +44,6 @@
                 <div class="module-meta">
                     <span><span data-icon="timer"></span> 25 minutes</span>
                     <span><span data-icon="chart"></span> Difficulty: Intermediate</span>
-                    <span><span data-icon="target"></span> 20 Knowledge Points</span>
                 </div>
             </div>
         </div>

--- a/paths/pragmatist/stage-3/module-9-real-life.html
+++ b/paths/pragmatist/stage-3/module-9-real-life.html
@@ -44,7 +44,6 @@
                 <div class="module-meta">
                     <span><span data-icon="timer"></span> 25 minutes</span>
                     <span><span data-icon="chart"></span> Difficulty: Intermediate</span>
-                    <span><span data-icon="target"></span> 20 Knowledge Points</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
**Pilot** for the site-wide gamification strip (approved 2026-06-15). Pragmatist only — the pattern here is the one to approve before rolling out to Curious/Principled/Sovereign/Builder/Hurried. Verified in-browser. 10 files, net −442 lines.

## What this removes (conflicts with unbounded mode)
- **Achievement popups** ("Module Complete! +15 Knowledge Points") + their JS (`completeModule`/`showAchievement`) + CSS.
- **Points/score UI**: "knowledge points" & "X quiz questions" meta labels; `index.html`'s stat cards (Modules Completed / Knowledge Points / Achievements / Path Completion %), the completion-% bar, and per-module point tags.
- **Scored-quiz framing** (module-2/3/5-security): "Select the correct answer" → "What do you think?"; pass/fail headers (`✓ Exactly Right` / `⚠️ CRITICAL ERROR` / "N/4" scores) → neutral **"How to think about it"** / **"Worth reconsidering"**. Same applied to module-1's reflection feedback.
- **Step-gating**: gated "Complete Quiz First" buttons (unlock after N correct) → plain ungated **"Continue to Module N →"** links; removed the `updateProgress()` enable logic.
- **Stage locking** (`index.html`): stages 2–3 no longer "Locked"/dimmed; `updateStageStates()` no longer locks or relabels → an open learning map.
- **Green `.feedback-box.positive`** → neutral surface (fixes the no-green brand rule *and* a residual "correct = green" pass/fail signal).

## What this keeps (per policy)
Reflection questions + their explanatory feedback (on **safety facts** the clear guidance stays — inform, don't hide); calculators / demos / lab cards; reflect-widget; per-module answer persistence (quiet resume); time estimates; difficulty labels; the shared **reading-progress bar** (you decided: page orientation, not course scoring); footer.

## Verification (in-browser, served worktree)
- All edited files: single de-gamified feedback pattern, ungated continue links with correct hrefs, neutral feedback box (`rgba(255,255,255,0.04)`), **no console errors**, all inline `<script>` blocks parse.
- `index.html`: 0 locked cards, stages full-opacity, badges "Start Here / Open / Open", no points/% text.
- Answering a reflection still works (handler fires, feedback shows, no throw).

## Notes
- `mains: 2` (double-`<main>`) and `data-path` on these files are handled by **#109** (separate branch off the same base; touches different lines, composes cleanly).
- **Out of scope / flagged**: pre-existing green callout/highlight boxes (`rgba(40,167,69)`) scattered in several pragmatist files — a brand-consistency cleanup, not gamification.

## ⏭️ Approval gate
Per your instruction: **approve this pattern before I roll it out to the other paths.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)