### PR TITLE
fix(ci): allowlist legitimate historical refs in defunct-services lint

### DIFF
--- a/scripts/check-defunct-services.config.mjs
+++ b/scripts/check-defunct-services.config.mjs
@@ -148,6 +148,28 @@ export const FILE_ALLOWLIST = [
   'reports/demo-audit-economics.md',
   'reports/demo-audit-protocol.md',
   'reports/tutor-evals-2026-04-24.md',
+  'reports/tutor-evals-2026-04-26.md',
+  'reports/content-audit-premium-2026-06-06.md',
+  // Audit/spec working docs — flag and discuss retired services by design.
+  'audit-2026-04/findings.md',
+  'audit-2026-04/spec-coinjoin-simulator.md',
+  'audit-2026-04/spec-kyc-best-practices.md',
+  // Bitcoin-backed lending deep dives — cite Celsius/Voyager/BlockFi/FTX as
+  // cautionary historical examples of rehypothecation & counterparty failure
+  // (the whole point of the lesson). Not recommendations.
+  'deep-dives/bitcoin-capital/bitcoin-backed-loans-deep-dive.md',
+  'deep-dives/bitcoin-capital/bitcoin-backed-loans.html',
+  'deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html',
+  // Foundational-layer thesis essays — discuss privacy protocols (Whirlpool) and
+  // "post-FTX" market context as part of the argument; historical/analytical.
+  'deep-dives/foundational-layer-thesis/competing-theses.md',
+  'deep-dives/foundational-layer-thesis/counter-map.md',
+  // DCA time machine — lists "FTX, Mt. Gox style events" as historical exchange-
+  // failure examples motivating self-custody.
+  'interactive-demos/bitcoin-dca-time-machine/index.html',
+  // CoinJoin simulator — references Whirlpool to state Sparrow no longer bundles it
+  // (accurate post-removal fact) and as historical CoinJoin context.
+  'interactive-demos/coinjoin-simulator/index.html',
   // Roadmap files where the names appear as task labels
   'TASKS.md',
   // Canonical CoinJoin history module — references Samourai/Whirlpool throughout


### PR DESCRIPTION
**Fixes a pre-existing, repo-wide quality-check failure** that was red on `main` and therefore on every open PR (#111, #112, #113) — none of which caused it.

`scripts/check-defunct-services.mjs` was flagging **31 matches across 12 files**, all **legitimate historical/educational/audit references** (verified each), not stale recommendations:

| File group | Why it's legitimate |
|---|---|
| `reports/content-audit-premium-*`, `reports/tutor-evals-2026-04-26`, `audit-2026-04/*` | Audit/eval docs that catalog retired services by design (same category already allowlisted) |
| `deep-dives/bitcoin-capital/*` (loans, mortgages) | Cite Celsius/Voyager/BlockFi/FTX as **cautionary** rehypothecation/counterparty-failure examples — the lesson itself |
| `deep-dives/foundational-layer-thesis/*` | Discuss Whirlpool + "post-FTX" market context analytically |
| `interactive-demos/bitcoin-dca-time-machine` | "FTX, Mt. Gox style events" as historical examples |
| `interactive-demos/coinjoin-simulator` | States "Sparrow Wallet (**no** Whirlpool)" — accurate post-removal fact |

Added all 12 to `FILE_ALLOWLIST` with per-file justifications, matching the existing "audit reports / historical demos" convention. Local run: `✅ defunct-services lint: clean (734 files scanned, 0 violations)`.

Note: file-level allowlisting means future genuinely-stale refs in these files won't be caught — acceptable per the config's chosen mechanism (these are stable educational/audit files). A `reports/**`-style skip could be a future robustness improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)