### PR TITLE
feat: free the learning paths + Skeptic "Question Money First" rebuild

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -27,7 +27,7 @@
     // Default configuration (PRODUCTION mode)
     const defaultConfig = {
         // Core feature flags
-        ENABLE_MODULE_GATING: true,      // Lock modules behind paywall
+        ENABLE_MODULE_GATING: false,     // Learning paths are free (education-first; revenue = kits + advisory, decided 2026-06-15). Was true.
         ENABLE_DEMO_LOCKS: true,         // Lock interactive demos
         ENABLE_PREVIEW_MODE: false,      // Allow limited preview access
         FULL_ACCESS: false,              // Bypass client-side locks (dev/testing)
@@ -44,7 +44,7 @@
     // Mode presets
     const modePresets = {
         production: {
-            ENABLE_MODULE_GATING: true,
+            ENABLE_MODULE_GATING: false,  // Learning paths free (education-first; revenue = kits + advisory, 2026-06-15)
             ENABLE_DEMO_LOCKS: true,
             ENABLE_PREVIEW_MODE: false,
             FULL_ACCESS: false,

--- a/js/membership-gate.js
+++ b/js/membership-gate.js
@@ -41,15 +41,10 @@
         // Path module-1 pages are always free
         freeModulePattern: /\/paths\/[^/]+\/stage-1\/module-1\.html$/,
 
-        // Fully-free paths (open map, no stage gating) — Skeptic = top-of-funnel.
-        freePaths: [
-            '/paths/skeptic/'
-        ],
-
         // Premium content patterns (everything else in paths/ and most demos)
+        // Learning paths are free (education-first model, decided 2026-06-15).
+        // Only the standalone deep-dives section remains premium.
         premiumPatterns: [
-            /\/paths\/[^/]+\/stage-[2-9]\//,
-            /\/paths\/[^/]+\/stage-1\/module-[2-9]\./,
             /\/deep-dives\//
         ]
     };
@@ -297,11 +292,6 @@
 
             // Free module pattern (module-1 of stage-1)
             if (CONFIG.freeModulePattern.test(path)) {
-                return false;
-            }
-
-            // Fully-free paths (open map, no stage gating)
-            if (CONFIG.freePaths && CONFIG.freePaths.some(p => path.startsWith(p))) {
                 return false;
             }
 

--- a/js/membership-gate.js
+++ b/js/membership-gate.js
@@ -41,6 +41,11 @@
         // Path module-1 pages are always free
         freeModulePattern: /\/paths\/[^/]+\/stage-1\/module-1\.html$/,
 
+        // Fully-free paths (open map, no stage gating) — Skeptic = top-of-funnel.
+        freePaths: [
+            '/paths/skeptic/'
+        ],
+
         // Premium content patterns (everything else in paths/ and most demos)
         premiumPatterns: [
             /\/paths\/[^/]+\/stage-[2-9]\//,
@@ -292,6 +297,11 @@
 
             // Free module pattern (module-1 of stage-1)
             if (CONFIG.freeModulePattern.test(path)) {
+                return false;
+            }
+
+            // Fully-free paths (open map, no stage gating)
+            if (CONFIG.freePaths && CONFIG.freePaths.some(p => path.startsWith(p))) {
                 return false;
             }
 

--- a/lib/premium-routes.js
+++ b/lib/premium-routes.js
@@ -4,9 +4,13 @@ const PREMIUM_PATH_IDS = Object.freeze([
   'hurried',
   'pragmatist',
   'principled',
-  'skeptic',
   'sovereign'
 ]);
+
+// Paths that are fully free (open map, no stage gating). The Skeptic path
+// ("Question Money First") is top-of-funnel — it must be explorable end-to-end
+// without a paywall, matching its unbounded-mode UI.
+const FREE_PATH_IDS = Object.freeze(['skeptic']);
 
 function stripQueryAndHash(pathname) {
   return pathname.split('?')[0].split('#')[0];
@@ -66,6 +70,16 @@ export function getProtectedRouteDetails(inputPathname) {
 
   const segments = pathname.split('/').filter(Boolean);
   const [, pathId, section, child] = segments;
+
+  if (FREE_PATH_IDS.includes(pathId)) {
+    return {
+      protected: false,
+      pathname,
+      area: 'path',
+      pathId,
+      reason: 'free-path'
+    };
+  }
 
   if (!PREMIUM_PATH_IDS.includes(pathId)) {
     return {

--- a/lib/premium-routes.js
+++ b/lib/premium-routes.js
@@ -7,10 +7,6 @@ const PREMIUM_PATH_IDS = Object.freeze([
   'sovereign'
 ]);
 
-// Paths that are fully free (open map, no stage gating). The Skeptic path
-// ("Question Money First") is top-of-funnel — it must be explorable end-to-end
-// without a paywall, matching its unbounded-mode UI.
-const FREE_PATH_IDS = Object.freeze(['skeptic']);
 
 function stripQueryAndHash(pathname) {
   return pathname.split('?')[0].split('#')[0];
@@ -68,99 +64,18 @@ export function getProtectedRouteDetails(inputPathname) {
     };
   }
 
+  // Learning paths are free — education-first model; revenue comes from kits
+  // + advisory, not from gating lessons (decided 2026-06-15). Only the
+  // standalone /deep-dives/ section stays gated (handled above), keeping the
+  // paths an open funnel toward the products.
   const segments = pathname.split('/').filter(Boolean);
-  const [, pathId, section, child] = segments;
-
-  if (FREE_PATH_IDS.includes(pathId)) {
-    return {
-      protected: false,
-      pathname,
-      area: 'path',
-      pathId,
-      reason: 'free-path'
-    };
-  }
-
-  if (!PREMIUM_PATH_IDS.includes(pathId)) {
-    return {
-      protected: false,
-      pathname,
-      area: 'path',
-      pathId: null,
-      reason: 'unknown-path'
-    };
-  }
-
-  if (section === 'capstone') {
-    return {
-      protected: true,
-      pathname,
-      area: 'path',
-      pathId,
-      reason: 'capstone'
-    };
-  }
-
-  if (section === 'stage-1') {
-    if (!child || child === 'index.html') {
-      return {
-        protected: false,
-        pathname,
-        area: 'path',
-        pathId,
-        reason: 'stage-1-index'
-      };
-    }
-
-    if (child === 'deep-dives') {
-      return {
-        protected: true,
-        pathname,
-        area: 'path',
-        pathId,
-        reason: 'stage-1-deep-dive'
-      };
-    }
-
-    if (isProtectedStageOneModule(child)) {
-      return {
-        protected: true,
-        pathname,
-        area: 'path',
-        pathId,
-        reason: 'stage-1-premium-module'
-      };
-    }
-
-    return {
-      protected: false,
-      pathname,
-      area: 'path',
-      pathId,
-      reason: 'stage-1-preview'
-    };
-  }
-
-  const stageMatch = /^stage-(\d+)$/.exec(section || '');
-  if (stageMatch) {
-    const stageNumber = Number(stageMatch[1]);
-    if (Number.isFinite(stageNumber) && stageNumber >= 2) {
-      return {
-        protected: true,
-        pathname,
-        area: 'path',
-        pathId,
-        reason: 'stage-2-plus'
-      };
-    }
-  }
-
+  const pathId = segments[1] || null;
   return {
     protected: false,
     pathname,
     area: 'path',
     pathId,
-    reason: 'path-orientation'
+    reason: 'paths-free'
   };
 }
 

--- a/paths/skeptic/index.html
+++ b/paths/skeptic/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Skeptic Path | Bitcoin Sovereign Academy</title>
-    <meta name="description" content="Think Bitcoin is bullshit? Take the challenge. We'll address every major objection with data, not hype. 2 stages: debunk the myths, then understand the MVP.">
+    <title>Question Money First | Bitcoin Sovereign Academy</title>
+    <meta name="description" content="A first-principles path through the questions about money most people skip. Start with your objection, examine what money is, follow the incentives, weigh the tradeoffs — and decide for yourself. No hype, no preaching.">
     
     <!-- Progress Manager -->
     <script src="/js/progress-manager.js"></script>
@@ -474,33 +474,25 @@
         <div class="container">
             <div class="path-title">
                 <div class="skeptic-container">
-                    <div class="path-icon"><span data-icon="question"></span></div>
+                    <div class="path-icon"><span data-icon="compass"></span></div>
                 </div>
-                <h1>The Skeptic Path</h1>
-                <p class="path-subtitle">"Fine, prove me wrong"</p>
+                <h1>Question Money First</h1>
+                <p class="path-subtitle">Discover, don't get convinced.</p>
             </div>
 
             <div class="path-stats">
                 <div class="stat-card">
-                    <div class="stat-value">2</div>
+                    <div class="stat-value">5</div>
                     <div class="stat-label">Stages</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-value">11</div>
-                    <div class="stat-label">Objections Addressed</div>
+                    <div class="stat-value">10</div>
+                    <div class="stat-label">Core questions</div>
                 </div>
                 <div class="stat-card">
-                    <div class="stat-value">~25 min</div>
-                    <div class="stat-label">Total Time</div>
+                    <div class="stat-value">~60 min</div>
+                    <div class="stat-label">At your pace</div>
                 </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="completion-percent">0%</div>
-                    <div class="stat-label">Completion</div>
-                </div>
-            </div>
-
-            <div class="progress-bar">
-                <div class="progress-fill" style="width: 0%" id="overall-progress"></div>
             </div>
         </div>
     </header>
@@ -510,106 +502,150 @@
         <div class="container">
             <!-- Path Introduction -->
             <div class="path-intro">
-                <h2>Challenge Accepted</h2>
+                <h2>Start with the doubt</h2>
                 <p>
-                    You think Bitcoin is rat poison? A scam? Tulip mania? <strong>Good.</strong> That's healthy skepticism.
+                    You don't have to be sold on Bitcoin. Skepticism is the right starting point. Most arguments about it — for and against — skip a more basic question: <strong>what is money actually doing, and who decides?</strong>
                 </p>
                 <p>
-                    This isn't an orange-pilling session. This is <strong>data vs. objections</strong>. We'll tackle every major criticism head-on—no hype, no preaching.
+                    This path doesn't try to convince you. It walks you through the questions most people never slow down to ask, and lets you reach your own conclusions. We examine claims, follow the incentives, and weigh the tradeoffs — no hype, no preaching.
                 </p>
                 <p style="margin-bottom: 0;">
-                    <strong>The Deal:</strong> If we can't answer your toughest objections, you walk away. If we can, you decide what to do next.
+                    You may end up unconvinced. That's a fair outcome. The goal isn't agreement — it's understanding the system you're already trusting.
                 </p>
             </div>
 
             <!-- Stages Grid -->
             <div class="stages-grid">
                 <!-- Stage 1 -->
-                <div class="stage-card current" id="stage-1">
+                <div class="stage-card" id="stage-1">
                     <div class="stage-header">
                         <div class="stage-title">
                             <div class="stage-icon"><span data-icon="search"></span></div>
-                            <h3>Stage 1: Debunking the Myths</h3>
+                            <h3>Stage 1: Start With the Objection</h3>
                             <div class="stage-meta">
-                                <span><span data-icon="timer"></span> 15-20 min</span>
-                                <span>11 objections</span>
+                                <span><span data-icon="timer"></span> ~15 min</span>
                             </div>
                         </div>
-                        <div class="stage-badge">Start Here</div>
                     </div>
 
                     <p class="stage-description">
-                        Every major Bitcoin criticism, addressed with data. Pick your strongest objection and watch us dismantle it—or prove us wrong.
+                        Begin where you are. Pick the objection that bugs you most — we won't rush to correct it. We'll just hold it up to the light and see what it's really asking.
                     </p>
 
                     <div class="modules-preview">
-                        <h4>Objections We'll Address:</h4>
+                        <h4>Objections worth taking seriously:</h4>
                         <div class="objections-dropdown" id="objections-dropdown">
                             <button class="dropdown-toggle" onclick="toggleDropdown()">
-                                <span>View all 11 objections</span>
+                                <span>See the objections we start from</span>
                                 <span class="arrow">▼</span>
                             </button>
                             <div class="dropdown-content">
-                                <div class="dropdown-item"><span class="item-icon" data-icon="money"></span> "It has no intrinsic value"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="lightning"></span> "It wastes insane amounts of energy"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="shield"></span> "It's only used by criminals"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="warning"></span> "Governments will just ban it"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="chart"></span> "It's a bubble / tulip mania"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="refresh"></span> "Someone will make a better one"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="lock"></span> "It can be easily hacked or stolen"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="network"></span> "It can't scale for global use"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="trend"></span> "It's too volatile to be useful"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="user"></span> "It's completely anonymous"</div>
-                                <div class="dropdown-item"><span class="item-icon" data-icon="globe"></span> "It has no real-world applications"</div>
+                                <div class="dropdown-item"><span class="item-icon" data-icon="chart"></span> "Isn't Bitcoin just speculation?"</div>
+                                <div class="dropdown-item"><span class="item-icon" data-icon="money"></span> "Why would digital money have value?"</div>
+                                <div class="dropdown-item"><span class="item-icon" data-icon="shield"></span> "Isn't government money safer — it's backed by the state?"</div>
+                                <div class="dropdown-item"><span class="item-icon" data-icon="chart"></span> "If it's so good, why is it so volatile?"</div>
+                                <div class="dropdown-item"><span class="item-icon" data-icon="institution"></span> "Why would anyone need it if banks already work?"</div>
+                                <div class="dropdown-item"><span class="item-icon" data-icon="refresh"></span> "Isn't this just another tech bubble?"</div>
+                                <div class="dropdown-item"><span class="item-icon" data-icon="alert"></span> "Can't governments simply ban it?"</div>
                             </div>
                         </div>
                     </div>
 
                     <div class="stage-action">
-                        <a href="/paths/skeptic/stage-1/" class="stage-btn">Challenge My Beliefs →</a>
+                        <a href="/paths/skeptic/stage-1/" class="stage-btn">Start with your objection →</a>
                     </div>
                 </div>
 
                 <!-- Stage 2 -->
-                <div class="stage-card locked" id="stage-2">
+                <div class="stage-card" id="stage-2">
                     <div class="stage-header">
                         <div class="stage-title">
-                            <div class="stage-icon"><span data-icon="tools"></span></div>
-                            <h3>Stage 2: Bitcoin's MVP</h3>
+                            <div class="stage-icon"><span data-icon="money"></span></div>
+                            <h3>Stage 2: Step Back — What Is Money?</h3>
                             <div class="stage-meta">
-                                <span><span data-icon="timer"></span> 15-20 min</span>
-                                <span>First Principles</span>
+                                <span><span data-icon="timer"></span> ~12 min</span>
                             </div>
                         </div>
-                        <div class="stage-badge"><span data-icon="lock"></span> Locked</div>
                     </div>
 
                     <p class="stage-description">
-                        Made it through the objections? Now see how Bitcoin solves the core problems of money from first principles. No fluff—just the MVP.
+                        Before judging Bitcoin, examine money itself. Why did people use shells, salt, gold, paper, and now digital balances — and what happens when the measuring tool keeps changing?
                     </p>
 
-                    <div class="modules-preview">
-                        <h4>What You'll Understand:</h4>
-                        <div class="module-list">
-                            <div class="module-item">The core problems Bitcoin solves</div>
-                            <div class="module-item">How proof-of-work actually works</div>
-                            <div class="module-item">Why the blockchain structure matters</div>
-                            <div class="module-item">Digital signatures &amp; cryptographic proof</div>
-                            <div class="module-item">The minimum viable product of sound money</div>
+                    <div class="stage-action">
+                        <a href="/paths/skeptic/stage-2/" class="stage-btn">Examine money →</a>
+                    </div>
+                </div>
+
+                <!-- Stage 3 -->
+                <div class="stage-card" id="stage-3">
+                    <div class="stage-header">
+                        <div class="stage-title">
+                            <div class="stage-icon"><span data-icon="institution"></span></div>
+                            <h3>Stage 3: Follow the Promise</h3>
+                            <div class="stage-meta">
+                                <span><span data-icon="timer"></span> ~12 min</span>
+                            </div>
                         </div>
                     </div>
 
+                    <p class="stage-description">
+                        Pensions, bailouts, stimulus, guarantees. Where does the money come from when promises exceed tax revenue — and who pays later? Not political; just follow the incentives.
+                    </p>
+
                     <div class="stage-action">
-                        <a href="/paths/skeptic/stage-2/" class="stage-btn">Understand the MVP →</a>
+                        <a href="/paths/skeptic/stage-3/" class="stage-btn">Follow the promise →</a>
+                    </div>
+                </div>
+
+                <!-- Stage 4 -->
+                <div class="stage-card" id="stage-4">
+                    <div class="stage-header">
+                        <div class="stage-title">
+                            <div class="stage-icon"><span data-icon="target"></span></div>
+                            <h3>Stage 4: Compare the Tradeoffs</h3>
+                            <div class="stage-meta">
+                                <span><span data-icon="timer"></span> ~12 min</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <p class="stage-description">
+                        Now bring Bitcoin in — only after the problem is clear. What would money look like if no one could print more? What's better, what's harder, and what risks remain fair to raise?
+                    </p>
+
+                    <div class="stage-action">
+                        <a href="/paths/skeptic/stage-4/" class="stage-btn">Compare the tradeoffs →</a>
+                    </div>
+                </div>
+
+                <!-- Stage 5 -->
+                <div class="stage-card" id="stage-5">
+                    <div class="stage-header">
+                        <div class="stage-title">
+                            <div class="stage-icon"><span data-icon="lightbulb"></span></div>
+                            <h3>Stage 5: You Decide</h3>
+                            <div class="stage-meta">
+                                <span><span data-icon="timer"></span> ~9 min</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <p class="stage-description">
+                        No pitch at the end. Which assumption changed? Which objection still feels strong? Where do you place your trust now — and what does each choice cost?
+                    </p>
+
+                    <div class="stage-action">
+                        <a href="/paths/skeptic/stage-5/" class="stage-btn">Decide for yourself →</a>
                     </div>
                 </div>
             </div>
 
             <!-- Footer Navigation -->
             <div class="footer-nav">
-                <h3>Still Not Convinced?</h3>
+                <h3>Take it at your own pace</h3>
                 <p>
-                    That's fine. Explore more resources, check out the interactive demos, or go back to the homepage.
+                    Start anywhere that interests you — the stages build on each other, but nothing is locked. Want to poke at the ideas directly? The interactive demos and deep dives are open too.
                 </p>
                 <div class="footer-buttons">
                     <a href="/" class="btn-secondary">← Back to Home</a>
@@ -654,30 +690,15 @@
             }
         });
 
-        // Track progress
-        document.addEventListener('DOMContentLoaded', function() {
-            const progress = JSON.parse(localStorage.getItem('skeptic-path-progress') || '{"stage1": false, "stage2": false}');
-
-            // Update progress bar
-            let completion = 0;
-            if (progress.stage1) completion += 50;
-            if (progress.stage2) completion += 50;
-
-            document.getElementById('overall-progress').style.width = completion + '%';
-            document.getElementById('completion-percent').textContent = completion + '%';
-
-            // Unlock stage 2 if stage 1 is complete
-            if (progress.stage1) {
-                document.getElementById('stage-2').classList.remove('locked');
-            }
-        });
+        // Unbounded mode: no completion scoring, no stage locking. The stages
+        // are an open map — every stage is accessible from the start.
     </script>
     <!-- Reflect: Socratic questions after module -->
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
              data-topic="money"
              data-path="skeptic"
-             data-title="Reflect: What convinced you — or didn&#39;t?">
+             data-title="Reflect: which assumption changed — and which still stands?">
         </div>
     </div>
     <script src="/js/reflect-widget.js"></script>

--- a/paths/skeptic/stage-1/index.html
+++ b/paths/skeptic/stage-1/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Stage 1: Debunking the Myths | The Skeptic Path</title>
-    <meta name="description" content="Every major Bitcoin objection, addressed with data. Select your concerns and see the counterarguments backed by evidence.">
+    <title>Stage 1: Start With the Objection | Question Money First</title>
+    <meta name="description" content="Begin where the doubt is. Pick the objection that bugs you most and examine what it's really asking — because most objections to Bitcoin are really questions about money itself. No hype, no preaching.">
 
     <style>
         :root {
@@ -430,484 +430,120 @@
     <div class="module-header">
         <div class="container">
             <div class="breadcrumb">
-                <a href="/">Home</a> &gt; <a href="/paths/skeptic/">The Skeptic Path</a> &gt; Stage 1
+                <a href="/">Home</a> &gt; <a href="/paths/skeptic/">Question Money First</a> &gt; Stage 1
             </div>
-            <h1>Stage 1: Debunking the Myths</h1>
+            <h1>Stage 1: Start With the Objection</h1>
         </div>
     </div>
 
     <main id="main-content" class="container">
-        <div class="intro">
-            <p><strong>What's your biggest concern about Bitcoin?</strong></p>
-            <p>Select the objections you want addressed. We'll show you data-driven rebuttals—no hype, no preaching.</p>
-            <p>If we can't answer it, you win. If we can, keep going.</p>
+        <style>
+            .obj-intro { max-width: 760px; margin: 0 0 2.5rem; }
+            .obj-intro p { color: var(--text-light); font-size: 1.1rem; line-height: 1.8; margin-bottom: 1rem; }
+            .obj-intro strong { color: var(--accent-skeptic-light); }
+            .obj-list { display: grid; gap: 1.5rem; margin-bottom: 3rem; }
+            .obj-card { background: var(--secondary-dark); border: 1px solid var(--border-color); border-left: 3px solid var(--accent-skeptic); border-radius: 0.75rem; padding: 1.75rem; }
+            .obj-q { font-size: 1.3rem; color: var(--accent-skeptic-light); margin: 0 0 1.25rem; }
+            .obj-block { margin-top: 1rem; }
+            .obj-label { display: inline-block; font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 0.35rem; }
+            .obj-block p { color: var(--text-light); line-height: 1.75; margin: 0; }
+            .obj-continue { max-width: 760px; margin: 0 0 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color); }
+            .obj-continue p { color: var(--text-light); line-height: 1.8; margin-bottom: 1.25rem; }
+            .obj-continue .next-btn { display: inline-block; background: var(--primary-orange); color: #101010; font-weight: 600; padding: 0.85rem 1.5rem; border-radius: 0.5rem; text-decoration: none; }
+            .obj-continue .next-btn:hover { filter: brightness(1.08); }
+        </style>
+
+        <div class="obj-intro">
+            <p><strong>Pick the objection that bugs you most.</strong> We won't rush to correct it. We'll hold it up to the light and ask what it's really getting at — because most objections to Bitcoin are really questions about money itself.</p>
+            <p>Nothing here is a verdict. The aim isn't to win an argument; it's to find the better question underneath the one you started with.</p>
         </div>
 
-        <!-- Myth Selector -->
-        <div class="myth-selector">
-            <h2>Select Your Concerns</h2>
-            <p>Check the boxes for the myths you want to explore, then click "Show Selected"</p>
+        <section class="obj-list" aria-label="Objections worth taking seriously">
+            <article class="obj-card">
+                <h3 class="obj-q">Isn't Bitcoin just speculation?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What this is really asking</span>
+                    <p>What gives anything monetary value — and is a volatile price the same as having no use?</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">How to examine it</span>
+                    <p>Separate the asset from its price chart. Ask what people actually <em>do</em> with it: settle payments, move value across borders, hold savings where the local currency is failing. Then test the assumption that "speculative" and "useful" can't both be true — most new networks look speculative before they look obvious. We dig into what gives money value in Stage&nbsp;2.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Why would digital money have value?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What this is really asking</span>
+                    <p>Where does monetary value come from at all?</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">How to examine it</span>
+                    <p>Notice that most of the money you already use is digital — your bank balance is a row in a database, not a stack of paper. So the real question isn't "digital vs. real," it's what stands behind the number. Follow that thread in Stage&nbsp;2: value tends to come from acceptance plus properties like scarcity and verifiability, not from a physical object.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Isn't government money safer — it's backed by the state?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What this is really asking</span>
+                    <p>What does "backed by the state" actually promise?</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">How to examine it</span>
+                    <p>Ask what the backing guarantees. Does it promise the money will hold its value, or only that it's legal tender you must accept? Then ask what happens to that value when far more of it is issued. We follow government promises — and who pays for them — in Stage&nbsp;3.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">If it's so good, why is it so volatile?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What this is really asking</span>
+                    <p>Does volatility mean it's broken — or that it's young and still small?</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">How to examine it</span>
+                    <p>Compare how a brand-new, freely traded, 24/7 global asset behaves against mature ones. Ask whether you'd expect something this small and this new to be stable yet. This isn't a promise it will settle down — that's an open question — but it's worth separating "volatile" from "worthless."</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Why would anyone need it if banks already work?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What this is really asking</span>
+                    <p>Work for whom — and where do they <em>not</em> work?</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">How to examine it</span>
+                    <p>"Banks work" smuggles in an assumption about whose experience counts. Ask who they don't serve: people in high-inflation economies, the unbanked, anyone whose account can be frozen or whose payment can be blocked. Follow the incentives of whoever controls access — that's the part the objection skips.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Isn't this just another tech bubble?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What this is really asking</span>
+                    <p>How do you tell a bubble from an early network?</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">How to examine it</span>
+                    <p>Bubbles pop and don't come back. Ask what's actually happened across Bitcoin's repeated crashes — it has been declared dead many times and is still here. Then test it honestly: what would have to be true for it to be <em>only</em> a bubble, versus a durable network? We weigh network effects and longevity in Stage&nbsp;4.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Can't governments simply ban it?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What this is really asking</span>
+                    <p>Can a government switch off a decentralized, global protocol — and what happens when they try?</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">How to examine it</span>
+                    <p>Distinguish two different things: banning <em>ownership</em> in one country, and shutting down a worldwide peer-to-peer network. Look at what's happened where bans were attempted. Be honest about the answer: a state can make it harder or illegal to use; whether it can actually stop the network is the real question worth examining.</p>
+                </div>
+            </article>
+        </section>
 
-            <div class="myth-checkboxes">
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-value" data-myth="value">
-                    <span class="myth-icon" data-icon="money"></span>
-                    <label for="myth-value">No intrinsic value</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-energy" data-myth="energy">
-                    <span class="myth-icon" data-icon="lightning"></span>
-                    <label for="myth-energy">Wastes too much energy</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-criminal" data-myth="criminal">
-                    <span class="myth-icon" data-icon="shield"></span>
-                    <label for="myth-criminal">Only used by criminals</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-ban" data-myth="ban">
-                    <span class="myth-icon" data-icon="warning"></span>
-                    <label for="myth-ban">Governments will ban it</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-bubble" data-myth="bubble">
-                    <span class="myth-icon" data-icon="chart"></span>
-                    <label for="myth-bubble">It's a bubble / going to zero</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-altcoins" data-myth="altcoins">
-                    <span class="myth-icon" data-icon="refresh"></span>
-                    <label for="myth-altcoins">Better crypto will replace it</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-hacked" data-myth="hacked">
-                    <span class="myth-icon" data-icon="lock"></span>
-                    <label for="myth-hacked">Can be easily hacked or stolen</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-scale" data-myth="scale">
-                    <span class="myth-icon" data-icon="network"></span>
-                    <label for="myth-scale">Can't scale for global use</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-volatile" data-myth="volatile">
-                    <span class="myth-icon" data-icon="trend"></span>
-                    <label for="myth-volatile">Too volatile to be useful</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-anonymous" data-myth="anonymous">
-                    <span class="myth-icon" data-icon="user"></span>
-                    <label for="myth-anonymous">Completely anonymous (untraceable)</label>
-                </div>
-                <div class="myth-checkbox">
-                    <input type="checkbox" id="myth-usecase" data-myth="usecase">
-                    <span class="myth-icon" data-icon="globe"></span>
-                    <label for="myth-usecase">No real-world applications</label>
-                </div>
-            </div>
-
-            <div class="selector-actions">
-                <button class="selector-btn" onclick="selectAll()">Select All</button>
-                <button class="selector-btn" onclick="clearAll()">Clear All</button>
-                <button class="selector-btn primary" onclick="showSelected()">Show Selected</button>
-            </div>
-            <div class="selection-count"><span id="count">0</span> of 11 selected</div>
+        <div class="obj-continue">
+            <p>Notice what these have in common: nearly every one turns into a question about <strong>what money is, who controls it, and what its value rests on</strong>. That's where we go next — not to defend Bitcoin, but to look at money from first principles.</p>
+            <a href="/paths/skeptic/stage-2/" class="next-btn">Continue to Stage 2: What Is Money? →</a>
         </div>
+    </main>
 
-        <div class="objections-grid" id="objections-grid">
-            <!-- Myth 1: No Intrinsic Value -->
-            <div class="flip-card" data-myth="value" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">💰</div>
-                        <div class="objection-title">No Intrinsic Value</div>
-                        <div class="objection-quote">"Bitcoin has no intrinsic value. It's not backed by anything."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">The Value Fallacy</div>
-                        <div class="rebuttal-content">
-                            <p><strong>You're right—it's not backed by anything.</strong> Neither is gold, really.</p>
-                            <p><strong>The Truth:</strong> "Intrinsic value" is a myth. Value is <em>subjective</em>, determined by what people are willing to exchange for it.</p>
-                            <ul>
-                                <li><strong>Gold:</strong> Valued for scarcity &amp; resistance to corrosion</li>
-                                <li><strong>Bitcoin:</strong> Valued for digital scarcity, portability, &amp; censorship resistance</li>
-                                <li><strong>Fiat:</strong> Backed only by government decree (and infinite supply)</li>
-                            </ul>
-                            <p><strong>Stock-to-flow ratio:</strong> Bitcoin has the highest of any asset—more scarce than gold.</p>
-                            <a href="/interactive-demos/stock-to-flow/" target="_blank" class="demo-link">📊 Explore Stock-to-Flow</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 2: Energy Waste -->
-            <div class="flip-card" data-myth="energy" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">⚡</div>
-                        <div class="objection-title">Energy Waste</div>
-                        <div class="objection-quote">"Bitcoin wastes insane amounts of energy for no reason."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">Energy = Security</div>
-                        <div class="rebuttal-content">
-                            <p><strong>Is securing $1+ trillion in value "waste"?</strong></p>
-                            <p><strong>The Data:</strong></p>
-                            <ul>
-                                <li><strong>Bitcoin:</strong> ~110 TWh/year (0.05% of global energy)</li>
-                                <li><strong>Traditional banking:</strong> ~260 TWh/year</li>
-                                <li><strong>Gold mining:</strong> ~240 TWh/year</li>
-                                <li><strong>Streaming video:</strong> ~200 TWh/year</li>
-                            </ul>
-                            <p><strong>Plus:</strong> 58% of Bitcoin mining uses renewable energy (vs. 28% for the global economy).</p>
-                            <p>Bitcoin isn't wasting energy—it's <em>converting</em> energy into immutable security.</p>
-                            <a href="/interactive-demos/energy-bucket/" target="_blank" class="demo-link">⚡ Energy Comparison Tool</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 3: Only Used by Criminals -->
-            <div class="flip-card" data-myth="criminal" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">🦹</div>
-                        <div class="objection-title">Criminal Tool</div>
-                        <div class="objection-quote">"Bitcoin is only used by criminals and drug dealers."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">Most Traceable "Anonymous" System</div>
-                        <div class="rebuttal-content">
-                            <p><strong>Criminals prefer cash—not Bitcoin.</strong></p>
-                            <p><strong>2025 Data:</strong></p>
-                            <ul>
-                                <li><strong>Bitcoin illicit activity:</strong> 0.24% of all transactions</li>
-                                <li><strong>Cash illicit activity:</strong> 2-5% (UN estimate)</li>
-                                <li><strong>Traditional banking:</strong> $2 trillion/year laundered</li>
-                            </ul>
-                            <p><strong>Why?</strong> Bitcoin's blockchain is a <em>public ledger</em>. Every transaction is permanently recorded. Chain analysis firms track criminal activity with &gt;95% accuracy.</p>
-                            <p>Criminals use what works: cash, banks, shell corps—not a transparent ledger.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 4: Government Ban -->
-            <div class="flip-card" data-myth="ban" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">🚫</div>
-                        <div class="objection-title">Government Will Ban It</div>
-                        <div class="objection-quote">"Governments will just ban Bitcoin when it gets too big."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">They've Tried. It Failed.</div>
-                        <div class="rebuttal-content">
-                            <p><strong>Ban attempts so far:</strong></p>
-                            <ul>
-                                <li><strong>China:</strong> Banned Bitcoin 6+ times (2013-2021). Result? Hashrate moved elsewhere. Bitcoin price up 10,000%.</li>
-                                <li><strong>India:</strong> Attempted ban 2018. Reversed. Now regulating.</li>
-                                <li><strong>Nigeria:</strong> Banned 2021. Bitcoin adoption surged.</li>
-                            </ul>
-                            <p><strong>The Problem:</strong> You can't ban math. Bitcoin is code. It runs on 17,000+ nodes in 100+ countries.</p>
-                            <p>Banning Bitcoin is like banning email. Good luck enforcing it globally.</p>
-                            <p><strong>Reality:</strong> US spot Bitcoin ETFs approved (2024). Nations buying Bitcoin reserves (El Salvador, Bhutan).</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 5: Tulip Bubble -->
-            <div class="flip-card" data-myth="bubble" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">🌷</div>
-                        <div class="objection-title">It's a Bubble</div>
-                        <div class="objection-quote">"Bitcoin is tulip mania. It's going to zero."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">15 Years of "Dying"</div>
-                        <div class="rebuttal-content">
-                            <p><strong>Bitcoin has "died" 473+ times...</strong> and yet:</p>
-                            <ul>
-                                <li>2011 crash: -93% → recovered to new ATH</li>
-                                <li>2013 crash: -87% → recovered to new ATH</li>
-                                <li>2017 crash: -84% → recovered to new ATH</li>
-                                <li>2021 crash: -77% → recovered to new ATH</li>
-                            </ul>
-                            <p><strong>Since 2010:</strong> Bitcoin is up 15,000,000%. Best performing asset of the decade.</p>
-                            <p><strong>Tulips?</strong> They crashed once and never recovered (because infinite supply).</p>
-                            <p><strong>Bitcoin?</strong> Fixed supply of 21M. Growing adoption. Surviving crashes. That's not a bubble—that's price discovery.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 6: Better Crypto Will Replace It -->
-            <div class="flip-card" data-myth="altcoins" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">🔄</div>
-                        <div class="objection-title">Altcoins Will Win</div>
-                        <div class="objection-quote">"Someone will just make a better cryptocurrency."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">Network Effects &amp; The Lindy Effect</div>
-                        <div class="rebuttal-content">
-                            <p><strong>They tried. Thousands of times.</strong></p>
-                            <p><strong>The Graveyard:</strong></p>
-                            <ul>
-                                <li>20,000+ altcoins launched since 2013</li>
-                                <li>99% failed or worth less than $0.01</li>
-                                <li>Bitcoin market dominance: 54% (and growing)</li>
-                            </ul>
-                            <p><strong>Why Bitcoin wins:</strong></p>
-                            <ul>
-                                <li><strong>Network effect:</strong> Most nodes, most miners, most liquidity</li>
-                                <li><strong>Lindy effect:</strong> Longest survival = highest future survival probability</li>
-                                <li><strong>Immaculate conception:</strong> No founder, no CEO, no premine</li>
-                            </ul>
-                            <p>Making a "better" Bitcoin is like making a "better" internet. The network effect is the moat.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 7: Can Be Hacked -->
-            <div class="flip-card" data-myth="hacked" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">🔓</div>
-                        <div class="objection-title">Easily Hacked or Stolen</div>
-                        <div class="objection-quote">"Bitcoin can be easily hacked. People lose their coins all the time."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">Bitcoin ≠ Exchanges</div>
-                        <div class="rebuttal-content">
-                            <p><strong>Bitcoin itself has never been hacked.</strong> Not once in 15+ years.</p>
-                            <p><strong>What gets hacked:</strong></p>
-                            <ul>
-                                <li><strong>Exchanges:</strong> Centralized companies with security flaws (Mt. Gox, FTX)</li>
-                                <li><strong>Individuals:</strong> Poor password hygiene, phishing attacks</li>
-                                <li><strong>NOT the Bitcoin network:</strong> $1 trillion secured by the most powerful computer network on Earth</li>
-                            </ul>
-                            <p><strong>The Math:</strong> To hack Bitcoin, you'd need to control 51% of all mining power. Cost? ~$20 billion+ in hardware alone. And you'd destroy the asset you're trying to steal.</p>
-                            <p><strong>Solution:</strong> Self-custody with proper security. Get Bitcoin off exchanges.</p>
-                            <a href="/interactive-demos/wallet-security-workshop/" target="_blank" class="demo-link">🔐 Learn Self-Custody</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 8: Can't Scale -->
-            <div class="flip-card" data-myth="scale" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">📈</div>
-                        <div class="objection-title">Can't Scale</div>
-                        <div class="objection-quote">"Bitcoin can only handle 7 transactions per second. It'll never work globally."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">Layers, Not Blocksize</div>
-                        <div class="rebuttal-content">
-                            <p><strong>The 7 TPS myth misses how Bitcoin scales.</strong></p>
-                            <p><strong>Layer 1 (Base layer):</strong> Settlement layer for large transactions. Like the Federal Reserve—slow, secure, final.</p>
-                            <p><strong>Layer 2 (Lightning Network):</strong></p>
-                            <ul>
-                                <li>1,000,000+ TPS capacity</li>
-                                <li>Instant settlement</li>
-                                <li>Near-zero fees ($0.001)</li>
-                                <li>Already processing millions of payments</li>
-                            </ul>
-                            <p><strong>Analogy:</strong> Visa doesn't settle on the Fed. Lightning doesn't settle every coffee on-chain. That's how scaling works.</p>
-                            <p><strong>Result:</strong> El Salvador uses Lightning for daily purchases. Strike moves billions instantly.</p>
-                            <a href="/interactive-demos/lightning-network-demo/" target="_blank" class="demo-link">⚡ Try Lightning Demo</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 9: Too Volatile -->
-            <div class="flip-card" data-myth="volatile" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">📊</div>
-                        <div class="objection-title">Too Volatile</div>
-                        <div class="objection-quote">"Bitcoin is too volatile to be a useful currency or store of value."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">Volatility Is a Feature (For Now)</div>
-                        <div class="rebuttal-content">
-                            <p><strong>You're right—Bitcoin is volatile.</strong> Here's why that's expected:</p>
-                            <p><strong>Price discovery phase:</strong> Bitcoin is transitioning from $0 to global reserve asset. This takes decades, not years.</p>
-                            <p><strong>Volatility is decreasing:</strong></p>
-                            <ul>
-                                <li>2011-2013: 100%+ swings common</li>
-                                <li>2017-2019: 80% drawdowns</li>
-                                <li>2020-2024: 50-70% drawdowns, faster recovery</li>
-                            </ul>
-                            <p><strong>Zoom out:</strong> Every 4-year period in Bitcoin history has been profitable. 100% of holders who waited 4+ years are in profit.</p>
-                            <p><strong>The trade-off:</strong> Volatility is the price of admission to the best-performing asset in history. As adoption grows, volatility decreases.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 10: Completely Anonymous -->
-            <div class="flip-card" data-myth="anonymous" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">👤</div>
-                        <div class="objection-title">Completely Anonymous</div>
-                        <div class="objection-quote">"Bitcoin transactions are completely anonymous and untraceable."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">Pseudonymous, Not Anonymous</div>
-                        <div class="rebuttal-content">
-                            <p><strong>This is backwards—Bitcoin is the most transparent financial system ever created.</strong></p>
-                            <p><strong>The Reality:</strong></p>
-                            <ul>
-                                <li><strong>Every transaction:</strong> Permanently recorded on a public blockchain</li>
-                                <li><strong>Chain analysis:</strong> Companies like Chainalysis track 95%+ of funds</li>
-                                <li><strong>Exchange KYC:</strong> Most entry/exit points require identity verification</li>
-                            </ul>
-                            <p><strong>Pseudonymous means:</strong> Your address doesn't show your name, but once linked to your identity (via exchange, purchase, etc.), your entire history is visible.</p>
-                            <p><strong>For privacy:</strong> Bitcoin requires active effort (CoinJoin, careful UTXO management). Cash is actually more anonymous.</p>
-                            <a href="/interactive-demos/coinjoin-simulator/" target="_blank" class="demo-link">🔒 Privacy Tools Demo</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Myth 11: No Real-World Use -->
-            <div class="flip-card" data-myth="usecase" onclick="this.classList.toggle('flipped')">
-                <div class="flip-card-inner">
-                    <div class="flip-card-front">
-                        <div class="objection-icon">🤷</div>
-                        <div class="objection-title">No Real Applications</div>
-                        <div class="objection-quote">"Bitcoin doesn't have any real-world applications. It's just speculation."</div>
-                        <div class="flip-hint">👆 Click to reveal</div>
-                    </div>
-                    <div class="flip-card-back">
-                        <div class="rebuttal-title">Already Changing Lives</div>
-                        <div class="rebuttal-content">
-                            <p><strong>Bitcoin is being used daily by millions:</strong></p>
-                            <p><strong>Remittances:</strong></p>
-                            <ul>
-                                <li>$700 billion/year sent by migrant workers</li>
-                                <li>Traditional fees: 6-10%</li>
-                                <li>Bitcoin/Lightning fees: less than 1%</li>
-                            </ul>
-                            <p><strong>Financial inclusion:</strong></p>
-                            <ul>
-                                <li>1.4 billion adults have no bank account</li>
-                                <li>Bitcoin requires only a smartphone</li>
-                                <li>No credit check, no permission needed</li>
-                            </ul>
-                            <p><strong>Savings protection:</strong></p>
-                            <ul>
-                                <li>Argentina: 140%+ inflation → Bitcoin adoption surging</li>
-                                <li>Turkey: 85% inflation → Bitcoin as savings</li>
-                                <li>Nigeria: Currency controls → Bitcoin as escape valve</li>
-                            </ul>
-                            <p><strong>Corporate treasury:</strong> MicroStrategy, Tesla, Block, and 50+ public companies hold Bitcoin.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="no-selection" id="no-selection" style="display: none;">
-            <p>👆 Select at least one concern above and click "Show Selected" to see the rebuttals.</p>
-        </div>
-
-        <!-- Completion Section -->
-        <div class="complete-section" id="complete-section" style="display: none;">
-            <h2>Still Here?</h2>
-            <p>You've explored the myths you selected. Not convinced? That's fine—healthy skepticism is good.</p>
-            <p>But if any of those rebuttals made you pause, maybe it's worth understanding <em>how</em> Bitcoin actually works.</p>
-            <a href="/paths/skeptic/stage-2/" class="next-btn" id="stage2-btn">Stage 2: Bitcoin's MVP →</a>
-        </div>
-    </div>
-
-    <script>
-        const checkboxes = document.querySelectorAll('.myth-checkbox input[type="checkbox"]');
-        const cards = document.querySelectorAll('.flip-card');
-        const countEl = document.getElementById('count');
-        const noSelection = document.getElementById('no-selection');
-        const completeSection = document.getElementById('complete-section');
-        const grid = document.getElementById('objections-grid');
-
-        // Update count
-        function updateCount() {
-            const checked = document.querySelectorAll('.myth-checkbox input:checked').length;
-            countEl.textContent = checked;
-        }
-
-        checkboxes.forEach(cb => cb.addEventListener('change', updateCount));
-
-        function selectAll() {
-            checkboxes.forEach(cb => cb.checked = true);
-            updateCount();
-        }
-
-        function clearAll() {
-            checkboxes.forEach(cb => cb.checked = false);
-            updateCount();
-            // Hide all cards
-            cards.forEach(card => card.classList.remove('visible'));
-            noSelection.style.display = 'block';
-            completeSection.style.display = 'none';
-        }
-
-        function showSelected() {
-            const selected = Array.from(document.querySelectorAll('.myth-checkbox input:checked'))
-                .map(cb => cb.dataset.myth);
-
-            let visibleCount = 0;
-            cards.forEach(card => {
-                if (selected.includes(card.dataset.myth)) {
-                    card.classList.add('visible');
-                    card.classList.remove('flipped');
-                    visibleCount++;
-                } else {
-                    card.classList.remove('visible');
-                }
-            });
-
-            if (visibleCount === 0) {
-                noSelection.style.display = 'block';
-                completeSection.style.display = 'none';
-            } else {
-                noSelection.style.display = 'none';
-                completeSection.style.display = 'block';
-                // Scroll to grid
-                grid.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            }
-        }
-
-        // Mark stage 1 as complete
-        document.getElementById('stage2-btn').addEventListener('click', function() {
-            let progress = JSON.parse(localStorage.getItem('skeptic-path-progress') || '{"stage1": false, "stage2": false}');
-            progress.stage1 = true;
-            localStorage.setItem('skeptic-path-progress', JSON.stringify(progress));
-        });
-
-        // Initialize: show no-selection message
-        noSelection.style.display = 'block';
-    </script>
-
-    <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
@@ -937,7 +573,7 @@
         <div class="reflect-widget"
              data-topic="money"
              data-path="skeptic"
-             data-title="Reflect: What convinced you — or didn&#39;t?">
+             data-title="Reflect: which objection still feels strongest to you — and what would answer it?">
         </div>
     </div>
     <script src="/js/reflect-widget.js"></script>

--- a/paths/skeptic/stage-2/index.html
+++ b/paths/skeptic/stage-2/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Stage 2: Bitcoin's MVP | The Skeptic Path</title>
-    <meta name="description" content="Made it through the objections? Understand how Bitcoin solves the core problems of money from first principles.">
-    
+    <title>Stage 2: What Is Money? | Question Money First</title>
+    <meta name="description" content="Before judging Bitcoin, examine money itself. What makes something money, why people have trusted it, and what happens when the measuring tool keeps changing length. No hype, no preaching.">
+
     <style>
         :root {
             --primary-orange: #FF7A00;
@@ -31,7 +31,7 @@
         }
 
         .container {
-            max-width: 900px;
+            max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
         }
@@ -41,7 +41,7 @@
             background: var(--secondary-dark);
             border-bottom: 3px solid var(--accent-skeptic);
             padding: 2rem 0;
-            margin-bottom: 3rem;
+            margin-bottom: 2rem;
         }
 
         .breadcrumb {
@@ -65,177 +65,16 @@
             margin-bottom: 0.5rem;
         }
 
-        .intro {
-            text-align: left;
-            padding: 2.5rem;
-            background: linear-gradient(135deg, rgba(168, 169, 173, 0.15), rgba(168, 169, 173, 0.05));
-            border: 3px solid var(--accent-skeptic);
-            border-radius: 1rem;
-            margin-bottom: 3rem;
-        }
-
-        .intro h2 {
-            font-size: 2rem;
-            color: var(--accent-skeptic-light);
-            margin-bottom: 1.5rem;
-        }
-
-        .intro p {
-            font-size: 1.1rem;
-            line-height: 1.8;
-            margin-bottom: 1rem;
-            color: var(--text-light);
-        }
-
-        .intro strong {
-            color: var(--accent-skeptic-light);
-        }
-
-        .mvp-link-box {
-            background: var(--secondary-dark);
-            border: 3px solid var(--accent-skeptic);
-            border-radius: 1rem;
-            padding: 2.5rem;
-            margin-bottom: 3rem;
-            text-align: left;
-        }
-
-        .mvp-link-box h3 {
-            font-size: 1.5rem;
-            color: var(--accent-skeptic-light);
-            margin-bottom: 1.5rem;
-        }
-
-        .mvp-link-box p {
-            font-size: 1.05rem;
-            line-height: 1.7;
-            margin-bottom: 2rem;
-            color: var(--text-light);
-        }
-
-        .big-link {
-            display: inline-block;
-            padding: 1.5rem 3rem;
-            background: linear-gradient(135deg, var(--accent-skeptic-dark), var(--accent-skeptic));
-            color: white;
-            text-decoration: none;
-            border-radius: 0.75rem;
-            font-weight: 700;
-            font-size: 1.2rem;
-            transition: all 0.3s ease;
-            box-shadow: 0 4px 15px rgba(168, 169, 173, 0.3);
-        }
-
-        .big-link:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(168, 169, 173, 0.5);
-        }
-
-        .key-points {
-            background: rgba(168, 169, 173, 0.05);
-            border-left: 4px solid var(--accent-skeptic);
-            padding: 2rem;
-            border-radius: 0.5rem;
-            margin-bottom: 3rem;
-        }
-
-        .key-points h3 {
-            color: var(--accent-skeptic-light);
-            margin-bottom: 1.5rem;
-        }
-
-        .key-points ul {
-            list-style: none;
-            padding: 0;
-        }
-
-        .key-points li {
-            padding: 0.75rem 0;
-            font-size: 1.05rem;
-            border-bottom: 1px solid var(--border-color);
-        }
-
-        .key-points li:last-child {
-            border-bottom: none;
-        }
-
-        .key-points strong {
-            color: var(--accent-skeptic-light);
-        }
-
-        .completion-box {
-            text-align: left;
-            padding: 3rem;
-            background: linear-gradient(135deg, rgba(168, 169, 173, 0.2), rgba(168, 169, 173, 0.1));
-            border: 3px solid var(--accent-skeptic);
-            border-radius: 1rem;
-        }
-
-        .completion-box h2 {
-            font-size: 2rem;
-            color: var(--accent-skeptic-light);
-            margin-bottom: 1rem;
-        }
-
-        .completion-box p {
-            font-size: 1.1rem;
-            margin-bottom: 2rem;
-            color: var(--text-light);
-        }
-
-        .next-steps {
-            display: flex;
-            gap: 1rem;
-            justify-content: center;
-            flex-wrap: wrap;
-            margin-top: 2rem;
-        }
-
-        .btn {
-            padding: 1rem 2rem;
-            text-decoration: none;
-            border-radius: 0.5rem;
-            font-weight: 600;
-            transition: all 0.3s ease;
-        }
-
-        .btn-primary {
-            background: linear-gradient(135deg, var(--accent-skeptic-dark), var(--accent-skeptic));
-            color: white;
-            box-shadow: 0 4px 15px rgba(168, 169, 173, 0.3);
-        }
-
-        .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(168, 169, 173, 0.5);
-        }
-
-        .btn-secondary {
-            background: transparent;
-            color: var(--text-light);
-            border: 2px solid var(--border-color);
-        }
-
-        .btn-secondary:hover {
-            border-color: var(--accent-skeptic);
-            background: rgba(168, 169, 173, 0.1);
-        }
-
+        /* Responsive */
         @media (max-width: 768px) {
             h1 {
                 font-size: 2rem;
             }
+        }
 
-            .intro h2 {
-                font-size: 1.5rem;
-            }
-
-            .next-steps {
-                flex-direction: column;
-            }
-
-            .btn {
-                width: 100%;
+        @media (prefers-reduced-motion: reduce) {
+            * {
+                transition: none !important;
             }
         }
     </style>
@@ -268,55 +107,220 @@
     <div class="module-header">
         <div class="container">
             <div class="breadcrumb">
-                <a href="/">Home</a> &gt; <a href="/paths/skeptic/">The Skeptic Path</a> &gt; Stage 2
+                <a href="/">Home</a> &gt; <a href="/paths/skeptic/">Question Money First</a> &gt; Stage 2
             </div>
-            <h1>Stage 2: Bitcoin's MVP</h1>
+            <h1>Stage 2: Step Back — What Is Money?</h1>
         </div>
     </div>
 
     <main id="main-content" class="container">
-        <div class="intro">
-            <h2>You Made It</h2>
-            <p>You've challenged every major objection. Now it's time to understand <strong>how</strong> Bitcoin actually works.</p>
-            <p style="margin-bottom: 0;">This isn't about investment hype—it's about understanding the <strong>minimum viable product</strong> of sound money, built from first principles.</p>
+        <style>
+            .obj-intro { max-width: 760px; margin: 0 0 2.5rem; }
+            .obj-intro p { color: var(--text-light); font-size: 1.1rem; line-height: 1.8; margin-bottom: 1rem; }
+            .obj-intro p:last-child { margin-bottom: 0; }
+            .obj-intro strong { color: var(--accent-skeptic-light); }
+            .obj-list { display: grid; gap: 1.5rem; margin-bottom: 3rem; }
+            .obj-card { background: var(--secondary-dark); border: 1px solid var(--border-color); border-left: 3px solid var(--accent-skeptic); border-radius: 0.75rem; padding: 1.75rem; }
+            .obj-q { font-size: 1.3rem; color: var(--accent-skeptic-light); margin: 0 0 1.25rem; }
+            .obj-block { margin-top: 1rem; }
+            .obj-label { display: inline-block; font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 0.35rem; }
+            .obj-block p { color: var(--text-light); line-height: 1.75; margin: 0; }
+            .obj-block p + p { margin-top: 0.75rem; }
+            .obj-block em { color: var(--accent-skeptic-light); font-style: italic; }
+
+            /* Calculator */
+            .calc { background: var(--secondary-dark); border: 1px solid var(--border-color); border-left: 3px solid var(--primary-orange); border-radius: 0.75rem; padding: 1.75rem; margin-bottom: 3rem; max-width: 820px; }
+            .calc h3 { font-size: 1.3rem; color: var(--accent-skeptic-light); margin: 0 0 0.5rem; }
+            .calc .calc-lede { color: var(--text-dim); font-size: 0.95rem; line-height: 1.7; margin-bottom: 1.5rem; }
+            .calc-fields { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+            .calc-field label { display: block; font-size: 0.8rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 0.4rem; }
+            .calc-field input { width: 100%; padding: 0.7rem 0.9rem; background: var(--primary-dark); border: 1px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; }
+            .calc-field input:focus { outline: 2px solid var(--accent-skeptic); outline-offset: 1px; border-color: var(--accent-skeptic); }
+            .calc-results { background: rgba(168, 169, 173, 0.08); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 1.25rem 1.5rem; }
+            .calc-results p { color: var(--text-light); line-height: 1.8; margin: 0 0 0.75rem; }
+            .calc-results p:last-of-type { margin-bottom: 0; }
+            .calc-results .calc-figure { color: var(--primary-orange); font-weight: 700; }
+            .calc-takeaway { margin-top: 1.25rem; padding-top: 1rem; border-top: 1px solid var(--border-color); color: var(--text-dim); font-size: 0.95rem; line-height: 1.7; }
+            .calc-takeaway strong { color: var(--accent-skeptic-light); }
+
+            .obj-continue { max-width: 760px; margin: 0 0 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color); }
+            .obj-continue p { color: var(--text-light); line-height: 1.8; margin-bottom: 1.25rem; }
+            .obj-continue em { color: var(--accent-skeptic-light); font-style: italic; }
+            .obj-continue strong { color: var(--accent-skeptic-light); }
+            .obj-continue .next-btn { display: inline-block; background: var(--primary-orange); color: #101010; font-weight: 600; padding: 0.85rem 1.5rem; border-radius: 0.5rem; text-decoration: none; }
+            .obj-continue .next-btn:hover { filter: brightness(1.08); }
+        </style>
+
+        <div class="obj-intro">
+            <p><strong>Slow the conversation down.</strong> Most people argue about Bitcoin before they've asked what money even is — like arguing over a map before asking what the map is supposed to measure.</p>
+            <p>So set Bitcoin aside for a moment. Before judging any new form of money, it's worth examining the thing all of them are trying to be. The questions below aren't trick questions, and none of them have a single right answer. They're here to make the familiar feel a little less obvious.</p>
         </div>
 
-        <div class="key-points">
-            <h3>What You'll Discover:</h3>
-            <ul>
-                <li><strong>Digital Scarcity:</strong> How Bitcoin creates verifiable scarcity in the digital realm</li>
-                <li><strong>Proof of Work:</strong> Why energy expenditure is the foundation of security</li>
-                <li><strong>The Blockchain:</strong> How to organize transactions without a central authority</li>
-                <li><strong>Digital Signatures:</strong> Cryptographic proof of ownership without passwords</li>
-                <li><strong>Network Consensus:</strong> How 17,000+ independent nodes agree without trusting each other</li>
-            </ul>
-        </div>
+        <section class="obj-list" aria-label="Questions about money worth sitting with">
+            <article class="obj-card">
+                <h3 class="obj-q">What makes something money?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">The question</span>
+                    <p>Economists usually name three jobs: a <em>medium of exchange</em> (you can trade with it), a <em>store of value</em> (it holds worth over time), and a <em>unit of account</em> (you can price other things in it).</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">Sit with it</span>
+                    <p>Which of these matters most depends on the moment. In a stable economy you barely think about "store of value" — you just spend. In a country with rapid inflation, that job suddenly dominates everything, and people reach for a different money to hold while still spending the local one. A thing can do one job well and another badly. So "is it money?" is rarely yes-or-no — it's "money for which job, for whom, and when?"</p>
+                </div>
+            </article>
 
-        <div class="mvp-link-box">
-            <h3>Ready to Build Bitcoin from First Principles?</h3>
-            <p>This interactive deep dive walks you through <em>why</em> each piece of Bitcoin exists—by starting from the problems it solves.</p>
-            <p>No hype. No complexity. Just the MVP.</p>
-            <a href="/deep-dives/first-principles/" class="big-link" id="mvp-btn">Explore Bitcoin's MVP →</a>
-        </div>
+            <article class="obj-card">
+                <h3 class="obj-q">Is money valuable because a government says so, or because people accept it?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">The question</span>
+                    <p>A law can declare something legal tender. But a law can't force you to <em>want</em> it, save in it, or trust it.</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">Sit with it</span>
+                    <p>History has examples of money that was legally mandated yet practically refused — people quietly preferred another currency, foreign cash, or barter. And examples of money no government declared, yet everyone accepted because everyone else did. Acceptance and decree usually reinforce each other, but they're not the same force. Worth asking which one you'd actually be relying on if things got shaky.</p>
+                </div>
+            </article>
 
-        <div class="completion-box">
-            <h2>Path Complete</h2>
-            <p>You've gone from skeptic to understanding the core innovation. What you do next is up to you.</p>
-            
-            <div class="next-steps">
-                <a href="/paths/curious/" class="btn btn-primary">Learn More: The Curious Path</a>
-                <a href="/interactive-demos/" class="btn btn-secondary"><span data-icon="game"></span> Interactive Demos</a>
-                <a href="/" class="btn btn-secondary">← Back to Home</a>
+            <article class="obj-card">
+                <h3 class="obj-q">Why have people used shells, salt, cattle, gold, paper, bank deposits — and now digital balances?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">The question</span>
+                    <p>Each of these was "money" somewhere. None of them lasted everywhere. What did each one get right, and where did it break?</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">Sit with it</span>
+                    <p>Cattle stored value but you can't make change for a cow. Salt was divisible and useful but heavy to move. Shells worked until someone found a beach full of them. Gold was hard to produce and lasted, but it's awkward to send across distance. Paper is portable and divisible, but easy to print more of. Bank deposits are convenient, but they're someone else's promise that can be frozen or fail. Notice the pattern: every form trades one strength for a new weakness. There's no perfect money — only the trade-offs a given society could live with.</p>
+                </div>
+            </article>
+
+            <article class="obj-card">
+                <h3 class="obj-q">What problems does money actually solve — and what makes a money fail?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">The question</span>
+                    <p>Money exists so you don't have to find someone who has what you want <em>and</em> wants what you have at the same time. It also lets value sit still until you need it, and lets strangers compare prices.</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">Sit with it</span>
+                    <p>A money fails when it can no longer do those jobs: when it loses value faster than you can spend it, when no one will take it, or when the number it reports stops meaning anything. Failure is rarely a single event — it's a slow erosion of trust that then tips over quickly. Ask what you'd watch for as the early signs.</p>
+                </div>
+            </article>
+
+            <article class="obj-card">
+                <h3 class="obj-q">Price vs. value vs. purchasing power — what's the difference?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">The question</span>
+                    <p>These three words get used interchangeably, and the confusion hides a lot.</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">Sit with it</span>
+                    <p><em>Price</em> is the number on the tag. <em>Value</em> is what something is actually worth to you — harder to pin down. <em>Purchasing power</em> is how much real stuff a unit of money can buy. A price can stay the same while purchasing power quietly falls; a price can rise while value is unchanged. When the price of bread doubles, it can mean bread got scarcer — or it can mean the money got weaker. Same number, very different stories. The calculator below lets you watch purchasing power move while the amount you carry stays the same.</p>
+                </div>
+            </article>
+
+            <article class="obj-card">
+                <h3 class="obj-q">If money is a measuring tool, what happens when the tool itself keeps changing length?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">The question</span>
+                    <p>A meter is useful because it's the same length tomorrow. A kilogram only works as a reference if it doesn't quietly shrink.</p>
+                </div>
+                <div class="obj-block">
+                    <span class="obj-label">Sit with it</span>
+                    <p>Money is the ruler we use to measure the worth of everything else. So what does it mean when the ruler itself gets shorter every year? Contracts, savings, wages, and prices are all measured against it — and if the unit drifts, every one of those measurements drifts too, often without anyone announcing it. This isn't an argument for or against any particular money. It's a question about the measuring tool itself, which is exactly what the calculator below makes visible.</p>
+                </div>
+            </article>
+        </section>
+
+        <section class="calc" aria-label="Purchasing-Power Eroder">
+            <h3>Purchasing-Power Eroder</h3>
+            <p class="calc-lede">Bring your own numbers. Use your own country's inflation rate — not a figure we picked for you. Change any input and the result updates as you type. This isn't a claim about the future; it's a way to see what a steadily changing measuring tool does to a fixed amount of cash.</p>
+            <div class="calc-fields">
+                <div class="calc-field">
+                    <label for="calc-amount">Amount today</label>
+                    <input type="number" id="calc-amount" value="1000" min="0" step="any" inputmode="decimal">
+                </div>
+                <div class="calc-field">
+                    <label for="calc-years">Years</label>
+                    <input type="number" id="calc-years" value="20" min="0" step="any" inputmode="decimal">
+                </div>
+                <div class="calc-field">
+                    <label for="calc-rate">Annual inflation rate (%)</label>
+                    <input type="number" id="calc-rate" value="4" min="0" step="any" inputmode="decimal">
+                </div>
             </div>
+            <div class="calc-results" aria-live="polite">
+                <p id="calc-line-cost"></p>
+                <p id="calc-line-erode"></p>
+            </div>
+            <p class="calc-takeaway"><strong>This is what "the measuring tool changing length" looks like.</strong> The amount you hold never moves. What it can buy does.</p>
+        </section>
+
+        <div class="obj-continue">
+            <p>Notice where this leads: if money can quietly lose value simply because more of it is created, the next question isn't <em>whether</em> that happens — it's <strong>who creates new money, and why</strong>. That's the thread we follow next, still without defending any particular answer.</p>
+            <a href="/paths/skeptic/stage-3/" class="next-btn">Continue to Stage 3: Follow the Promise →</a>
         </div>
-    </div>
+    </main>
 
     <script>
-        // Mark stage 2 as complete
-        document.getElementById('mvp-btn').addEventListener('click', function() {
-            let progress = JSON.parse(localStorage.getItem('skeptic-path-progress') || '{"stage1": false, "stage2": false}');
-            progress.stage2 = true;
-            localStorage.setItem('skeptic-path-progress', JSON.stringify(progress));
+        (function () {
+            var amountEl = document.getElementById('calc-amount');
+            var yearsEl = document.getElementById('calc-years');
+            var rateEl = document.getElementById('calc-rate');
+            var costEl = document.getElementById('calc-line-cost');
+            var erodeEl = document.getElementById('calc-line-erode');
+
+            function clampNum(value, fallback) {
+                var n = parseFloat(value);
+                if (isNaN(n) || n < 0) { return fallback; }
+                return n;
+            }
+
+            function fmt(n) {
+                if (!isFinite(n)) { return '—'; }
+                return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+            }
+
+            function update() {
+                var amount = clampNum(amountEl.value, 0);
+                var years = clampNum(yearsEl.value, 0);
+                var rate = clampNum(rateEl.value, 0);
+                var factor = Math.pow(1 + rate / 100, years);
+
+                var futureCost = amount * factor;
+                var erodedValue = factor === 0 ? amount : amount / factor;
+
+                costEl.textContent =
+                    'What you can buy with ' + fmt(amount) + ' today would cost about ' +
+                    fmt(futureCost) + ' in ' + fmt(years) + ' years at ' + fmt(rate) + '% per year.';
+                erodeEl.textContent =
+                    'Put another way: ' + fmt(amount) + ' kept as cash for ' + fmt(years) +
+                    ' years would then buy only what about ' + fmt(erodedValue) + ' buys today.';
+            }
+
+            amountEl.addEventListener('input', update);
+            yearsEl.addEventListener('input', update);
+            rateEl.addEventListener('input', update);
+            update();
+        })();
+    </script>
+
+    <script src="/js/icon-library.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            if (window.IconLibrary) {
+                document.querySelectorAll('[data-icon]').forEach(function(element) {
+                    var iconName = element.getAttribute('data-icon');
+                    if (iconName) {
+                        var iconHTML = IconLibrary.get(iconName, 24, true);
+                        var span = document.createElement('span');
+                        span.innerHTML = iconHTML;
+                        span.className = 'icon-inline';
+                        span.style.display = 'inline-block';
+                        span.style.verticalAlign = 'middle';
+                        element.innerHTML = '';
+                        element.appendChild(span);
+                    }
+                });
+            }
         });
     </script>
 
@@ -328,7 +332,7 @@
         <div class="reflect-widget"
              data-topic="money"
              data-path="skeptic"
-             data-title="Reflect: What convinced you — or didn&#39;t?">
+             data-title="Reflect: what has to be true for something to work as money?">
         </div>
     </div>
     <script src="/js/reflect-widget.js"></script>

--- a/paths/skeptic/stage-3/index.html
+++ b/paths/skeptic/stage-3/index.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html><html lang="en"><head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stage 3: Follow the Promise | Question Money First</title>
+    <meta name="description" content="Where does the money come from when government promises — pensions, bailouts, subsidies, guarantees, stimulus — exceed tax revenue? Examine the mechanism plainly. Not political, not conspiratorial. Follow the incentives.">
+
+    <style>
+        :root {
+            --primary-orange: #FF7A00;
+            --primary-dark: #1a1a1a;
+            --secondary-dark: #2d2d2d;
+            --accent-skeptic: #A8A9AD;
+            --accent-skeptic-dark: #71717A;
+            --accent-skeptic-light: #D4D4D8;
+            --text-light: #e0e0e0;
+            --text-dim: #b3b3b3;
+            --border-color: rgba(168, 169, 173, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--primary-dark);
+            color: var(--text-light);
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        /* Header */
+        .module-header {
+            background: var(--secondary-dark);
+            border-bottom: 3px solid var(--accent-skeptic);
+            padding: 2rem 0;
+            margin-bottom: 2rem;
+        }
+
+        .breadcrumb {
+            font-size: 0.9rem;
+            color: var(--text-dim);
+            margin-bottom: 1rem;
+        }
+
+        .breadcrumb a {
+            color: var(--accent-skeptic-light);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            color: var(--accent-skeptic-light);
+            margin-bottom: 0.5rem;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            h1 {
+                font-size: 2rem;
+            }
+        }
+    </style>
+    <link rel="stylesheet" href="/css/icons.css">
+<link rel="canonical" href="https://bitcoinsovereign.academy/"><meta property="og:title" content="Bitcoin Sovereign Academy"><meta property="og:description" content="Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/"><meta property="og:type" content="website"><script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "EducationalOrganization",
+  "name": "Bitcoin Sovereign Academy",
+  "description": "Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here.",
+  "url": "https://bitcoinsovereign.academy",
+  "logo": "https://bitcoinsovereign.academy/assets/og-image.jpg",
+  "sameAs": [
+    "https://github.com/Sovereigndwp/bitcoin-sovereign-academy"
+  ],
+  "educationalLevel": "Beginner to Advanced",
+  "teaches": [
+    "Bitcoin Fundamentals",
+    "Cryptocurrency Technology",
+    "Financial Sovereignty",
+    "Digital Asset Security"
+  ],
+  "audience": {
+    "@type": "Audience",
+    "audienceType": "Students interested in Bitcoin and cryptocurrency"
+  }
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
+    <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+    <div class="module-header">
+        <div class="container">
+            <div class="breadcrumb">
+                <a href="/">Home</a> &gt; <a href="/paths/skeptic/">Question Money First</a> &gt; Stage 3
+            </div>
+            <h1>Stage 3: Follow the Promise</h1>
+        </div>
+    </div>
+
+    <main id="main-content" class="container">
+        <style>
+            .obj-intro { max-width: 760px; margin: 0 0 2.5rem; }
+            .obj-intro p { color: var(--text-light); font-size: 1.1rem; line-height: 1.8; margin-bottom: 1rem; }
+            .obj-intro strong { color: var(--accent-skeptic-light); }
+            .obj-list { display: grid; gap: 1.5rem; margin-bottom: 3rem; }
+            .obj-card { background: var(--secondary-dark); border: 1px solid var(--border-color); border-left: 3px solid var(--accent-skeptic); border-radius: 0.75rem; padding: 1.75rem; }
+            .obj-q { font-size: 1.3rem; color: var(--accent-skeptic-light); margin: 0 0 1.25rem; }
+            .obj-block { margin-top: 1rem; }
+            .obj-block p { color: var(--text-light); line-height: 1.75; margin: 0 0 0.75rem; }
+            .obj-block p:last-child { margin-bottom: 0; }
+            .obj-aha { max-width: 760px; margin: 0 0 3rem; background: rgba(168, 169, 173, 0.05); border: 2px solid var(--accent-skeptic); border-radius: 1rem; padding: 1.75rem; }
+            .obj-aha .obj-label { display: inline-block; font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 0.5rem; }
+            .obj-aha p { color: var(--text-light); font-size: 1.1rem; line-height: 1.8; margin: 0; }
+            .obj-aha strong { color: var(--accent-skeptic-light); }
+
+            /* Promise-Gap Calculator */
+            .calc { max-width: 760px; margin: 0 0 3rem; background: var(--secondary-dark); border: 1px solid var(--border-color); border-left: 3px solid var(--primary-orange); border-radius: 0.75rem; padding: 1.75rem; }
+            .calc h2 { font-size: 1.4rem; color: var(--accent-skeptic-light); margin: 0 0 0.5rem; }
+            .calc .calc-sub { color: var(--text-dim); font-size: 0.95rem; margin-bottom: 1.5rem; line-height: 1.7; }
+            .calc-inputs { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+            .calc-field label { display: block; font-size: 0.85rem; color: var(--text-dim); margin-bottom: 0.4rem; }
+            .calc-field input { width: 100%; padding: 0.65rem 0.75rem; background: rgba(168, 169, 173, 0.08); border: 1px solid var(--border-color); border-radius: 0.5rem; color: var(--text-light); font-size: 1rem; font-family: inherit; }
+            .calc-field input:focus { outline: 2px solid var(--accent-skeptic); outline-offset: 1px; border-color: var(--accent-skeptic); }
+            .calc-field .calc-unit { font-size: 0.75rem; color: var(--text-dim); margin-top: 0.3rem; }
+            .calc-btn { padding: 0.75rem 1.5rem; border: 2px solid var(--accent-skeptic); background: var(--accent-skeptic); color: var(--primary-dark); border-radius: 0.5rem; cursor: pointer; font-size: 0.95rem; font-weight: 600; font-family: inherit; transition: background 0.2s ease; }
+            .calc-btn:hover { background: var(--accent-skeptic-light); }
+            .calc-result { margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border-color); }
+            .calc-headline { font-size: 1.15rem; color: var(--accent-skeptic-light); line-height: 1.6; margin-bottom: 1rem; }
+            .calc-options { display: grid; gap: 0.75rem; margin-top: 1rem; }
+            .calc-option { background: rgba(168, 169, 173, 0.07); border: 1px solid var(--border-color); border-radius: 0.5rem; padding: 0.9rem 1.1rem; }
+            .calc-option .opt-name { font-weight: 600; color: var(--accent-skeptic-light); display: block; margin-bottom: 0.25rem; }
+            .calc-option .opt-desc { color: var(--text-light); font-size: 0.92rem; line-height: 1.6; margin: 0; }
+            .calc-note { color: var(--text-dim); font-size: 0.85rem; margin-top: 1.25rem; line-height: 1.6; }
+
+            .obj-continue { max-width: 760px; margin: 0 0 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color); }
+            .obj-continue p { color: var(--text-light); line-height: 1.8; margin-bottom: 1.25rem; }
+            .obj-continue .next-btn { display: inline-block; background: var(--primary-orange); color: #101010; font-weight: 600; padding: 0.85rem 1.5rem; border-radius: 0.5rem; text-decoration: none; }
+            .obj-continue .next-btn:hover { filter: brightness(1.08); }
+        </style>
+
+        <div class="obj-intro">
+            <p><strong>Government money, debt, and promises — examined plainly.</strong> Pensions, bailouts, subsidies, guarantees, and stimulus are all promises: commitments to pay someone, something, at some point.</p>
+            <p>The question here isn't whether those promises are good or bad. That's a values question, and reasonable people disagree. The question is simpler and more mechanical: <strong>where does the money come from when the promises add up to more than the government collects in taxes?</strong> Follow that, and a lot of arguments that sound political turn out to be about arithmetic.</p>
+        </div>
+
+        <section class="obj-list" aria-label="Questions worth following">
+            <article class="obj-card">
+                <h3 class="obj-q">What does a government promise actually commit?</h3>
+                <div class="obj-block">
+                    <p>When a government promises pensions, benefits, bailouts, subsidies, guarantees, or stimulus, it is committing to deliver money — or things money buys — to specific people on a schedule.</p>
+                    <p>A promise isn't free just because it's announced. Every promise is a future bill. The interesting question is who that bill eventually lands on, and in what form.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Where does the money come from when promises exceed tax revenue?</h3>
+                <div class="obj-block">
+                    <p>Taxes are the obvious source, but they have a ceiling — there's only so much a government can collect before people and businesses change their behavior or push back.</p>
+                    <p>When promised spending runs ahead of what taxes bring in, the gap doesn't vanish. It has to be filled some other way: by borrowing, by creating new money, by raising taxes, or by not keeping the promise. There is no fifth door.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">What happens when a country borrows to pay for past borrowing?</h3>
+                <div class="obj-block">
+                    <p>Borrowing pushes today's bill into the future. That can be reasonable — for an emergency, or an investment that pays off later.</p>
+                    <p>But when new borrowing is used mainly to cover the interest and principal on old borrowing, the total keeps climbing. At that point the question shifts from "can we afford this program?" to "can we afford the debt itself?" — and the answer increasingly depends on how cheaply the government can keep borrowing.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Who benefits first when new money enters the system — and who pays later?</h3>
+                <div class="obj-block">
+                    <p>New money doesn't reach everyone at once. Whoever receives or spends it first does so before prices have adjusted. Whoever is further down the line — wage earners, savers, people on fixed incomes — tends to feel it later, after prices have already risen.</p>
+                    <p>This isn't a claim about anyone's intentions. It's just timing: the early hands get the money at the old prices, and the later hands get the higher prices. The cost shows up as weaker savings and fewer options, not as a line item anyone voted on.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Can a government keep every promise without changing the value of the money?</h3>
+                <div class="obj-block">
+                    <p>If the promises are funded by real resources — taxes collected or value genuinely created — the money's value can hold.</p>
+                    <p>But if the gap is closed by creating more money rather than collecting more value, the same claims are spread across a larger supply. The promise gets paid in name, while each unit buys a little less. The number on the cheque is honored; the purchasing power quietly isn't.</p>
+                </div>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">What happens to trust when the promise looks bigger than the system can honor?</h3>
+                <div class="obj-block">
+                    <p>Money and government debt both run on confidence — the belief that the promise will be kept in something close to its current value.</p>
+                    <p>When enough people start to doubt that, behavior changes: lenders demand higher interest, savers move into assets they think will hold value, and the cost of every future promise rises. Trust is slow to build and quick to wobble, which is why the <em>perception</em> of a gap can matter almost as much as the gap itself.</p>
+                </div>
+            </article>
+        </section>
+
+        <div class="obj-aha">
+            <span class="obj-label">The thing worth noticing</span>
+            <p>A government promise is not magic. It is ultimately paid through some mix of <strong>taxes, debt, inflation, default, or financial repression</strong>. The promise can be announced for free; it can never be <em>funded</em> for free. Once you know the menu, the only real questions are which doors get used, in what proportion, and who ends up carrying the cost.</p>
+        </div>
+
+        <section class="calc" aria-label="Promise-Gap Calculator">
+            <h2>The Promise-Gap Calculator</h2>
+            <p class="calc-sub">Set a year's promised spending against the taxes collected to pay for it. The units are arbitrary "billions" — reinterpret them however you like; what matters is the gap and what has to fill it. This is arithmetic, not ideology.</p>
+            <div class="calc-inputs">
+                <div class="calc-field">
+                    <label for="calc-promised">Promised spending</label>
+                    <input type="text" id="calc-promised" inputmode="decimal" value="6000" autocomplete="off">
+                    <div class="calc-unit">in billions (arbitrary units)</div>
+                </div>
+                <div class="calc-field">
+                    <label for="calc-revenue">Tax revenue collected</label>
+                    <input type="text" id="calc-revenue" inputmode="decimal" value="4000" autocomplete="off">
+                    <div class="calc-unit">in billions (arbitrary units)</div>
+                </div>
+                <div class="calc-field" style="align-self: end;">
+                    <button type="button" class="calc-btn" id="calc-run">Find the gap</button>
+                </div>
+            </div>
+            <div class="calc-result" id="calc-result" hidden>
+                <p class="calc-headline" id="calc-headline"></p>
+                <div class="calc-options" id="calc-options"></div>
+                <p class="calc-note" id="calc-note"></p>
+            </div>
+        </section>
+
+        <div class="obj-continue">
+            <p>If every promise eventually shows up in the value of the money — through taxes, debt, inflation, default, or repression — that raises a question worth sitting with: <strong>what would money look like if no one could quietly expand it?</strong></p>
+            <a href="/paths/skeptic/stage-4/" class="next-btn">Continue to Stage 4: Compare the Tradeoffs →</a>
+        </div>
+    </main>
+
+    <script src="/js/icon-library.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            if (window.IconLibrary) {
+                document.querySelectorAll('[data-icon]').forEach(function(element) {
+                    var iconName = element.getAttribute('data-icon');
+                    if (iconName) {
+                        var iconHTML = IconLibrary.get(iconName, 24, true);
+                        var span = document.createElement('span');
+                        span.innerHTML = iconHTML;
+                        span.className = 'icon-inline';
+                        span.style.display = 'inline-block';
+                        span.style.verticalAlign = 'middle';
+                        element.innerHTML = '';
+                        element.appendChild(span);
+                    }
+                });
+            }
+        });
+    </script>
+
+    <script>
+        // Promise-Gap Calculator — vanilla JS, no eval, sanitized via textContent.
+        (function () {
+            var promisedEl = document.getElementById('calc-promised');
+            var revenueEl = document.getElementById('calc-revenue');
+            var runBtn = document.getElementById('calc-run');
+            var resultEl = document.getElementById('calc-result');
+            var headlineEl = document.getElementById('calc-headline');
+            var optionsEl = document.getElementById('calc-options');
+            var noteEl = document.getElementById('calc-note');
+
+            if (!promisedEl || !revenueEl || !runBtn) { return; }
+
+            function fmt(n) {
+                // Group thousands for readability; no currency symbol (units are arbitrary).
+                return n.toLocaleString('en-US', { maximumFractionDigits: 2 });
+            }
+
+            function run() {
+                var promised = parseFloat(promisedEl.value);
+                var revenue = parseFloat(revenueEl.value);
+
+                resultEl.hidden = false;
+                optionsEl.textContent = '';
+                noteEl.textContent = '';
+
+                if (isNaN(promised) || isNaN(revenue) || promised < 0 || revenue < 0) {
+                    headlineEl.textContent = 'Enter two numbers that are zero or greater to find the gap.';
+                    return;
+                }
+
+                var gap = promised - revenue;
+                var gapStr = fmt(Math.abs(gap));
+
+                if (gap <= 0) {
+                    headlineEl.textContent = 'This year’s promises fit inside revenue. The gap is ' + fmt(gap) + ' — there is nothing extra to fund.';
+                    noteEl.textContent = 'Promised ' + fmt(promised) + ' against revenue of ' + fmt(revenue) + '. When promises stay within what taxes bring in, none of the doors below have to open. Raise the promise above the revenue to see what happens.';
+                    return;
+                }
+
+                headlineEl.textContent = 'Promised ' + fmt(promised) + ', collected ' + fmt(revenue) + '. The gap is ' + gapStr + ' that has to come from somewhere. There are four ways to fill it — and only four.';
+
+                var options = [
+                    {
+                        name: 'Borrow it',
+                        desc: 'Cover the ' + gapStr + ' by issuing debt. The promise is kept now; the bill plus interest is added to what future budgets must repay.'
+                    },
+                    {
+                        name: 'Create new money',
+                        desc: 'Fund the ' + gapStr + ' with newly created money. The promise is paid in full, but the larger supply dilutes the value of money already held.'
+                    },
+                    {
+                        name: 'Raise taxes',
+                        desc: 'Collect the ' + gapStr + ' by taxing more. The gap closes with real resources — paid directly and visibly by taxpayers this year.'
+                    },
+                    {
+                        name: 'Break the promise',
+                        desc: 'Don’t fill the ' + gapStr + '. Cut, delay, or default on the promise. The arithmetic balances, but someone who was counting on the money doesn’t receive it.'
+                    }
+                ];
+
+                options.forEach(function (opt) {
+                    var card = document.createElement('div');
+                    card.className = 'calc-option';
+                    var name = document.createElement('span');
+                    name.className = 'opt-name';
+                    name.textContent = opt.name;
+                    var desc = document.createElement('p');
+                    desc.className = 'opt-desc';
+                    desc.textContent = opt.desc;
+                    card.appendChild(name);
+                    card.appendChild(desc);
+                    optionsEl.appendChild(card);
+                });
+
+                noteEl.textContent = 'These are the only options, and most real budgets use some blend of them. Which doors get used — and in what proportion — decides who carries the cost, not whether there is a cost.';
+            }
+
+            runBtn.addEventListener('click', run);
+            [promisedEl, revenueEl].forEach(function (el) {
+                el.addEventListener('keydown', function (e) {
+                    if (e.key === 'Enter') { run(); }
+                });
+            });
+        })();
+    </script>
+
+
+    <!-- Navigation Context (return-to-path functionality) -->
+    <script src="/js/navigation-context.js"></script>
+    <!-- Reflect: Socratic questions after module -->
+    <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
+        <div class="reflect-widget"
+             data-topic="money"
+             data-path="skeptic"
+             data-title="Reflect: when a promise is bigger than the budget, who actually pays?">
+        </div>
+    </div>
+    <script src="/js/reflect-widget.js"></script>
+
+<script src="/js/membership-gate.js"></script>
+
+<!-- Analytics, Email Capture & Tip CTAs -->
+<div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
+    <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
+    <div id="tip-page" data-tip-cta="compact"></div>
+</div>
+<script src="/js/analytics.js" defer></script>
+<script src="/js/email-capture.js" defer></script>
+<script src="/js/tip-cta.js" defer></script>
+
+</body></html>

