### PR TITLE
fix(builder): reposition as optional/advanced track + correct module count

### DIFF
--- a/paths/builder/index.html
+++ b/paths/builder/index.html
@@ -879,6 +879,7 @@
             </div>
             <h1>🔨 The Builder Path</h1>
             <p class="subtitle">Master Bitcoin Development from Protocol to Production</p>
+            <p class="path-positioning" style="max-width: 640px; margin: 0.5rem auto 0; color: var(--text-dim); font-size: 1rem; line-height: 1.6;">An <strong>optional, advanced track</strong> for developers who want to build on Bitcoin. It sits outside the core custody &amp; inheritance journey — take it if you want to go deep on the protocol, Lightning, and applications.</p>
             <div class="path-meta">
                 <div class="path-meta-item">
                     <span><span data-icon="books"></span> </span>
@@ -886,7 +887,7 @@
                 </div>
                 <div class="path-meta-item">
                     <span>📝</span>
-                    <span>10 Modules</span>
+                    <span>12 Modules</span>
                 </div>
                 <div class="path-meta-item">
                     <span><span data-icon="timer"></span> </span>


### PR DESCRIPTION
Decided 2026-06-15 (paths audit): **keep Builder, reposition it** (don't retire). Small, scoped change. Verified in-browser.

## Changes
- **Hero positioning line** added: *"An optional, advanced track for developers who want to build on Bitcoin. It sits outside the core custody & inheritance journey — take it if you want to go deep on the protocol, Lightning, and applications."* — clarifies Builder is off the core family/advisor identity without burying it.
- **Module count fixed**: header said **"10 Modules"** but the curriculum lists **12** (3 per stage × 4 stages). Now reads "12 Modules". (Not "13" — that file count includes an orphan; see below.)

## Verification
"12 Modules" + the positioning line render; positioning text is readable muted gray (`rgb(179,179,179)`); no console errors.

## Out of scope (flagged, intentionally not touched)
- **Orphan file**: `paths/builder/stage-2/module-4.html` exists but isn't in the index curriculum (12 listed) — separate orphan cleanup.
- **Gamification** (badges, "Your Progress" dashboard, stage locking) stays for the **gated gamification rollout** (after #110's pattern is approved).
- **Pre-existing brand drift** in the hero: purple `{};( )` builder logo + green progress-dashboard border (violates no-green/no-purple) — covered by the brand-consistency follow-up.
- **S8 a11y**: builder's index has **4 `<main>` landmarks**. S8 in #109 was scoped to hurried/pragmatist/skeptic; a phase-2 S8 sweep should cover builder + the remaining paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)