--- a/paths/skeptic/stage-4/index.html
+++ b/paths/skeptic/stage-4/index.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html><html lang="en"><head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stage 4: Compare the Tradeoffs | Question Money First</title>
+    <meta name="description" content="Now — and only now — weigh Bitcoin's tradeoffs honestly. What's actually better, what's harder, and what risks still remain. This is compare, not convince: every upside is named with its cost.">
+
+    <style>
+        :root {
+            --primary-orange: #FF7A00;
+            --primary-dark: #1a1a1a;
+            --secondary-dark: #2d2d2d;
+            --accent-skeptic: #A8A9AD;
+            --accent-skeptic-dark: #71717A;
+            --accent-skeptic-light: #D4D4D8;
+            --text-light: #e0e0e0;
+            --text-dim: #b3b3b3;
+            --border-color: rgba(168, 169, 173, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--primary-dark);
+            color: var(--text-light);
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        /* Header */
+        .module-header {
+            background: var(--secondary-dark);
+            border-bottom: 3px solid var(--accent-skeptic);
+            padding: 2rem 0;
+            margin-bottom: 2rem;
+        }
+
+        .breadcrumb {
+            font-size: 0.9rem;
+            color: var(--text-dim);
+            margin-bottom: 1rem;
+        }
+
+        .breadcrumb a {
+            color: var(--accent-skeptic-light);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            color: var(--accent-skeptic-light);
+            margin-bottom: 0.5rem;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            h1 {
+                font-size: 2rem;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            * {
+                transition: none !important;
+            }
+        }
+    </style>
+    <link rel="stylesheet" href="/css/icons.css">
+<link rel="canonical" href="https://bitcoinsovereign.academy/"><meta property="og:title" content="Bitcoin Sovereign Academy"><meta property="og:description" content="Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/"><meta property="og:type" content="website"><script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "EducationalOrganization",
+  "name": "Bitcoin Sovereign Academy",
+  "description": "Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here.",
+  "url": "https://bitcoinsovereign.academy",
+  "logo": "https://bitcoinsovereign.academy/assets/og-image.jpg",
+  "sameAs": [
+    "https://github.com/Sovereigndwp/bitcoin-sovereign-academy"
+  ],
+  "educationalLevel": "Beginner to Advanced",
+  "teaches": [
+    "Bitcoin Fundamentals",
+    "Cryptocurrency Technology",
+    "Financial Sovereignty",
+    "Digital Asset Security"
+  ],
+  "audience": {
+    "@type": "Audience",
+    "audienceType": "Students interested in Bitcoin and cryptocurrency"
+  }
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
+    <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+    <div class="module-header">
+        <div class="container">
+            <div class="breadcrumb">
+                <a href="/">Home</a> &gt; <a href="/paths/skeptic/">Question Money First</a> &gt; Stage 4
+            </div>
+            <h1>Stage 4: Compare the Tradeoffs</h1>
+        </div>
+    </div>
+
+    <main id="main-content" class="container">
+        <style>
+            .obj-intro { max-width: 760px; margin: 0 0 2.5rem; }
+            .obj-intro p { color: var(--text-light); font-size: 1.1rem; line-height: 1.8; margin-bottom: 1rem; }
+            .obj-intro p:last-child { margin-bottom: 0; }
+            .obj-intro strong { color: var(--accent-skeptic-light); }
+            .obj-list { display: grid; gap: 1.5rem; margin-bottom: 3rem; }
+            .obj-card { background: var(--secondary-dark); border: 1px solid var(--border-color); border-left: 3px solid var(--accent-skeptic); border-radius: 0.75rem; padding: 1.75rem; }
+            .obj-q { font-size: 1.3rem; color: var(--accent-skeptic-light); margin: 0 0 1.25rem; }
+            .obj-block { margin-top: 1rem; }
+            .obj-label { display: inline-block; font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 0.35rem; }
+            .obj-block p { color: var(--text-light); line-height: 1.75; margin: 0; }
+            .obj-block.cost .obj-label { color: var(--primary-orange); }
+            .obj-block em { color: var(--accent-skeptic-light); font-style: italic; }
+
+            .section-head { max-width: 760px; margin: 0 0 1.5rem; }
+            .section-head h2 { font-size: 1.6rem; color: var(--accent-skeptic-light); margin-bottom: 0.5rem; }
+            .section-head p { color: var(--text-dim); line-height: 1.7; }
+
+            /* Risks card */
+            .risk-card { background: var(--secondary-dark); border: 1px solid var(--border-color); border-left: 3px solid var(--primary-orange); border-radius: 0.75rem; padding: 1.75rem; margin-bottom: 3rem; }
+            .risk-card h3 { font-size: 1.3rem; color: var(--accent-skeptic-light); margin-bottom: 1rem; }
+            .risk-card ul { list-style: none; display: grid; gap: 0.9rem; }
+            .risk-card li { color: var(--text-light); line-height: 1.7; padding-left: 1.25rem; position: relative; }
+            .risk-card li::before { content: "—"; position: absolute; left: 0; color: var(--primary-orange); }
+            .risk-card li strong { color: var(--accent-skeptic-light); }
+
+            /* Custody comparison */
+            .custody-wrap { margin-bottom: 3rem; }
+            .custody-controls { display: flex; flex-wrap: wrap; gap: 0.6rem; margin-bottom: 1.5rem; }
+            .custody-btn { padding: 0.7rem 1.1rem; border: 2px solid var(--accent-skeptic); background: transparent; color: var(--text-light); border-radius: 0.5rem; cursor: pointer; font-size: 0.92rem; font-family: inherit; transition: background 0.2s ease, color 0.2s ease; }
+            .custody-btn:hover { background: rgba(168, 169, 173, 0.15); }
+            .custody-btn[aria-pressed="true"] { background: var(--accent-skeptic); color: var(--primary-dark); font-weight: 600; }
+            .custody-btn:focus-visible { outline: 2px solid var(--primary-orange); outline-offset: 2px; }
+
+            .custody-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1.25rem; }
+            .custody-col { background: var(--secondary-dark); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 1.5rem; display: none; }
+            .custody-col.visible { display: block; }
+            .custody-col h3 { font-size: 1.15rem; color: var(--accent-skeptic-light); margin-bottom: 0.35rem; }
+            .custody-col .custody-sub { font-size: 0.85rem; color: var(--text-dim); margin-bottom: 1.1rem; }
+            .custody-axis { margin-bottom: 1rem; }
+            .custody-axis:last-child { margin-bottom: 0; }
+            .custody-axis .axis-label { display: block; font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 0.25rem; }
+            .custody-axis .axis-val { color: var(--text-light); line-height: 1.55; font-size: 0.95rem; }
+            .custody-note { max-width: 760px; margin-top: 1.5rem; font-size: 0.95rem; color: var(--text-dim); line-height: 1.7; }
+            .custody-note strong { color: var(--accent-skeptic-light); }
+
+            .obj-continue { max-width: 760px; margin: 0 0 1rem; padding-top: 1rem; border-top: 1px solid var(--border-color); }
+            .obj-continue p { color: var(--text-light); line-height: 1.8; margin-bottom: 1.25rem; }
+            .obj-continue .next-btn { display: inline-block; background: var(--primary-orange); color: #101010; font-weight: 600; padding: 0.85rem 1.5rem; border-radius: 0.5rem; text-decoration: none; }
+            .obj-continue .next-btn:hover { filter: brightness(1.08); }
+        </style>
+
+        <div class="obj-intro">
+            <p><strong>Now — and only now — we bring Bitcoin in.</strong> You've looked at what money is (Stage&nbsp;2) and how promises actually get paid (Stage&nbsp;3). With that in hand, the question isn't "is Bitcoin good?" but "what does it trade away, and what does it buy?"</p>
+            <p>One reframe before we start: Bitcoin isn't interesting because it's <em>digital</em> — almost all the money you already use is digital. It's interesting because it changes <strong>who can create, freeze, dilute, censor, or verify money</strong>. That's the axis worth examining. So every upside below comes paired with its cost. This is <strong>compare, not convince</strong>.</p>
+        </div>
+
+        <section class="obj-list" aria-label="Bitcoin tradeoffs, each with its cost">
+            <article class="obj-card">
+                <h3 class="obj-q">What if no one could create more of it?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What's better</span>
+                    <p>Bitcoin's issuance is fixed by rule, not by anyone's decision. No central party can quietly print more and dilute what you hold. The supply schedule is the same for a government, a bank, and you.</p>
+                </div>
+                <div class="obj-block cost">
+                    <span class="obj-label">What's harder</span>
+                    <p>A money no one can expand has no lender of last resort. In a banking panic, there's no central bank to flood the system with liquidity. A fixed supply tends to be <em>deflationary</em> over time — good for savers, but it can encourage hoarding and gives policymakers far less room to soften a downturn. You're trading flexibility for predictability.</p>
+                </div>
+            </article>
+
+            <article class="obj-card">
+                <h3 class="obj-q">Why does a fixed supply matter — and what does it give up?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What's better</span>
+                    <p>You can plan against a known cap. Unlike a currency whose supply can change with policy, Bitcoin's 21-million limit is auditable by anyone running the software. Scarcity isn't promised; it's verifiable.</p>
+                </div>
+                <div class="obj-block cost">
+                    <span class="obj-label">What it gives up</span>
+                    <p>It gives up discretion. A fixed cap can't respond to a crisis, a war, or a recession. Critics argue an economy sometimes <em>needs</em> a flexible money supply; Bitcoin deliberately removes that lever. Whether that rigidity is a feature or a flaw depends on whether you trust the people who'd otherwise pull the lever — which is exactly the Stage&nbsp;3 question.</p>
+                </div>
+            </article>
+
+            <article class="obj-card">
+                <h3 class="obj-q">Why does self-custody matter — and what does it put on you?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What's better</span>
+                    <p>You can hold value that no one can freeze, seize, or block. No account to close, no permission to ask. For people under capital controls or unstable banking, that's not abstract — it's the difference between keeping savings and losing them.</p>
+                </div>
+                <div class="obj-block cost">
+                    <span class="obj-label">What new responsibility it creates</span>
+                    <p>There's no password reset and no fraud department. If you lose your keys, the money is gone; if you're tricked into signing, it's gone. The same property that removes the gatekeeper removes the safety net. Self-custody trades <em>someone else's responsibility</em> for <em>your own discipline</em> — which is why the next section looks at ways to soften that edge.</p>
+                </div>
+            </article>
+
+            <article class="obj-card">
+                <h3 class="obj-q">Why does decentralization matter — and what does it cost?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What's better</span>
+                    <p>No single company, server, or government runs the network, so there's no single point to capture, bribe, or switch off. The rules are enforced by thousands of independent participants rather than one administrator.</p>
+                </div>
+                <div class="obj-block cost">
+                    <span class="obj-label">What it costs</span>
+                    <p>Speed and convenience. Having thousands of nodes agree is slower and clunkier than one company updating a database. There's no support line, no instant reversal, and the base layer settles a limited number of transactions per block. Decentralization buys censorship-resistance at the price of raw efficiency — a tradeoff a centralized system simply doesn't make.</p>
+                </div>
+            </article>
+
+            <article class="obj-card">
+                <h3 class="obj-q">Why does verification — "don't trust, verify" — matter?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">What's better</span>
+                    <p>You don't have to take anyone's word for the supply, your balance, or whether a payment settled. You can check it yourself against the same rules everyone else runs. Trust shifts from institutions to math you can independently confirm.</p>
+                </div>
+                <div class="obj-block cost">
+                    <span class="obj-label">What it asks of you</span>
+                    <p>Verification only protects you if you actually do it — or use tools that do. "Verify" assumes effort and some technical literacy; most people will lean on software and services to verify on their behalf, which quietly reintroduces a little of the trust it was meant to remove. The ideal is powerful; living up to it takes work.</p>
+                </div>
+            </article>
+
+            <article class="obj-card">
+                <h3 class="obj-q">Rules vs. discretion: why prefer fixed rules — and when is judgment useful?</h3>
+                <div class="obj-block">
+                    <span class="obj-label">The case for rules</span>
+                    <p>Fixed rules can't play favorites, can't be lobbied, and apply the same way to everyone. If you don't trust that discretion will be used in your interest, a rule you can read is more trustworthy than a promise you have to believe.</p>
+                </div>
+                <div class="obj-block cost">
+                    <span class="obj-label">When discretion is actually useful</span>
+                    <p>Judgment lets a system respond to things no rule anticipated — a natural disaster, a bank run, a fraud that needs reversing. Rigid rules can be cruel in edge cases that a human would handle sensibly. The honest version isn't "rules good, judgment bad"; it's <em>who do you want holding the lever, and can you check what they do with it?</em></p>
+                </div>
+            </article>
+        </section>
+
+        <div class="risk-card">
+            <h3>What risks does Bitcoin still have?</h3>
+            <p style="color:var(--text-dim);margin-bottom:1rem;line-height:1.7;">No honest comparison ends on the upside. These are real and worth weighing before you decide anything:</p>
+            <ul>
+                <li><strong>Volatility.</strong> The price swings hard. As a young, small, freely-traded global asset it can drop 50% or more — money you might need soon should not assume it holds value short-term.</li>
+                <li><strong>Key loss.</strong> Lose your keys with no backup and the funds are unrecoverable. There is no recovery hotline for true self-custody done alone.</li>
+                <li><strong>Scams.</strong> Irreversibility cuts both ways — fake support, phishing, "double your coins" cons, and bad signing prompts have drained real wallets. Once sent, it stays sent.</li>
+                <li><strong>Regulatory pressure.</strong> Governments can tax, restrict, or complicate access, and rules vary by country and change over time. That uncertainty is itself a cost.</li>
+                <li><strong>Energy debates.</strong> Proof-of-work consumes real energy. There are reasonable arguments on both sides about whether that cost is justified — it's a genuine open debate, not a settled point.</li>
+                <li><strong>Fee markets.</strong> When the network is busy, transaction fees rise. As block rewards shrink over decades, whether fees alone keep the network secure is an open question.</li>
+            </ul>
+        </div>
+
+        <section class="custody-wrap" aria-label="Custody tradeoff comparison">
+            <div class="section-head">
+                <h2>Custody tradeoff comparison</h2>
+                <p>"Holding value" isn't one thing. The same dollar — or bitcoin — behaves very differently depending on <em>who can touch it</em>. Pick the options you want to compare. No scoring, no winner — just how each one trades off control, recovery, and counterparty risk.</p>
+            </div>
+
+            <div class="custody-controls" role="group" aria-label="Choose which options to compare">
+                <button type="button" class="custody-btn" data-option="bank" aria-pressed="true">Bank account</button>
+                <button type="button" class="custody-btn" data-option="exchange" aria-pressed="true">Exchange account</button>
+                <button type="button" class="custody-btn" data-option="single" aria-pressed="true">Single-key self-custody</button>
+                <button type="button" class="custody-btn" data-option="collab" aria-pressed="true">Collaborative custody</button>
+            </div>
+
+            <div class="custody-grid">
+                <article class="custody-col visible" data-col="bank">
+                    <h3>Bank account</h3>
+                    <p class="custody-sub">A regulated institution holds your money for you.</p>
+                    <div class="custody-axis"><span class="axis-label">Who can freeze or seize it</span><span class="axis-val">The bank, a court, or a government can freeze or seize it. Access depends on their permission and policies.</span></div>
+                    <div class="custody-axis"><span class="axis-label">Who can move it</span><span class="axis-val">The bank moves funds on your instruction — and can decline, delay, or reverse a transfer.</span></div>
+                    <div class="custody-axis"><span class="axis-label">If you lose access</span><span class="axis-val">Recoverable. Reset your login, prove your identity, and you're back in. Strong safety net.</span></div>
+                    <div class="custody-axis"><span class="axis-label">Counterparty risk</span><span class="axis-val">High. You rely on the bank's solvency, honesty, and continued willingness to serve you. Often insured up to a limit.</span></div>
+                </article>
+
+                <article class="custody-col visible" data-col="exchange">
+                    <h3>Exchange account</h3>
+                    <p class="custody-sub">A platform holds bitcoin on your behalf; you hold an IOU.</p>
+                    <div class="custody-axis"><span class="axis-label">Who can freeze or seize it</span><span class="axis-val">The exchange can freeze, restrict, or lose your funds; regulators can compel it. You don't hold the keys.</span></div>
+                    <div class="custody-axis"><span class="axis-label">Who can move it</span><span class="axis-val">The exchange moves coins for you, subject to its limits, withdrawal holds, and approval.</span></div>
+                    <div class="custody-axis"><span class="axis-label">If you lose access</span><span class="axis-val">Usually recoverable via support and identity checks — but only if the exchange is solvent and cooperative.</span></div>
+                    <div class="custody-axis"><span class="axis-label">Counterparty risk</span><span class="axis-val">High. "Not your keys, not your coins." Exchange failure or fraud can wipe out balances, often uninsured.</span></div>
+                </article>
+
+                <article class="custody-col visible" data-col="single">
+                    <h3>Single-key self-custody</h3>
+                    <p class="custody-sub">You hold one key. You alone control the funds.</p>
+                    <div class="custody-axis"><span class="axis-label">Who can freeze or seize it</span><span class="axis-val">No one can freeze it remotely. Only someone who gets your key — by theft or coercion — can take it.</span></div>
+                    <div class="custody-axis"><span class="axis-label">Who can move it</span><span class="axis-val">Only you. No permission, no gatekeeper, no reversal.</span></div>
+                    <div class="custody-axis"><span class="axis-label">If you lose access</span><span class="axis-val">Unrecoverable. Lose the key with no backup and the funds are gone forever. No safety net at all.</span></div>
+                    <div class="custody-axis"><span class="axis-label">Counterparty risk</span><span class="axis-val">None — there's no counterparty. That removes institutional risk but concentrates all responsibility on you.</span></div>
+                </article>
+
+                <article class="custody-col visible" data-col="collab">
+                    <h3>Collaborative custody</h3>
+                    <p class="custody-sub">Self-custody with guardrails — you keep custody and hold a key.</p>
+                    <div class="custody-axis"><span class="axis-label">Who can freeze or seize it</span><span class="axis-val">No single party can freeze or move funds alone. In a 2-of-3 setup, two of three keys are needed — and holding one key is not custody by that party.</span></div>
+                    <div class="custody-axis"><span class="axis-label">Who can move it</span><span class="axis-val">Only with your participation. You keep custody; a partner holding one key cannot move funds without you.</span></div>
+                    <div class="custody-axis"><span class="axis-label">If you lose access</span><span class="axis-val">Recoverable by design. If one key is lost, the remaining keys can still recover the funds — a recovery path single-key custody doesn't have.</span></div>
+                    <div class="custody-axis"><span class="axis-label">Counterparty risk</span><span class="axis-val">Low and bounded. A key-holder can't act alone and can't take your coins; you avoid both the single-point-of-failure of one key and the trust-the-institution risk of a custodian.</span></div>
+                </article>
+            </div>
+
+            <p class="custody-note"><strong>On collaborative custody:</strong> this is self-custody designed for real humans, not a step toward giving up control. You keep custody and hold a key; in a 2-of-3 arrangement no single party can move funds alone, and holding one key is not the same as having custody. It's self-custody with guardrails and a recovery path — a way to get the censorship-resistance of holding your own keys without betting everything on never making a single mistake.</p>
+        </section>
+
+        <div class="obj-continue">
+            <p>You've now seen the problem (Stages&nbsp;2–3) <strong>and</strong> the tradeoffs — the genuine upsides next to their real costs and risks. We haven't told you what to conclude. The last step is yours.</p>
+            <a href="/paths/skeptic/stage-5/" class="next-btn">Continue to Stage 5: You Decide →</a>
+        </div>
+    </main>
+
+    <script src="/js/icon-library.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            if (window.IconLibrary) {
+                document.querySelectorAll('[data-icon]').forEach(function(element) {
+                    var iconName = element.getAttribute('data-icon');
+                    if (iconName) {
+                        var iconHTML = IconLibrary.get(iconName, 24, true);
+                        var span = document.createElement('span');
+                        span.innerHTML = iconHTML;
+                        span.className = 'icon-inline';
+                        span.style.display = 'inline-block';
+                        span.style.verticalAlign = 'middle';
+                        element.innerHTML = '';
+                        element.appendChild(span);
+                    }
+                });
+            }
+        });
+    </script>
+
+    <script>
+        // Custody comparison toggle — vanilla JS, no eval, no dynamic text injection.
+        (function () {
+            var buttons = document.querySelectorAll('.custody-btn');
+            function syncColumn(option, pressed) {
+                var col = document.querySelector('.custody-col[data-col="' + option + '"]');
+                if (col) {
+                    if (pressed) {
+                        col.classList.add('visible');
+                    } else {
+                        col.classList.remove('visible');
+                    }
+                }
+            }
+            buttons.forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    var pressed = btn.getAttribute('aria-pressed') === 'true';
+                    var next = !pressed;
+                    btn.setAttribute('aria-pressed', next ? 'true' : 'false');
+                    syncColumn(btn.getAttribute('data-option'), next);
+                });
+            });
+        })();
+    </script>
+
+
+    <!-- Navigation Context (return-to-path functionality) -->
+    <script src="/js/navigation-context.js"></script>
+    <!-- Reflect: Socratic questions after module -->
+    <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
+        <div class="reflect-widget"
+             data-topic="money"
+             data-path="skeptic"
+             data-title="Reflect: which tradeoff matters most to you — and which risk still gives you pause?">
+        </div>
+    </div>
+    <script src="/js/reflect-widget.js"></script>
+
+<script src="/js/membership-gate.js"></script>
+
+<!-- Analytics, Email Capture & Tip CTAs -->
+<div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
+    <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
+    <div id="tip-page" data-tip-cta="compact"></div>
+</div>
+<script src="/js/analytics.js" defer></script>
+<script src="/js/email-capture.js" defer></script>
+<script src="/js/tip-cta.js" defer></script>
+
+</body></html>

--- a/paths/skeptic/stage-5/index.html
+++ b/paths/skeptic/stage-5/index.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html><html lang="en"><head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stage 5: You Decide | Question Money First</title>
+    <meta name="description" content="The reflective close. No conclusion is handed to you here — sit with the questions, name the objections that still stand, and decide for yourself. No pitch, no verdict.">
+
+    <style>
+        :root {
+            --primary-orange: #FF7A00;
+            --primary-dark: #1a1a1a;
+            --secondary-dark: #2d2d2d;
+            --accent-skeptic: #A8A9AD;
+            --accent-skeptic-dark: #71717A;
+            --accent-skeptic-light: #D4D4D8;
+            --text-light: #e0e0e0;
+            --text-dim: #b3b3b3;
+            --border-color: rgba(168, 169, 173, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--primary-dark);
+            color: var(--text-light);
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem;
+        }
+
+        /* Header */
+        .module-header {
+            background: var(--secondary-dark);
+            border-bottom: 3px solid var(--accent-skeptic);
+            padding: 2rem 0;
+            margin-bottom: 2rem;
+        }
+
+        .breadcrumb {
+            font-size: 0.9rem;
+            color: var(--text-dim);
+            margin-bottom: 1rem;
+        }
+
+        .breadcrumb a {
+            color: var(--accent-skeptic-light);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            text-decoration: underline;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            color: var(--accent-skeptic-light);
+            margin-bottom: 0.5rem;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            h1 {
+                font-size: 2rem;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .trust-option {
+                transition: none;
+            }
+        }
+    </style>
+    <link rel="stylesheet" href="/css/icons.css">
+<link rel="canonical" href="https://bitcoinsovereign.academy/"><meta property="og:title" content="Bitcoin Sovereign Academy"><meta property="og:description" content="Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/"><meta property="og:type" content="website"><script type="application/ld+json">{
+  "@context": "https://schema.org",
+  "@type": "EducationalOrganization",
+  "name": "Bitcoin Sovereign Academy",
+  "description": "Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here.",
+  "url": "https://bitcoinsovereign.academy",
+  "logo": "https://bitcoinsovereign.academy/assets/og-image.jpg",
+  "sameAs": [
+    "https://github.com/Sovereigndwp/bitcoin-sovereign-academy"
+  ],
+  "educationalLevel": "Beginner to Advanced",
+  "teaches": [
+    "Bitcoin Fundamentals",
+    "Cryptocurrency Technology",
+    "Financial Sovereignty",
+    "Digital Asset Security"
+  ],
+  "audience": {
+    "@type": "Audience",
+    "audienceType": "Students interested in Bitcoin and cryptocurrency"
+  }
+}</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+</head>
+<body class="bsa-skin">
+    <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+    <div class="module-header">
+        <div class="container">
+            <div class="breadcrumb">
+                <a href="/">Home</a> &gt; <a href="/paths/skeptic/">Question Money First</a> &gt; Stage 5
+            </div>
+            <h1>Stage 5: You Decide</h1>
+        </div>
+    </div>
+
+    <main id="main-content" class="container">
+        <style>
+            .obj-intro { max-width: 760px; margin: 0 0 2.5rem; }
+            .obj-intro p { color: var(--text-light); font-size: 1.1rem; line-height: 1.8; margin-bottom: 1rem; }
+            .obj-intro p:last-child { margin-bottom: 0; }
+            .obj-intro strong { color: var(--accent-skeptic-light); }
+            .obj-list { display: grid; gap: 1.5rem; margin-bottom: 3rem; }
+            .obj-card { background: var(--secondary-dark); border: 1px solid var(--border-color); border-left: 3px solid var(--accent-skeptic); border-radius: 0.75rem; padding: 1.75rem; }
+            .obj-q { font-size: 1.3rem; color: var(--accent-skeptic-light); margin: 0 0 1rem; }
+            .obj-card p { color: var(--text-light); line-height: 1.75; margin: 0; }
+            .obj-card .obj-aside { color: var(--text-dim); font-size: 0.95rem; margin-top: 0.75rem; }
+
+            /* Trust reflection */
+            .trust-reflect { max-width: 860px; margin: 0 0 3rem; background: var(--secondary-dark); border: 1px solid var(--border-color); border-radius: 0.75rem; padding: 2rem; }
+            .trust-reflect h2 { font-size: 1.5rem; color: var(--accent-skeptic-light); margin: 0 0 0.75rem; }
+            .trust-reflect > p { color: var(--text-dim); margin-bottom: 1.5rem; line-height: 1.7; }
+            .trust-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.75rem; margin-bottom: 1.5rem; }
+            .trust-option { display: flex; flex-direction: column; align-items: center; gap: 0.4rem; padding: 1rem 0.75rem; background: rgba(168, 169, 173, 0.08); border: 1px solid var(--border-color); border-radius: 0.5rem; cursor: pointer; transition: background 0.2s ease, border-color 0.2s ease; text-align: center; font: inherit; color: var(--text-light); }
+            .trust-option:hover, .trust-option:focus-visible { background: rgba(168, 169, 173, 0.18); border-color: var(--accent-skeptic); outline: none; }
+            .trust-option[aria-pressed="true"] { border-color: var(--accent-skeptic-light); background: rgba(168, 169, 173, 0.22); }
+            .trust-option .trust-icon { font-size: 1.6rem; line-height: 1; }
+            .trust-option .trust-name { font-size: 0.95rem; }
+            .trust-readout { min-height: 5.5rem; padding: 1.25rem 1.5rem; background: rgba(168, 169, 173, 0.05); border: 1px dashed var(--border-color); border-radius: 0.5rem; }
+            .trust-readout .tr-name { display: block; font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 0.5rem; }
+            .trust-readout .tr-line { color: var(--text-light); line-height: 1.7; margin: 0 0 0.5rem; }
+            .trust-readout .tr-line:last-child { margin-bottom: 0; }
+            .trust-readout .tr-line strong { color: var(--accent-skeptic-light); }
+            .trust-note { margin-top: 1rem; color: var(--text-dim); font-size: 0.9rem; line-height: 1.6; }
+
+            /* Closing */
+            .obj-continue { max-width: 760px; margin: 0 0 1rem; padding-top: 1.5rem; border-top: 1px solid var(--border-color); }
+            .closing-line { font-size: 1.35rem; line-height: 1.6; color: var(--accent-skeptic-light); margin-bottom: 1.5rem; }
+            .obj-continue p { color: var(--text-light); line-height: 1.8; margin-bottom: 1.25rem; }
+            .closing-links { display: flex; flex-wrap: wrap; gap: 0.85rem; }
+            .closing-links a { display: inline-block; padding: 0.85rem 1.5rem; border: 1px solid var(--accent-skeptic); color: var(--text-light); border-radius: 0.5rem; text-decoration: none; font-weight: 600; transition: background 0.2s ease, color 0.2s ease; }
+            .closing-links a:hover { background: var(--accent-skeptic); color: var(--primary-dark); }
+            .closing-links a.primary { border-color: var(--accent-skeptic-light); }
+        </style>
+
+        <div class="obj-intro">
+            <p><strong>No conclusion is handed to you here.</strong> You've examined what money is, how promises get paid, and where Bitcoin's tradeoffs actually sit. None of that was building toward a verdict.</p>
+            <p>The point was never agreement. It was understanding the system you're already trusting — clearly enough to make your own call, on your own terms, in your own time.</p>
+            <p>So spend this stage sitting with questions rather than answers. Read each one slowly. You don't have to resolve it today.</p>
+        </div>
+
+        <section class="obj-list" aria-label="Questions to sit with">
+            <article class="obj-card">
+                <h3 class="obj-q">Which assumption changed for you along the way?</h3>
+                <p>Maybe something you took as settled — what makes money "real," who guarantees its value, whether digital means flimsy — looks different now. Name the one that shifted, and notice what shifted it.</p>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Which objection still feels strong?</h3>
+                <p>That's fine — say it plainly. An objection you can still state clearly after all this is a good objection. Keeping it is honest, not a failure to "get it."</p>
+                <p class="obj-aside">A doubt you can articulate is worth more than an agreement you can't defend.</p>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">What would you need to understand better before trusting Bitcoin?</h3>
+                <p>Be specific. Is it the technology, the volatility, the custody, the incentives, the history — or the people around it? Knowing exactly where your understanding runs out is more useful than a yes or a no.</p>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">Where do you currently place your trust?</h3>
+                <p>Government, banks, markets, code, yourself — or some mix of all of them. You already trust something with your money every day. The question is only whether you've ever looked at it directly.</p>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">What is the cost of trusting each of those?</h3>
+                <p>Every place you put trust asks something in return — a fee, a constraint, a counterparty, a responsibility, a single point of failure. There's no option with zero cost. The honest move is to see the price, not to pretend it isn't there.</p>
+            </article>
+            <article class="obj-card">
+                <h3 class="obj-q">What is the cost of not asking these questions at all?</h3>
+                <p>Trust you never examine is still trust — you just don't know its terms. The most expensive position is often the one held by default, simply because no one ever stopped to ask.</p>
+            </article>
+        </section>
+
+        <section class="trust-reflect" aria-label="Where do you place your trust">
+            <h2>Where do you place your trust?</h2>
+            <p>This isn't a test, and there's no right answer. Pick whatever you'd reach for first with your money. Each choice surfaces a neutral note on what you'd be trusting and what it tends to cost — so you can weigh it yourself. Pick another any time. Nothing is scored, and nothing is saved.</p>
+            <div class="trust-grid" role="group" aria-label="Choose where you place trust">
+                <button type="button" class="trust-option" data-trust="government" aria-pressed="false">
+                    <span class="trust-icon" aria-hidden="true">🏛️</span>
+                    <span class="trust-name">Government</span>
+                </button>
+                <button type="button" class="trust-option" data-trust="banks" aria-pressed="false">
+                    <span class="trust-icon" aria-hidden="true">🏦</span>
+                    <span class="trust-name">Banks</span>
+                </button>
+                <button type="button" class="trust-option" data-trust="markets" aria-pressed="false">
+                    <span class="trust-icon" aria-hidden="true">📈</span>
+                    <span class="trust-name">Markets</span>
+                </button>
+                <button type="button" class="trust-option" data-trust="code" aria-pressed="false">
+                    <span class="trust-icon" aria-hidden="true">⛓️</span>
+                    <span class="trust-name">Bitcoin / code</span>
+                </button>
+                <button type="button" class="trust-option" data-trust="yourself" aria-pressed="false">
+                    <span class="trust-icon" aria-hidden="true">🪞</span>
+                    <span class="trust-name">Yourself</span>
+                </button>
+            </div>
+            <div class="trust-readout" aria-live="polite">
+                <span class="tr-name" id="tr-name">Pick one to reflect</span>
+                <p class="tr-line" id="tr-trusting">Hover or select an option above. There's nothing to get right — just something to notice.</p>
+                <p class="tr-line" id="tr-cost"></p>
+            </div>
+            <p class="trust-note">Most people land on a mix, and the mix shifts with the situation. That's not indecision — it's just an honest map of where your trust already lives.</p>
+        </section>
+
+        <div class="obj-continue">
+            <p class="closing-line">You don't need to agree with Bitcoin today. But you should understand the system you're already trusting.</p>
+            <p>Wherever you've landed — convinced, unconvinced, or somewhere honestly in between — the judgment is yours to keep. If you want to keep examining, these are open doors, not next steps you owe anyone.</p>
+            <div class="closing-links">
+                <a href="/paths/skeptic/" class="primary">Back to Question Money First</a>
+                <a href="/interactive-demos/">Explore the interactive demos</a>
+                <a href="/deep-dives/">Read the deep dives</a>
+            </div>
+        </div>
+    </main>
+
+    <script src="/js/icon-library.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            if (window.IconLibrary) {
+                document.querySelectorAll('[data-icon]').forEach(function(element) {
+                    var iconName = element.getAttribute('data-icon');
+                    if (iconName) {
+                        var iconHTML = IconLibrary.get(iconName, 24, true);
+                        var span = document.createElement('span');
+                        span.innerHTML = iconHTML;
+                        span.className = 'icon-inline';
+                        span.style.display = 'inline-block';
+                        span.style.verticalAlign = 'middle';
+                        element.innerHTML = '';
+                        element.appendChild(span);
+                    }
+                });
+            }
+        });
+    </script>
+
+    <script>
+        // Trust reflection: no score, no right answer, no completion state.
+        // Just surfaces a neutral note on what you trust and what it costs.
+        (function () {
+            var NOTES = {
+                government: {
+                    name: 'Government',
+                    trusting: 'You are trusting that the state keeps its money worth holding, and that the rules behind it stay stable.',
+                    cost: 'The cost: you accept whatever happens to that value when more money is issued, and you rely on decisions you do not get to make.'
+                },
+                banks: {
+                    name: 'Banks',
+                    trusting: 'You are trusting an institution to hold your balance, honor withdrawals, and keep your account open.',
+                    cost: 'The cost: a counterparty stands between you and your money — it can charge fees, freeze access, or fail.'
+                },
+                markets: {
+                    name: 'Markets',
+                    trusting: 'You are trusting that prices roughly reflect reality and that you can exit when you need to.',
+                    cost: 'The cost: prices move with crowds and emotion, and liquidity can vanish exactly when you want it most.'
+                },
+                code: {
+                    name: 'Bitcoin / code',
+                    trusting: 'You are trusting open rules enforced by a network, with no one able to quietly change the supply.',
+                    cost: 'The cost: the responsibility shifts to you — keys, backups, mistakes — and the price can swing hard along the way.'
+                },
+                yourself: {
+                    name: 'Yourself',
+                    trusting: 'You are trusting your own judgment, custody, and follow-through over any institution.',
+                    cost: 'The cost: there is no one to call when something goes wrong, and the discipline has to be yours alone.'
+                }
+            };
+
+            var nameEl = document.getElementById('tr-name');
+            var trustingEl = document.getElementById('tr-trusting');
+            var costEl = document.getElementById('tr-cost');
+            var buttons = Array.prototype.slice.call(document.querySelectorAll('.trust-option'));
+
+            function show(key) {
+                var note = NOTES[key];
+                if (!note) { return; }
+                nameEl.textContent = note.name;
+                trustingEl.textContent = note.trusting;
+                costEl.textContent = note.cost;
+            }
+
+            function select(btn) {
+                buttons.forEach(function (b) { b.setAttribute('aria-pressed', b === btn ? 'true' : 'false'); });
+                show(btn.getAttribute('data-trust'));
+            }
+
+            buttons.forEach(function (btn) {
+                btn.addEventListener('click', function () { select(btn); });
+                btn.addEventListener('mouseenter', function () { show(btn.getAttribute('data-trust')); });
+                btn.addEventListener('focus', function () { show(btn.getAttribute('data-trust')); });
+            });
+        })();
+    </script>
+
+
+    <!-- Navigation Context (return-to-path functionality) -->
+    <script src="/js/navigation-context.js"></script>
+    <!-- Reflect: Socratic questions after module -->
+    <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
+        <div class="reflect-widget"
+             data-topic="money"
+             data-path="skeptic"
+             data-title="Reflect: which assumption changed — and which objection still stands?">
+        </div>
+    </div>
+    <script src="/js/reflect-widget.js"></script>
+
+<script src="/js/membership-gate.js"></script>
+
+<!-- Analytics, Email Capture & Tip CTAs -->
+<div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
+    <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
+    <div id="tip-page" data-tip-cta="compact"></div>
+</div>
+<script src="/js/analytics.js" defer></script>
+<script src="/js/email-capture.js" defer></script>
+<script src="/js/tip-cta.js" defer></script>
+
+</body></html>

--- a/tests/premium-routes.test.mjs
+++ b/tests/premium-routes.test.mjs
@@ -7,30 +7,27 @@ test('normalizes clean URLs and removes trailing slashes', () => {
   assert.equal(normalizePathname('deep-dives/'), '/deep-dives');
 });
 
-test('treats stage-1 module-1 as free preview content', () => {
-  const details = getProtectedRouteDetails('/paths/curious/stage-1/module-1');
-  assert.equal(details.protected, false);
-  assert.equal(details.reason, 'stage-1-preview');
+// Learning paths are free (education-first model, decided 2026-06-15) — revenue
+// comes from kits + advisory, not from gating lessons. Every /paths/* route is open.
+test('treats all learning-path content as free', () => {
+  const free = [
+    '/paths/curious/stage-1/module-1',
+    '/paths/curious/stage-1/module-2',
+    '/paths/curious/stage-1/module-2-5.html',
+    '/paths/builder/stage-3',
+    '/paths/principled/capstone/index.html',
+    '/paths/curious/stage-1/deep-dives/fractional-reserve.html',
+    '/paths/skeptic/stage-5/'
+  ];
+  for (const route of free) {
+    const details = getProtectedRouteDetails(route);
+    assert.equal(details.protected, false, `${route} should be free`);
+    assert.equal(details.reason, 'paths-free', `${route} reason`);
+  }
 });
 
-test('protects stage-1 follow-up modules including special module names', () => {
-  assert.equal(isProtectedPremiumRoute('/paths/curious/stage-1/module-2'), true);
-  assert.equal(isProtectedPremiumRoute('/paths/curious/stage-1/module-2-5.html'), true);
-});
-
-test('protects stage-2 and later path routes', () => {
-  const details = getProtectedRouteDetails('/paths/builder/stage-3');
-  assert.equal(details.protected, true);
-  assert.equal(details.pathId, 'builder');
-  assert.equal(details.reason, 'stage-2-plus');
-});
-
-test('protects explicit path outliers included in phase 1', () => {
-  assert.equal(isProtectedPremiumRoute('/paths/curious/stage-1/deep-dives/fractional-reserve.html'), true);
-  assert.equal(isProtectedPremiumRoute('/paths/principled/capstone/index.html'), true);
-});
-
-test('protects the deep-dives area', () => {
+// The standalone deep-dives section remains the one premium content tier.
+test('keeps the standalone deep-dives area premium', () => {
   assert.equal(isProtectedPremiumRoute('/deep-dives'), true);
   assert.equal(isProtectedPremiumRoute('/deep-dives/sovereign-tools/running-a-node.html'), true);
 });


### PR DESCRIPTION
Two coupled changes (the skeptic rebuild surfaced the model decision):

## 🟠 Model change: learning paths are now FREE
**Decided 2026-06-15.** Reasoning: traffic is the funnel bottleneck (not conversion); the real revenue is **kits + advisory**, and the paths are the funnel that *feeds* them. Paywalling lessons fought the mission (inform-not-convince, unbounded mode) and choked the funnel. So **all `/paths/*` are free**; the standalone **`/deep-dives/`** section stays the one premium tier.

Turns off the module paywall across three gate layers:
- **`lib/premium-routes.js`** (server) — `/paths/*` → `protected:false`; `/deep-dives/` still protected. `getPremiumPathIds` kept for route-token tiers.
- **`js/membership-gate.js`** (client overlay) — removed `/paths/` premium patterns; only `/deep-dives/` premium.
- **`js/config.js`** — `ENABLE_MODULE_GATING: false` (default + production) → disables `module-gate.js` + `module-gate-subdomain.js`. `ENABLE_DEMO_LOCKS` unchanged.
- **tests** updated to the new model; `premium-routes` passes 3/3.

⚠️ **This turns off the production module paywall** — review with that in mind. (Demos + deep-dives stay gated. Reversible by flipping the flag back.) Resolves the Codex review thread about open-map-vs-paywall.

## Skeptic path → "Question Money First" (discover, not convince)
Index + 5 stages replacing debunk/convince mode. Stage 1 = 7 respect-the-objection cards; Stage 2 = Purchasing-Power Eroder; Stage 3 = Promise-Gap calculator; Stage 4 = honest tradeoff cards + custody comparison (collaborative = self-custody-with-guardrails, no "middle ground"); Stage 5 = trust reflection (no score). De-gamified, no green/purple, single `<main>`, calculators verified, no console errors.

## Open question for you
**`/deep-dives/` stays gated** — I scoped "free the paths" to the learning paths only. Tell me if you also want deep-dives free (one-line change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)