### PR TITLE
feat(paths): de-gamify the remaining 5 paths (unbounded mode)

### DIFF
--- a/paths/builder/index.html
+++ b/paths/builder/index.html
@@ -73,110 +73,6 @@
             gap: 0.5rem;
         }
 
-        /* Progress Dashboard */
-        .progress-dashboard {
-            background: var(--secondary-dark);
-            border: 2px solid var(--accent-green);
-            border-radius: 1rem;
-            padding: 2rem;
-            margin: 3rem 0;
-        }
-
-        .progress-header {
-            text-align: center;
-            margin-bottom: 2rem;
-        }
-
-        .progress-header h2 {
-            color: var(--accent-green);
-            margin-bottom: 0.5rem;
-        }
-
-        .progress-stats {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 1.5rem;
-            margin-bottom: 2rem;
-        }
-
-        .stat-card {
-            background: rgba(255, 122, 0, 0.1);
-            border: 2px solid var(--border-color);
-            border-radius: 0.75rem;
-            padding: 1.5rem;
-            text-align: center;
-        }
-
-        .stat-value {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--primary-orange);
-            display: block;
-            margin-bottom: 0.5rem;
-        }
-
-        .stat-label {
-            font-size: 0.9rem;
-            color: var(--text-dim);
-        }
-
-        .progress-bar-container {
-            background: rgba(0, 0, 0, 0.3);
-            border-radius: 2rem;
-            height: 2rem;
-            overflow: hidden;
-            margin: 1.5rem 0;
-        }
-
-        .progress-bar {
-            background: linear-gradient(90deg, var(--primary-orange), var(--accent-green));
-            height: 100%;
-            border-radius: 2rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-weight: 700;
-            transition: width 0.5s ease;
-            min-width: 2rem;
-        }
-
-        /* Badges */
-        .badges-section {
-            margin-top: 2rem;
-        }
-
-        .badges-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-            gap: 1rem;
-            margin-top: 1rem;
-        }
-
-        .badge-card {
-            background: rgba(76, 175, 80, 0.1);
-            border: 2px solid var(--accent-green);
-            border-radius: 0.75rem;
-            padding: 1rem;
-            text-align: center;
-            transition: all 0.3s ease;
-        }
-
-        .badge-card.locked {
-            background: rgba(0, 0, 0, 0.2);
-            border-color: var(--border-color);
-            opacity: 0.5;
-        }
-
-        .badge-icon {
-            font-size: 2.5rem;
-            margin-bottom: 0.5rem;
-        }
-
-        .badge-name {
-            font-weight: 600;
-            color: var(--text-light);
-        }
-
         /* Stages Grid */
         .stages-section {
             margin: 4rem 0;
@@ -206,15 +102,6 @@
         .stage-card:hover {
             border-color: var(--primary-orange);
             transform: translateY(-5px);
-        }
-
-        .stage-card.locked {
-            opacity: 0.6;
-            cursor: not-allowed;
-        }
-
-        .stage-card.locked:hover {
-            transform: none;
         }
 
         .stage-header {
@@ -248,11 +135,6 @@
             border-radius: 0.5rem;
             font-size: 0.85rem;
             font-weight: 600;
-        }
-
-        .stage-status.locked {
-            background: rgba(255, 255, 255, 0.1);
-            color: var(--text-dim);
         }
 
         .stage-description {
@@ -324,13 +206,6 @@
         .stage-cta:hover {
             background: #ff8c00;
             transform: translateX(5px);
-        }
-
-        .stage-cta.locked {
-            background: var(--border-color);
-            color: var(--text-dim);
-            cursor: not-allowed;
-            pointer-events: none;
         }
 
         /* Genesis Timeline */
@@ -760,10 +635,6 @@
                 gap: 0.5rem;
             }
 
-            .progress-stats {
-                grid-template-columns: 1fr;
-            }
-
             .stage-header {
                 flex-direction: column;
                 gap: 1rem;
@@ -898,68 +769,12 @@
                     <span>Expert Level</span>
                 </div>
             </div>
-        </div>
+        </main>
     </section>
-
-    <!-- Progress Dashboard -->
-    <main id="main-content-2" class="container">
-        <div class="progress-dashboard" id="progress-dashboard">
-            <div class="progress-header">
-                <h2>Your Progress</h2>
-                <p style="color: var(--text-dim);">Track your journey to becoming a Bitcoin developer</p>
-            </div>
-
-            <div class="progress-stats">
-                <div class="stat-card">
-                    <span class="stat-value" id="modules-completed">0</span>
-                    <span class="stat-label">Modules Completed</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-value" id="current-stage">1</span>
-                    <span class="stat-label">Current Stage</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-value" id="badges-earned">0</span>
-                    <span class="stat-label">Badges Earned</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-value" id="completion-percent">0%</span>
-                    <span class="stat-label">Overall Progress</span>
-                </div>
-            </div>
-
-            <div class="progress-bar-container">
-                <div class="progress-bar" id="progress-bar" style="width: 0%;">0%</div>
-            </div>
-
-            <!-- Badges -->
-            <div class="badges-section">
-                <h3 style="text-align: center; margin-bottom: 1rem; color: var(--text-light);"><span data-icon="trophy"></span> Achievements</h3>
-                <div class="badges-grid">
-                    <div class="badge-card locked" data-badge="protocol-mastery">
-                        <div class="badge-icon">🔬</div>
-                        <div class="badge-name">Protocol Mastery</div>
-                    </div>
-                    <div class="badge-card locked" data-badge="lightning-developer">
-                        <div class="badge-icon"><span data-icon="lightning"></span> </div>
-                        <div class="badge-name">Lightning Developer</div>
-                    </div>
-                    <div class="badge-card locked" data-badge="bitcoin-builder">
-                        <div class="badge-icon">🛠️</div>
-                        <div class="badge-name">Bitcoin Builder</div>
-                    </div>
-                    <div class="badge-card locked" data-badge="bitcoin-contributor">
-                        <div class="badge-icon">🌟</div>
-                        <div class="badge-name">Bitcoin Contributor</div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
 
     <!-- Genesis Timeline Section -->
     <section class="genesis-section">
-        <main id="main-content-3" class="container">
+        <div class="container">
             <div class="genesis-intro">
                 <h2>🌟 The Bitcoin Genesis Timeline</h2>
                 <p>Every revolution stands on the shoulders of giants. Discover the technologies, visionaries, and pivotal moments that had to happen before Satoshi could write the whitepaper.</p>
@@ -1183,7 +998,7 @@
 
     <!-- Stages Section -->
     <section class="stages-section">
-        <main id="main-content-4" class="container">
+        <div class="container">
             <h2>Learning Stages</h2>
 
             <div class="stages-grid">
@@ -1194,7 +1009,7 @@
                             <h3>Stage 1: Technical Foundations</h3>
                             <p class="stage-subtitle">Deep dive into Bitcoin's core protocol and cryptography</p>
                         </div>
-                        <div class="stage-status" data-status="unlocked">Unlocked</div>
+                        <div class="stage-status">Open</div>
                     </div>
 
                     <div class="stage-description">
@@ -1215,20 +1030,19 @@
                         <div class="stage-meta">
                             <span><span data-icon="timer"></span> ~2.5 hours</span>
                             <span><span data-icon="target"></span> 3 modules</span>
-                            <span><span data-icon="trophy"></span> Protocol Mastery badge</span>
                         </div>
                         <a href="/paths/builder/stage-1/" class="stage-cta">Begin Stage 1 →</a>
                     </div>
                 </div>
 
                 <!-- Stage 2 -->
-                <div class="stage-card locked" data-stage="2">
+                <div class="stage-card" data-stage="2">
                     <div class="stage-header">
                         <div class="stage-title">
                             <h3>Stage 2: Lightning Network</h3>
                             <p class="stage-subtitle">Build scalable payment solutions with Lightning</p>
                         </div>
-                        <div class="stage-status locked" data-status="locked"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-status">Open</div>
                     </div>
 
                     <div class="stage-description">
@@ -1249,20 +1063,19 @@
                         <div class="stage-meta">
                             <span><span data-icon="timer"></span> ~3.25 hours</span>
                             <span><span data-icon="target"></span> 3 modules</span>
-                            <span><span data-icon="trophy"></span> Lightning Developer badge</span>
                         </div>
-                        <a href="/paths/builder/stage-2/" class="stage-cta locked">Complete Stage 1 First</a>
+                        <a href="/paths/builder/stage-2/" class="stage-cta">Begin Stage 2 →</a>
                     </div>
                 </div>
 
                 <!-- Stage 3 -->
-                <div class="stage-card locked" data-stage="3">
+                <div class="stage-card" data-stage="3">
                     <div class="stage-header">
                         <div class="stage-title">
                             <h3>Stage 3: Building Applications</h3>
                             <p class="stage-subtitle">Create production-ready Bitcoin applications</p>
                         </div>
-                        <div class="stage-status locked" data-status="locked"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-status">Open</div>
                     </div>
 
                     <div class="stage-description">
@@ -1283,20 +1096,19 @@
                         <div class="stage-meta">
                             <span><span data-icon="timer"></span> ~3.75 hours</span>
                             <span><span data-icon="target"></span> 3 modules</span>
-                            <span><span data-icon="trophy"></span> Bitcoin Builder badge</span>
                         </div>
-                        <a href="/paths/builder/stage-3/" class="stage-cta locked">Complete Stage 2 First</a>
+                        <a href="/paths/builder/stage-3/" class="stage-cta">Begin Stage 3 →</a>
                     </div>
                 </div>
 
                 <!-- Stage 4 -->
-                <div class="stage-card locked" data-stage="4">
+                <div class="stage-card" data-stage="4">
                     <div class="stage-header">
                         <div class="stage-title">
                             <h3>Stage 4: Contributing to Bitcoin</h3>
                             <p class="stage-subtitle">Join the Bitcoin Core contributor community</p>
                         </div>
-                        <div class="stage-status locked" data-status="locked"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-status">Open</div>
                     </div>
 
                     <div class="stage-description">
@@ -1317,9 +1129,8 @@
                         <div class="stage-meta">
                             <span><span data-icon="timer"></span> ~2.5+ hours</span>
                             <span><span data-icon="target"></span> 3 modules</span>
-                            <span><span data-icon="trophy"></span> Bitcoin Contributor badge</span>
                         </div>
-                        <a href="/paths/builder/stage-4/" class="stage-cta locked">Complete Stage 3 First</a>
+                        <a href="/paths/builder/stage-4/" class="stage-cta">Begin Stage 4 →</a>
                     </div>
                 </div>
             </div>
@@ -1327,79 +1138,6 @@
     </section>
 
     <script>
-        // Load and display progress
-        function updateProgress() {
-            const progress = JSON.parse(localStorage.getItem('learningProgress') || '{}');
-
-            if (progress.path !== 'builder') {
-                // Initialize Builder path progress
-                return;
-            }
-
-            const completedModules = progress.completedModules || [];
-            const badges = progress.badges || [];
-            const completedStages = progress.completedStages || [];
-
-            // Update stats
-            const builderModules = completedModules.filter(m => m.startsWith('builder-'));
-            document.getElementById('modules-completed').textContent = builderModules.length;
-            document.getElementById('current-stage').textContent = progress.currentStage || 1;
-            document.getElementById('badges-earned').textContent = badges.length;
-
-            const totalModules = 10;
-            const completionPercent = Math.round((builderModules.length / totalModules) * 100);
-            document.getElementById('completion-percent').textContent = completionPercent + '%';
-
-            // Update progress bar
-            const progressBar = document.getElementById('progress-bar');
-            progressBar.style.width = completionPercent + '%';
-            progressBar.textContent = completionPercent + '%';
-
-            // Update badges
-            badges.forEach(badge => {
-                const badgeCard = document.querySelector(`[data-badge="${badge}"]`);
-                if (badgeCard) {
-                    badgeCard.classList.remove('locked');
-                }
-            });
-
-            // Update modules completion checkmarks
-            builderModules.forEach(moduleId => {
-                const moduleLi = document.querySelector(`[data-module="${moduleId}"]`);
-                if (moduleLi) {
-                    moduleLi.classList.add('completed');
-                }
-            });
-
-            // Unlock stages
-            completedStages.forEach(stageId => {
-                const stageNum = parseInt(stageId.split('-')[1]);
-                const nextStage = document.querySelector(`[data-stage="${stageNum + 1}"]`);
-                if (nextStage) {
-                    nextStage.classList.remove('locked');
-                    const statusBadge = nextStage.querySelector('[data-status]');
-                    statusBadge.textContent = 'Unlocked';
-                    statusBadge.classList.remove('locked');
-                    const cta = nextStage.querySelector('.stage-cta');
-                    cta.classList.remove('locked');
-                    cta.textContent = `Begin Stage ${stageNum + 1} →`;
-                }
-            });
-
-            // Mark completed stages
-            completedStages.forEach(stageId => {
-                const stageNum = parseInt(stageId.split('-')[1]);
-                const stage = document.querySelector(`[data-stage="${stageNum}"]`);
-                if (stage) {
-                    const statusBadge = stage.querySelector('[data-status]');
-                    statusBadge.textContent = '✓ Complete';
-                    statusBadge.style.background = 'rgba(76, 175, 80, 0.3)';
-                }
-            });
-        }
-
-        updateProgress();
-
         // === Genesis Timeline Functions ===
 
         function revealCard(card) {
@@ -2296,69 +2034,6 @@ Instant payments, micro-transactions, global scalability
             output.classList.add('visible');
         }
 
-        // ===== PREVIEW MODE ACCESS CONTROL =====
-        (function() {
-            const urlParams = new URLSearchParams(window.location.search);
-            const isDeveloperMode = urlParams.get('unlock') === 'all' || localStorage.getItem('devUnlockAll') === 'true';
-
-            if (isDeveloperMode) {
-                const devIndicator = document.createElement('div');
-                devIndicator.style.cssText = `
-                    position: fixed; top: 10px; right: 10px; background: #4CAF50; color: white;
-                    padding: 8px 16px; border-radius: 20px; font-size: 12px; font-weight: bold;
-                    z-index: 10000; box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-                `;
-                devIndicator.textContent = '🔓 DEV MODE';
-                devIndicator.title = 'All stages unlocked. Go to homepage with ?unlock=off to disable.';
-                document.body.appendChild(devIndicator);
-                return;
-            }
-
-            // PREVIEW MODE: Lock stages 2, 3, 4 (Only Genesis timeline/Stage 1 unlocked)
-            console.log('🔒 Preview Mode: Only Stage 1 (Genesis Timeline) unlocked');
-
-            const lockedStages = ['stage-2', 'stage-3', 'stage-4'];
-            lockedStages.forEach(stageId => {
-                const stageCard = document.getElementById(stageId);
-                if (!stageCard) return;
-
-                stageCard.classList.remove('current', 'completed');
-                stageCard.classList.add('locked');
-
-                const badge = stageCard.querySelector('.stage-badge');
-                if (badge) {
-                    badge.textContent = '🔒 Preview Locked';
-                    badge.style.background = 'rgba(244, 67, 54, 0.2)';
-                    badge.style.color = '#F44336';
-                }
-
-                const btn = stageCard.querySelector('.stage-btn');
-                if (btn) {
-                    btn.style.background = '#666';
-                    btn.style.cursor = 'not-allowed';
-                    btn.style.pointerEvents = 'none';
-                    btn.textContent = '🔒 Available in Full Release';
-                    btn.addEventListener('click', (e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        alert('🔒 This stage is locked in preview mode.\n\nIt will be available in the full release.');
-                    }, true);
-                }
-
-                const lockBadge = document.createElement('div');
-                lockBadge.style.cssText = `
-                    position: absolute; top: 20px; right: 20px; background: rgba(244, 67, 54, 0.9);
-                    color: white; padding: 6px 14px; border-radius: 20px; font-size: 12px;
-                    font-weight: 700; z-index: 100; box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-                `;
-                lockBadge.innerHTML = '🔒 PREVIEW LOCKED';
-                lockBadge.title = 'Available in full release';
-                stageCard.style.position = 'relative';
-                stageCard.insertBefore(lockBadge, stageCard.firstChild);
-                stageCard.style.opacity = '0.6';
-            });
-
-        })();
     </script>
 
     <!-- Animated Icon Library -->

--- a/paths/builder/stage-1/module-3.html
+++ b/paths/builder/stage-1/module-3.html
@@ -1059,15 +1059,14 @@ Next Halving (~2028):
             </section>
 
             <!-- Completion Banner -->
-            <div class="completion-banner" id="completion-banner">
-                <div class="badge-display">🔬</div>
-                <h3>Congratulations! Stage 1 Complete!</h3>
+            <div class="completion-banner" id="completion-banner" style="display:block">
+                <h3>Stage 1 wrap-up</h3>
                 <p style="margin-bottom: 1.5rem;">
-                    You've earned the <strong>"Protocol Mastery"</strong> badge! You now understand Bitcoin's technical architecture
-                    at a deep level: UTXOs, cryptographic primitives, and proof-of-work consensus.
+                    You now understand Bitcoin's technical architecture at a deep level: UTXOs,
+                    cryptographic primitives, and proof-of-work consensus.
                 </p>
                 <p style="margin-bottom: 1.5rem;">
-                    <strong>You've Mastered:</strong>
+                    <strong>What you've covered:</strong>
                 </p>
                 <ul style="list-style: none; display: inline-block; text-align: left; margin-bottom: 1.5rem;">
                     <li>✅ UTXO model and transaction structure</li>
@@ -1106,55 +1105,11 @@ Next Halving (~2028):
 
 <nav class="module-navigation">
                 <a href="module-2.html" class="nav-btn nav-btn-secondary">← Previous: Cryptographic Primitives</a>
-                <button id="complete-module" class="nav-btn">Mark Complete &amp; Finish Stage 1 →</button>
+                <a href="/paths/builder/stage-2/" class="nav-btn">Continue to Stage 2 →</a>
             </nav>
         </div>
     </main>
 
-    <script>
-        document.getElementById('complete-module').addEventListener('click', function() {
-            const progress = JSON.parse(localStorage.getItem('learningProgress') || '{}');
-
-            if (!progress.completedModules) {
-                progress.completedModules = [];
-            }
-
-            if (!progress.completedModules.includes('builder-1-3')) {
-                progress.completedModules.push('builder-1-3');
-            }
-
-            // Mark Stage 1 complete
-            if (!progress.completedStages) {
-                progress.completedStages = [];
-            }
-            if (!progress.completedStages.includes('builder-1')) {
-                progress.completedStages.push('builder-1');
-            }
-
-            // Award badge
-            if (!progress.badges) {
-                progress.badges = [];
-            }
-            if (!progress.badges.includes('protocol-mastery')) {
-                progress.badges.push('protocol-mastery');
-            }
-
-            progress.lastActivity = new Date().toISOString();
-            progress.path = 'builder';
-            progress.currentStage = 2;
-            progress.currentModule = 1;
-
-            localStorage.setItem('learningProgress', JSON.stringify(progress));
-
-            // Show completion banner
-            document.getElementById('completion-banner').style.display = 'block';
-
-            setTimeout(() => {
-                document.getElementById('completion-banner').scrollIntoView({ behavior: 'smooth', block: 'center' });
-            }, 100);
-        });
-    </script>
-    
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>
     <script>

--- a/paths/builder/stage-2/module-3.html
+++ b/paths/builder/stage-2/module-3.html
@@ -758,42 +758,11 @@ subscribeToInvoices();</code></pre>
 
 <nav class="module-navigation">
                 <a href="/paths/builder/stage-2/module-2.html" class="nav-btn nav-btn-secondary">← Previous Module</a>
-                <button id="complete-module" class="nav-btn">Complete Stage 2 →</button>
+                <a href="/paths/builder/stage-3/" class="nav-btn">Continue to Stage 3 →</a>
             </nav>
         </div>
     </main>
 
-    <script>
-        document.getElementById('complete-module').addEventListener('click', function() {
-            const progress = JSON.parse(localStorage.getItem('learningProgress') || '{}');
-
-            if (!progress.completedModules) {
-                progress.completedModules = [];
-            }
-
-            if (!progress.completedModules.includes('builder-2-3')) {
-                progress.completedModules.push('builder-2-3');
-            }
-
-            if (!progress.badges) {
-                progress.badges = [];
-            }
-
-            if (!progress.badges.includes('lightning-developer')) {
-                progress.badges.push('lightning-developer');
-            }
-
-            progress.lastActivity = new Date().toISOString();
-            progress.path = 'builder';
-            progress.currentStage = 2;
-
-            localStorage.setItem('learningProgress', JSON.stringify(progress));
-
-            alert('🎉 Stage 2 Complete! You earned the "Lightning Developer" badge! Redirecting...');
-            window.location.href = '/paths/builder/stage-2/';
-        });
-    </script>
-    
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>
     <script>

--- a/paths/builder/stage-3/module-3.html
+++ b/paths/builder/stage-3/module-3.html
@@ -1255,9 +1255,9 @@ class Config:
                     itself, understanding consensus rules, and becoming part of the protocol development community.
                 </p>
                 <p style="margin-top: 1.5rem; padding: 1rem; background: #2D2D2D; border-radius: 0.5rem;">
-                    <strong style="color: var(--builder-purple);">You're now a Bitcoin Builder.</strong>
-                    You can create applications that handle real value, secure user funds, and contribute to Bitcoin's ecosystem.
-                    That's a significant achievement—wear it with pride and responsibility.
+                    <strong style="color: var(--builder-purple);">You can now build on Bitcoin.</strong>
+                    You can create applications that handle real value, secure user funds, and contribute to Bitcoin's ecosystem—
+                    work that carries real responsibility.
                 </p>
             </section>
 
@@ -1300,34 +1300,11 @@ class Config:
 
 <nav class="module-navigation">
                 <a href="module-2.html" class="nav-btn nav-btn-secondary">← Previous: Building with Bitcoin</a>
-                <button id="complete-module" class="nav-btn">Mark Complete &amp; Finish Stage 3 →</button>
+                <a href="/paths/builder/stage-3/" class="nav-btn">Back to Stage 3 →</a>
             </nav>
         </div>
     </main>
 
-    <script>
-        document.getElementById('complete-module').addEventListener('click', function() {
-            const progress = JSON.parse(localStorage.getItem('learningProgress') || '{}');
-
-            if (!progress.completedModules) {
-                progress.completedModules = [];
-            }
-
-            if (!progress.completedModules.includes('builder-3-3')) {
-                progress.completedModules.push('builder-3-3');
-            }
-
-            progress.lastActivity = new Date().toISOString();
-            progress.path = 'builder';
-            progress.currentStage = 3;
-
-            localStorage.setItem('learningProgress', JSON.stringify(progress));
-
-            alert('✓ Congratulations! Stage 3 completed! You\'ve earned the Bitcoin Builder badge!');
-            window.location.href = '/paths/builder/stage-3/';
-        });
-    </script>
-    
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>
     <script>

--- a/paths/curious/index.html
+++ b/paths/curious/index.html
@@ -12,8 +12,6 @@
     <!-- Safety Assessment -->
     <link rel="stylesheet" href="/css/safety-assessment.css">
 
-    <!-- Progress Manager -->
-    <script src="/js/progress-manager.js"></script>
     <!-- Navigation Context (return-to-path functionality) -->
     <script src="/js/navigation-context.js"></script>
 
@@ -80,48 +78,6 @@
         .path-subtitle {
             font-size: 1.2rem;
             color: var(--text-dim);
-        }
-
-        .path-stats {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 1.5rem;
-            margin-top: 2rem;
-        }
-
-        .stat-card {
-            background: #101010;
-            border: 2px solid var(--accent-green);
-            border-radius: 0.75rem;
-            padding: 1.5rem;
-            text-align: center;
-        }
-
-        .stat-value {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--accent-green);
-            margin-bottom: 0.5rem;
-        }
-
-        .stat-label {
-            font-size: 0.9rem;
-            color: var(--text-dim);
-        }
-
-        .progress-bar {
-            width: 100%;
-            height: 10px;
-            background: #101010;
-            border-radius: 5px;
-            overflow: hidden;
-            margin-top: 2rem;
-        }
-
-        .progress-fill {
-            height: 100%;
-            background: #FF7A00;
-            transition: width 0.3s ease;
         }
 
         /* Main Content */
@@ -296,54 +252,6 @@
             pointer-events: none;
         }
 
-        /* Completion Section */
-        .completion-section {
-            background: #101010;
-            border: 3px solid var(--accent-green);
-            border-radius: 1rem;
-            padding: 3rem 2rem;
-            text-align: center;
-            margin-bottom: 3rem;
-            display: none;
-        }
-
-        .completion-section.show {
-            display: block;
-        }
-
-        .completion-badge {
-            font-size: 5rem;
-            margin-bottom: 1rem;
-        }
-
-        .completion-section h2 {
-            color: var(--accent-green);
-            font-size: 2rem;
-            margin-bottom: 1rem;
-        }
-
-        .badges-earned {
-            display: flex;
-            justify-content: center;
-            gap: 2rem;
-            margin: 2rem 0;
-            flex-wrap: wrap;
-        }
-
-        .badge-item {
-            text-align: center;
-        }
-
-        .badge-icon {
-            font-size: 3rem;
-            margin-bottom: 0.5rem;
-        }
-
-        .badge-name {
-            font-size: 0.9rem;
-            color: var(--text-dim);
-        }
-
         /* Footer Nav */
         .footer-nav {
             background: var(--secondary-dark);
@@ -393,16 +301,7 @@
                 font-size: 2rem;
             }
 
-            .path-stats {
-                grid-template-columns: 1fr;
-            }
-
             .stage-header {
-                flex-direction: column;
-                gap: 1rem;
-            }
-
-            .badges-earned {
                 flex-direction: column;
                 gap: 1rem;
             }
@@ -496,29 +395,6 @@
                 <h1>The Curious Path</h1>
                 <p class="path-subtitle">From questions to clarity — your Bitcoin learning journey</p>
             </div>
-
-            <div class="path-stats">
-                <div class="stat-card">
-                    <div class="stat-value" id="completed-modules">0/13</div>
-                    <div class="stat-label">Modules Completed</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="badges-earned">0/4</div>
-                    <div class="stat-label">Badges Earned</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="time-invested">0 hrs</div>
-                    <div class="stat-label">Time Invested</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="completion-percent">0%</div>
-                    <div class="stat-label">Path Completion</div>
-                </div>
-            </div>
-
-            <div class="progress-bar">
-                <div class="progress-fill" style="width: 0%" id="overall-progress"></div>
-            </div>
         </div>
     </header>
 
@@ -576,7 +452,7 @@
                 </div>
 
                 <!-- Stage 2 -->
-                <div class="stage-card locked" id="stage-2">
+                <div class="stage-card" id="stage-2">
                     <div class="stage-header">
                         <div class="stage-title">
                             <div class="stage-icon"><span data-icon="lightning"></span> </div>
@@ -587,7 +463,7 @@
                                 <span><span data-icon="graduation"></span> ~75 minutes</span>
                             </div>
                         </div>
-                        <div class="stage-badge"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-badge">Open</div>
                     </div>
 
                     <p class="stage-description">
@@ -610,7 +486,7 @@
                 </div>
 
                 <!-- Stage 3 -->
-                <div class="stage-card locked" id="stage-3">
+                <div class="stage-card" id="stage-3">
                     <div class="stage-header">
                         <div class="stage-title">
                             <div class="stage-icon">₿</div>
@@ -621,7 +497,7 @@
                                 <span><span data-icon="graduation"></span> ~100 minutes</span>
                             </div>
                         </div>
-                        <div class="stage-badge"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-badge">Open</div>
                     </div>
 
                     <p class="stage-description">
@@ -644,7 +520,7 @@
                 </div>
 
                 <!-- Stage 4 -->
-                <div class="stage-card locked" id="stage-4">
+                <div class="stage-card" id="stage-4">
                     <div class="stage-header">
                         <div class="stage-title">
                             <div class="stage-icon"><span data-icon="lock"></span> </div>
@@ -655,7 +531,7 @@
                                 <span><span data-icon="graduation"></span> ~85 minutes</span>
                             </div>
                         </div>
-                        <div class="stage-badge"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-badge">Open</div>
                     </div>
 
                     <p class="stage-description">
@@ -678,41 +554,15 @@
                 </div>
             </div>
 
-            <!-- Completion Section (hidden until path complete) -->
-            <div class="completion-section" id="completion-section">
-                <div class="completion-badge">🎉</div>
-                <h2>Congratulations! You've Completed The Curious Path!</h2>
-                <p style="color: var(--text-light); margin-bottom: 2rem;">
-                    You're now a confident Bitcoin user with solid fundamentals, practical skills, and essential security knowledge.
+            <!-- Continue Learning -->
+            <div class="footer-nav" style="margin-bottom: 3rem;">
+                <h3>Where to Next?</h3>
+                <p>
+                    When you're ready to go deeper, explore these advanced paths.
                 </p>
-
-                <div class="badges-earned">
-                    <div class="badge-item">
-                        <div class="badge-icon">💎</div>
-                        <div class="badge-name">Understanding Money</div>
-                    </div>
-                    <div class="badge-item">
-                        <div class="badge-icon"><span data-icon="lightning"></span> </div>
-                        <div class="badge-name">Bitcoin Fundamentals</div>
-                    </div>
-                    <div class="badge-item">
-                        <div class="badge-icon">₿</div>
-                        <div class="badge-name">First Bitcoin</div>
-                    </div>
-                    <div class="badge-item">
-                        <div class="badge-icon"><span data-icon="lock"></span> </div>
-                        <div class="badge-name">Bitcoin Security</div>
-                    </div>
-                </div>
-
-                <h3 style="color: var(--primary-orange); margin-bottom: 1rem;">What's Next?</h3>
-                <p style="color: var(--text-dim); margin-bottom: 1.5rem;">
-                    Continue your Bitcoin journey with advanced paths:
-                </p>
-
-                <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
-                    <a href="/paths/builder/" class="stage-btn"><span data-icon="lightning"></span> The Builder Path →</a>
-                    <a href="/paths/sovereign/" class="stage-btn"><span data-icon="target"></span> The Sovereign Path →</a>
+                <div class="footer-buttons">
+                    <a href="/paths/builder/" class="btn-secondary"><span data-icon="lightning"></span> The Builder Path</a>
+                    <a href="/paths/sovereign/" class="btn-secondary"><span data-icon="target"></span> The Sovereign Path</a>
                 </div>
             </div>
 
@@ -730,222 +580,6 @@
             </div>
         </div>
     </main>
-
-    <script>
-        // Initialize ProgressManager
-        const progressManager = new ProgressManager();
-        progressManager.init();
-
-        // Progress tracking and UI updates
-        function updatePathProgress() {
-            // Get completion percentage
-            const completionPercent = progressManager.getPathProgress('curious');
-
-            // Count completed modules
-            let modulesCompleted = 0;
-            let badgesEarned = 0;
-            let stage1Complete = false;
-            let stage2Complete = false;
-            let stage3Complete = false;
-            let stage4Complete = false;
-
-            // Stage 1: 4 modules
-            const s1m1 = progressManager.isModuleComplete('curious', 1, 1);
-            const s1m2 = progressManager.isModuleComplete('curious', 1, 2);
-            const s1m25 = progressManager.isModuleComplete('curious', 1, 2.5); // module 2.5
-            const s1m3 = progressManager.isModuleComplete('curious', 1, 3);
-            if (s1m1) modulesCompleted++;
-            if (s1m2) modulesCompleted++;
-            if (s1m25) modulesCompleted++;
-            if (s1m3) modulesCompleted++;
-            stage1Complete = s1m1 && s1m2 && s1m25 && s1m3;
-            if (stage1Complete) badgesEarned++;
-
-            // Stage 2: 3 modules
-            const s2m1 = progressManager.isModuleComplete('curious', 2, 1);
-            const s2m2 = progressManager.isModuleComplete('curious', 2, 2);
-            const s2m3 = progressManager.isModuleComplete('curious', 2, 3);
-            if (s2m1) modulesCompleted++;
-            if (s2m2) modulesCompleted++;
-            if (s2m3) modulesCompleted++;
-            stage2Complete = s2m1 && s2m2 && s2m3;
-            if (stage2Complete) badgesEarned++;
-
-            // Stage 3: 3 modules
-            const s3m1 = progressManager.isModuleComplete('curious', 3, 1);
-            const s3m2 = progressManager.isModuleComplete('curious', 3, 2);
-            const s3m3 = progressManager.isModuleComplete('curious', 3, 3);
-            if (s3m1) modulesCompleted++;
-            if (s3m2) modulesCompleted++;
-            if (s3m3) modulesCompleted++;
-            stage3Complete = s3m1 && s3m2 && s3m3;
-            if (stage3Complete) badgesEarned++;
-
-            // Stage 4: 3 modules
-            const s4m1 = progressManager.isModuleComplete('curious', 4, 1);
-            const s4m2 = progressManager.isModuleComplete('curious', 4, 2);
-            const s4m3 = progressManager.isModuleComplete('curious', 4, 3);
-            if (s4m1) modulesCompleted++;
-            if (s4m2) modulesCompleted++;
-            if (s4m3) modulesCompleted++;
-            stage4Complete = s4m1 && s4m2 && s4m3;
-            if (stage4Complete) badgesEarned++;
-
-            const totalModules = 13;
-
-            // Estimate time (5 min per module on average)
-            const timeInvested = Math.round((modulesCompleted * 5) / 60 * 10) / 10; // Hours with 1 decimal
-
-            // Update header stats
-            document.getElementById('completed-modules').textContent = `${modulesCompleted}/${totalModules}`;
-            document.getElementById('badges-earned').textContent = `${badgesEarned}/4`;
-            document.getElementById('time-invested').textContent = `${timeInvested} hrs`;
-            document.getElementById('completion-percent').textContent = `${completionPercent}%`;
-            document.getElementById('overall-progress').style.width = `${completionPercent}%`;
-
-            // Stage 1 (starts unlocked)
-            if (stage1Complete) {
-                document.getElementById('stage-1').classList.remove('current');
-                document.getElementById('stage-1').classList.add('completed');
-                document.querySelector('#stage-1 .stage-badge').textContent = '✓ Completed';
-                document.querySelector('#stage-1 .stage-btn').textContent = '✓ Review Stage';
-
-                // Unlock Stage 2
-                document.getElementById('stage-2').classList.remove('locked');
-                document.getElementById('stage-2').classList.add('current');
-                document.querySelector('#stage-2 .stage-badge').textContent = 'Continue';
-                document.querySelector('#stage-2 .stage-badge').style.background = '#101010';
-                document.querySelector('#stage-2 .stage-badge').style.color = 'var(--primary-orange)';
-            }
-
-            if (stage2Complete) {
-                document.getElementById('stage-2').classList.remove('current');
-                document.getElementById('stage-2').classList.add('completed');
-                document.querySelector('#stage-2 .stage-badge').textContent = '✓ Completed';
-                document.querySelector('#stage-2 .stage-btn').textContent = '✓ Review Stage';
-
-                // Unlock Stage 3
-                document.getElementById('stage-3').classList.remove('locked');
-                document.getElementById('stage-3').classList.add('current');
-                document.querySelector('#stage-3 .stage-badge').textContent = 'Continue';
-                document.querySelector('#stage-3 .stage-badge').style.background = '#101010';
-                document.querySelector('#stage-3 .stage-badge').style.color = 'var(--primary-orange)';
-            }
-
-            if (stage3Complete) {
-                document.getElementById('stage-3').classList.remove('current');
-                document.getElementById('stage-3').classList.add('completed');
-                document.querySelector('#stage-3 .stage-badge').textContent = '✓ Completed';
-                document.querySelector('#stage-3 .stage-btn').textContent = '✓ Review Stage';
-
-                // Unlock Stage 4
-                document.getElementById('stage-4').classList.remove('locked');
-                document.getElementById('stage-4').classList.add('current');
-                document.querySelector('#stage-4 .stage-badge').textContent = 'Continue';
-                document.querySelector('#stage-4 .stage-badge').style.background = '#101010';
-                document.querySelector('#stage-4 .stage-badge').style.color = 'var(--primary-orange)';
-            }
-
-            if (stage4Complete) {
-                document.getElementById('stage-4').classList.remove('current');
-                document.getElementById('stage-4').classList.add('completed');
-                document.querySelector('#stage-4 .stage-badge').textContent = '✓ Completed';
-                document.querySelector('#stage-4 .stage-btn').textContent = '✓ Review Stage';
-
-                // Show completion section
-                document.getElementById('completion-section').classList.add('show');
-
-                // Scroll to completion
-                setTimeout(() => {
-                    document.getElementById('completion-section').scrollIntoView({ behavior: 'smooth', block: 'center' });
-                }, 500);
-            }
-        }
-
-        // Run on page load
-        updatePathProgress();
-
-        // Update every 5 seconds (in case user has multiple tabs open)
-        setInterval(updatePathProgress, 5000);
-
-        // ===== PREVIEW MODE ACCESS CONTROL =====
-        (function() {
-            const urlParams = new URLSearchParams(window.location.search);
-            const isDeveloperMode = urlParams.get('unlock') === 'all' || localStorage.getItem('devUnlockAll') === 'true';
-
-            if (isDeveloperMode) {
-                // Dev mode indicator
-                const devIndicator = document.createElement('div');
-                devIndicator.style.cssText = `
-                    position: fixed; top: 10px; right: 10px; background: #4CAF50; color: white;
-                    padding: 8px 16px; border-radius: 20px; font-size: 12px; font-weight: bold;
-                    z-index: 10000; box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-                `;
-                devIndicator.textContent = '🔓 DEV MODE';
-                devIndicator.title = 'All stages unlocked. Go to homepage with ?unlock=off to disable.';
-                document.body.appendChild(devIndicator);
-                return; // Skip restrictions
-            }
-
-            // PREVIEW MODE: Lock stages 2, 3, 4
-            console.log('🔒 Preview Mode: Only Stage 1 unlocked');
-
-            const lockedStages = ['stage-2', 'stage-3', 'stage-4'];
-            lockedStages.forEach(stageId => {
-                const stageCard = document.getElementById(stageId);
-                if (!stageCard) return;
-
-                // Force locked state
-                stageCard.classList.remove('current', 'completed');
-                stageCard.classList.add('locked');
-
-                // Update badge
-                const badge = stageCard.querySelector('.stage-badge');
-                if (badge) {
-                    badge.textContent = '🔒 Preview Locked';
-                    badge.style.background = '#101010';
-                    badge.style.color = '#F44336';
-                }
-
-                // Add lock overlay to button
-                const btn = stageCard.querySelector('.stage-btn');
-                if (btn) {
-                    btn.style.background = '#666';
-                    btn.style.cursor = 'not-allowed';
-                    btn.style.pointerEvents = 'none';
-                    btn.textContent = '🔒 Available in Full Release';
-                    btn.onclick = (e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        alert('🔒 This stage is locked in preview mode.\n\nIt will be available in the full release.');
-                        return false;
-                    };
-                    // Force prevent click
-                    btn.addEventListener('click', (e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        alert('🔒 This stage is locked in preview mode.\n\nIt will be available in the full release.');
-                    }, true);
-                }
-
-                // Add visual lock indicator
-                const lockBadge = document.createElement('div');
-                lockBadge.style.cssText = `
-                    position: absolute; top: 20px; right: 20px; background: #dc3545;
-                    color: white; padding: 6px 14px; border-radius: 20px; font-size: 12px;
-                    font-weight: 700; z-index: 100; box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-                `;
-                lockBadge.innerHTML = '🔒 PREVIEW LOCKED';
-                lockBadge.title = 'Available in full release';
-                stageCard.style.position = 'relative';
-                stageCard.insertBefore(lockBadge, stageCard.firstChild);
-
-                // Reduce opacity
-                stageCard.style.opacity = '0.6';
-            });
-
-        })();
-    </script>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/hurried/index.html
+++ b/paths/hurried/index.html
@@ -10,7 +10,7 @@
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
             --accent-gold: #f59e0b;
-            --accent-green: #4caf50;
+            --accent-green: #A8AEB2;
             --accent-blue: #2196f3;
             --accent-purple: #dc3545;
             --text-light: #e0e0e0;
@@ -67,38 +67,6 @@
             font-weight: 700;
             font-size: 1.1rem;
             margin-top: 0.5rem;
-        }
-
-        /* Progress */
-        .progress-indicator {
-            background: var(--secondary-dark);
-            border: 2px solid var(--accent-gold);
-            border-radius: 1rem;
-            padding: 1.5rem;
-            margin-bottom: 3rem;
-            text-align: center;
-        }
-
-        .progress-text {
-            font-size: 1.2rem;
-            color: var(--accent-gold);
-            font-weight: bold;
-            margin-bottom: 1rem;
-        }
-
-        .progress-bar-container {
-            width: 100%;
-            height: 12px;
-            background: rgba(0, 0, 0, 0.3);
-            border-radius: 6px;
-            overflow: hidden;
-        }
-
-        .progress-bar-fill {
-            height: 100%;
-            background: linear-gradient(90deg, var(--primary-orange), var(--accent-gold));
-            transition: width 0.5s ease;
-            border-radius: 6px;
         }
 
         /* Stage Section */
@@ -278,14 +246,6 @@
     </header>
 
     <main id="main-content" class="container">
-        <!-- Progress Indicator -->
-        <div class="progress-indicator">
-            <div class="progress-text" id="progress-text">0 / 6 Steps Completed</div>
-            <div class="progress-bar-container">
-                <div class="progress-bar-fill" id="progress-bar" style="width: 0%;"></div>
-            </div>
-        </div>
-
         <!-- Introduction -->
         <div class="intro-box">
             <h3>Your 7-Step Journey</h3>
@@ -392,57 +352,7 @@
             <p style="margin-top: 0.5rem;">You're 68 minutes away from Bitcoin sovereignty.</p>
             <p style="margin-top: 1rem; font-size: 0.9rem; color: #999;">No signup. No theory. Just action.</p>
         </div>
-    </div>
-
-    <script>
-        // Track progress across all modules
-        function updateProgress() {
-            const modules = [
-                'hurried_module1_progress',
-                'hurried_module2_progress',
-                'hurried_module3_progress',
-                'hurried_module4_progress',
-                'hurried_module5_progress',
-                'hurried_module6_progress',
-                'hurried_module7_progress'
-            ];
-
-            let completedModules = 0;
-            const totalModules = 7;
-
-            // Check each module for completion
-            modules.forEach(moduleKey => {
-                const saved = localStorage.getItem(moduleKey);
-                if (saved) {
-                    const progress = JSON.parse(saved);
-                    // If module has any checked items, count it as started/visited
-                    if (progress.length > 0) {
-                        completedModules++;
-                    }
-                }
-            });
-
-            // Check if module 7 was reached (completion page)
-            if (localStorage.getItem('hurried_path_completed')) {
-                completedModules = 7;
-            }
-
-            // Update UI
-            const percentage = (completedModules / totalModules) * 100;
-            document.getElementById('progress-text').textContent =
-                `${completedModules} / ${totalModules} Steps Completed`;
-            document.getElementById('progress-bar').style.width = percentage + '%';
-
-            // Show completion message
-            if (completedModules === totalModules) {
-                document.getElementById('progress-text').innerHTML =
-                    '🎉 Complete! Bitcoin secured in 68 minutes.';
-            }
-        }
-
-        // Initialize on page load
-        window.addEventListener('DOMContentLoaded', updateProgress);
-    </script>
+    </main>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/principled/index.html
+++ b/paths/principled/index.html
@@ -363,13 +363,6 @@
             box-shadow: 0 5px 20px rgba(255, 122, 0, 0.4);
         }
 
-        .stage-cta.locked {
-            background: var(--secondary-dark);
-            border: 2px solid var(--border-color);
-            color: var(--text-dim);
-            cursor: not-allowed;
-        }
-
         /* Capstone Section */
         .capstone-section {
             background: linear-gradient(135deg, rgba(31, 32, 36, 0.1), rgba(31, 32, 36, 0.1));
@@ -392,36 +385,6 @@
             max-width: 700px;
             margin: 0 auto 2rem;
             line-height: 1.8;
-        }
-
-        .badge-tiers {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 1.5rem;
-            margin-top: 2rem;
-        }
-
-        .badge-tier {
-            background: var(--secondary-dark);
-            border: 2px solid var(--border-color);
-            border-radius: 1rem;
-            padding: 1.5rem;
-        }
-
-        .badge-icon {
-            font-size: 3rem;
-            margin-bottom: 0.5rem;
-        }
-
-        .badge-name {
-            font-weight: 600;
-            color: var(--accent-bronze);
-            margin-bottom: 0.5rem;
-        }
-
-        .badge-requirement {
-            font-size: 0.9rem;
-            color: var(--text-dim);
         }
 
         /* Responsive */
@@ -753,7 +716,8 @@
                         </div>
                     </div>
 
-                    <a href="/paths/principled/stage-3/" class="stage-cta locked"><span data-icon="lock"></span> Complete Stages 1-2 First
+                    <a href="/paths/principled/stage-3/" class="stage-cta">
+                        Begin Stage 3 →
                     </a>
                 </div>
 
@@ -804,7 +768,8 @@
                         </div>
                     </div>
 
-                    <a href="/paths/principled/stage-4/" class="stage-cta locked"><span data-icon="lock"></span> Complete Stages 1-3 First
+                    <a href="/paths/principled/stage-4/" class="stage-cta">
+                        Begin Stage 4 →
                     </a>
                 </div>
 
@@ -855,7 +820,8 @@
                         </div>
                     </div>
 
-                    <a href="/paths/principled/stage-5/" class="stage-cta locked"><span data-icon="lock"></span> Complete Stages 1-4 First
+                    <a href="/paths/principled/stage-5/" class="stage-cta">
+                        Begin Stage 5 →
                     </a>
                 </div>
             </div>
@@ -865,32 +831,10 @@
         <section class="capstone-section">
             <h2><span data-icon="trophy"></span> Final Capstone Challenge</h2>
             <p>
-                After completing all five stages, demonstrate your mastery by explaining Bitcoin from first principles.
-                Choose your format and earn your badge.
+                When you've worked through all five stages, put it to the test: explain Bitcoin from first principles —
+                in writing, out loud, or to someone who's never heard of it. If you can derive it rather than recite it,
+                you understand it.
             </p>
-
-            <div class="badge-tiers">
-                <div class="badge-tier">
-                    <div class="badge-icon">🥉</div>
-                    <div class="badge-name">Bronze: Foundational</div>
-                    <div class="badge-requirement">Complete all 15 modules</div>
-                </div>
-                <div class="badge-tier">
-                    <div class="badge-icon">🥈</div>
-                    <div class="badge-name">Silver: Articulate</div>
-                    <div class="badge-requirement">Bronze + Pass 1 capstone format</div>
-                </div>
-                <div class="badge-tier">
-                    <div class="badge-icon">🥇</div>
-                    <div class="badge-name">Gold: Principled Thinker</div>
-                    <div class="badge-requirement">Bronze + Pass 3 capstone formats</div>
-                </div>
-                <div class="badge-tier">
-                    <div class="badge-icon">💎</div>
-                    <div class="badge-name">Diamond: Original Insight</div>
-                    <div class="badge-requirement">Gold + Contribute 1 original insight</div>
-                </div>
-            </div>
         </section>
     </div>
 

--- a/paths/principled/stage-2/module-1.html
+++ b/paths/principled/stage-2/module-1.html
@@ -1161,11 +1161,6 @@
 
         window.addEventListener('DOMContentLoaded', () => {
             loadReflections();
-            let progress = JSON.parse(localStorage.getItem('principled_stage2_progress') || '[]');
-            if (!progress.includes('module-1')) {
-                progress.push('module-1');
-                localStorage.setItem('principled_stage2_progress', JSON.stringify(progress));
-            }
         });
     </script>
 

--- a/paths/sovereign/index.html
+++ b/paths/sovereign/index.html
@@ -13,7 +13,6 @@
             --sovereign-amber: #FFBF00;
             --primary-dark: #1a1a1a;
             --secondary-dark: #2d2d2d;
-            --accent-green: #EAE6DD;
             --text-light: #e0e0e0;
             --text-dim: #b3b3b3;
             --border-color: rgba(212, 175, 55, 0.2);
@@ -70,48 +69,6 @@
             color: var(--text-dim);
         }
 
-        .path-stats {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 1.5rem;
-            margin-top: 2rem;
-        }
-
-        .stat-card {
-            background: rgba(212, 175, 55, 0.1);
-            border: 2px solid var(--sovereign-gold);
-            border-radius: 0.75rem;
-            padding: 1.5rem;
-            text-align: center;
-        }
-
-        .stat-value {
-            font-size: 2rem;
-            font-weight: 700;
-            color: var(--sovereign-gold);
-            margin-bottom: 0.5rem;
-        }
-
-        .stat-label {
-            font-size: 0.9rem;
-            color: var(--text-dim);
-        }
-
-        .progress-bar {
-            width: 100%;
-            height: 10px;
-            background: rgba(212, 175, 55, 0.1);
-            border-radius: 5px;
-            overflow: hidden;
-            margin-top: 2rem;
-        }
-
-        .progress-fill {
-            height: 100%;
-            background: var(--sovereign-gold);
-            transition: width 0.3s ease;
-        }
-
         /* Main Content */
         .main-content {
             padding: 3rem 0;
@@ -149,20 +106,6 @@
             padding: 2rem;
             transition: all 0.3s ease;
             position: relative;
-        }
-
-        .stage-card.completed {
-            border-color: var(--accent-green);
-            background: rgba(76, 175, 80, 0.05);
-        }
-
-        .stage-card.current {
-            border-color: var(--sovereign-gold);
-            box-shadow: 0 0 30px rgba(212, 175, 55, 0.4);
-        }
-
-        .stage-card.locked {
-            opacity: 0.6;
         }
 
         .stage-header {
@@ -206,11 +149,6 @@
             white-space: nowrap;
         }
 
-        .stage-card.locked .stage-badge {
-            background: rgba(153, 153, 153, 0.2);
-            color: var(--text-dim);
-        }
-
         .stage-description {
             color: var(--text-dim);
             margin-bottom: 1.5rem;
@@ -240,16 +178,6 @@
             font-size: 0.95rem;
         }
 
-        .stage-card.completed .module-item {
-            background: rgba(76, 175, 80, 0.1);
-            border-left-color: var(--accent-green);
-        }
-
-        .stage-card.locked .module-item {
-            background: rgba(153, 153, 153, 0.1);
-            border-left-color: var(--text-dim);
-        }
-
         .stage-action {
             text-align: center;
         }
@@ -270,66 +198,6 @@
             background: var(--sovereign-amber);
             transform: translateY(-2px);
             box-shadow: 0 5px 15px rgba(212, 175, 55, 0.4);
-        }
-
-        .stage-card.completed .stage-btn {
-            background: transparent;
-            border: 2px solid var(--accent-green);
-            color: var(--accent-green);
-        }
-
-        .stage-card.locked .stage-btn {
-            background: var(--text-dim);
-            cursor: not-allowed;
-            pointer-events: none;
-        }
-
-        /* Completion Section */
-        .completion-section {
-            background: linear-gradient(135deg, rgba(212, 175, 55, 0.3), rgba(212, 175, 55, 0.1));
-            border: 3px solid var(--sovereign-gold);
-            border-radius: 1rem;
-            padding: 3rem 2rem;
-            text-align: center;
-            margin-bottom: 3rem;
-            display: none;
-        }
-
-        .completion-section.show {
-            display: block;
-        }
-
-        .completion-badge {
-            font-size: 5rem;
-            margin-bottom: 1rem;
-        }
-
-        .completion-section h2 {
-            color: var(--sovereign-gold);
-            font-size: 2rem;
-            margin-bottom: 1rem;
-        }
-
-        .badges-earned {
-            display: flex;
-            justify-content: center;
-            gap: 2rem;
-            margin: 2rem 0;
-            flex-wrap: wrap;
-        }
-
-        .badge-item {
-            text-align: center;
-        }
-
-        .badge-icon {
-            font-size: 3rem;
-            margin-bottom: 0.5rem;
-        }
-
-        .badge-name {
-            font-size: 0.9rem;
-            color: var(--text-dim);
         }
 
         /* Footer Nav */
@@ -381,16 +249,7 @@
                 font-size: 2rem;
             }
 
-            .path-stats {
-                grid-template-columns: 1fr;
-            }
-
             .stage-header {
-                flex-direction: column;
-                gap: 1rem;
-            }
-
-            .badges-earned {
                 flex-direction: column;
                 gap: 1rem;
             }
@@ -480,29 +339,6 @@
                 <h1>The Sovereign Path</h1>
                 <p class="path-subtitle">Master self-custody, privacy, and true Bitcoin sovereignty</p>
             </div>
-
-            <div class="path-stats">
-                <div class="stat-card">
-                    <div class="stat-value" id="completed-modules">0/12</div>
-                    <div class="stat-label">Modules Completed</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="badges-earned">0/4</div>
-                    <div class="stat-label">Badges Earned</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="time-invested">0 hrs</div>
-                    <div class="stat-label">Time Invested</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-value" id="completion-percent">0%</div>
-                    <div class="stat-label">Path Completion</div>
-                </div>
-            </div>
-
-            <div class="progress-bar">
-                <div class="progress-fill" style="width: 0%" id="overall-progress"></div>
-            </div>
         </div>
     </header>
 
@@ -587,7 +423,7 @@
                 </div>
 
                 <!-- Stage 2 -->
-                <div class="stage-card locked" id="stage-2">
+                <div class="stage-card" id="stage-2">
                     <div class="stage-header">
                         <div class="stage-title">
                             <div class="stage-icon">🎭</div>
@@ -598,7 +434,7 @@
                                 <span><span data-icon="graduation"></span> ~100 minutes</span>
                             </div>
                         </div>
-                        <div class="stage-badge"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-badge">Open</div>
                     </div>
 
                     <p class="stage-description">
@@ -621,7 +457,7 @@
                 </div>
 
                 <!-- Stage 3 -->
-                <div class="stage-card locked" id="stage-3">
+                <div class="stage-card" id="stage-3">
                     <div class="stage-header">
                         <div class="stage-title">
                             <div class="stage-icon"><span data-icon="lightning"></span> </div>
@@ -632,7 +468,7 @@
                                 <span><span data-icon="graduation"></span> ~120 minutes</span>
                             </div>
                         </div>
-                        <div class="stage-badge"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-badge">Open</div>
                     </div>
 
                     <p class="stage-description">
@@ -655,7 +491,7 @@
                 </div>
 
                 <!-- Stage 4 -->
-                <div class="stage-card locked" id="stage-4">
+                <div class="stage-card" id="stage-4">
                     <div class="stage-header">
                         <div class="stage-title">
                             <div class="stage-icon">🏰</div>
@@ -666,7 +502,7 @@
                                 <span><span data-icon="graduation"></span> ~110 minutes</span>
                             </div>
                         </div>
-                        <div class="stage-badge"><span data-icon="lock"></span> Locked</div>
+                        <div class="stage-badge">Open</div>
                     </div>
 
                     <p class="stage-description">
@@ -689,44 +525,6 @@
                 </div>
             </div>
 
-            <!-- Completion Section (hidden until path complete) -->
-            <div class="completion-section" id="completion-section">
-                <div class="completion-badge">👑</div>
-                <h2>Congratulations! You've Achieved Bitcoin Sovereignty!</h2>
-                <p style="color: var(--text-light); margin-bottom: 2rem;">
-                    You've mastered self-custody, privacy, and sovereignty. You are now a true Bitcoin sovereign.
-                </p>
-
-                <div class="badges-earned">
-                    <div class="badge-item">
-                        <div class="badge-icon"><span data-icon="lock"></span> </div>
-                        <div class="badge-name">Self-Custody Master</div>
-                    </div>
-                    <div class="badge-item">
-                        <div class="badge-icon">🎭</div>
-                        <div class="badge-name">Privacy Expert</div>
-                    </div>
-                    <div class="badge-item">
-                        <div class="badge-icon"><span data-icon="lightning"></span> </div>
-                        <div class="badge-name">Advanced Operator</div>
-                    </div>
-                    <div class="badge-item">
-                        <div class="badge-icon">🏰</div>
-                        <div class="badge-name">Bitcoin Sovereign</div>
-                    </div>
-                </div>
-
-                <h3 style="color: var(--sovereign-gold); margin-bottom: 1rem;">What's Next?</h3>
-                <p style="color: var(--text-dim); margin-bottom: 1.5rem;">
-                    Continue your Bitcoin journey by teaching others or exploring development:
-                </p>
-
-                <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
-                    <a href="/paths/builder/" class="stage-btn">⚙️ The Builder Path →</a>
-                    <a href="/community/" class="stage-btn"><span data-icon="globe"></span> Join the Community →</a>
-                </div>
-            </div>
-
             <!-- Footer Navigation -->
             <div class="footer-nav">
                 <h3>Need Help?</h3>
@@ -744,186 +542,6 @@
   <strong>Disclosure:</strong> I advise at The Bitcoin Adviser. I mention TBA here because it is one example of a collaborative security model, but it is not the only qualified option.
 </aside>
 </main>
-
-    <script>
-        // Progress tracking and UI updates
-        function updatePathProgress() {
-            const progress = JSON.parse(localStorage.getItem('learningProgress') || '{}');
-            const completedModules = progress.completedModules || [];
-            const completedStages = progress.completedStages || [];
-            const badges = progress.badges || [];
-
-            // Calculate stats
-            const modulesCompleted = completedModules.filter(m => m.startsWith('sovereign-')).length;
-            const totalModules = 12;
-            const completionPercent = Math.round((modulesCompleted / totalModules) * 100);
-
-            // Estimate time (8 min per module on average)
-            const timeInvested = Math.round((modulesCompleted * 8) / 60 * 10) / 10; // Hours with 1 decimal
-
-            // Update header stats
-            document.getElementById('completed-modules').textContent = `${modulesCompleted}/${totalModules}`;
-            document.getElementById('badges-earned').textContent = `${badges.filter(b => b.startsWith('sovereign')).length}/${4}`;
-            document.getElementById('time-invested').textContent = `${timeInvested} hrs`;
-            document.getElementById('completion-percent').textContent = `${completionPercent}%`;
-            document.getElementById('overall-progress').style.width = `${completionPercent}%`;
-
-            // Update stage cards
-            const stage1Complete = completedStages.includes('sovereign-1');
-            const stage2Complete = completedStages.includes('sovereign-2');
-            const stage3Complete = completedStages.includes('sovereign-3');
-            const stage4Complete = completedStages.includes('sovereign-4');
-
-            // Stage 1 (starts unlocked)
-            if (stage1Complete) {
-                document.getElementById('stage-1').classList.remove('current');
-                document.getElementById('stage-1').classList.add('completed');
-                document.querySelector('#stage-1 .stage-badge').textContent = '✓ Completed';
-                document.querySelector('#stage-1 .stage-btn').textContent = '✓ Review Stage';
-
-                // Unlock Stage 2
-                document.getElementById('stage-2').classList.remove('locked');
-                document.getElementById('stage-2').classList.add('current');
-                document.querySelector('#stage-2 .stage-badge').textContent = 'Continue';
-                document.querySelector('#stage-2 .stage-badge').style.background = 'rgba(212, 175, 55, 0.2)';
-                document.querySelector('#stage-2 .stage-badge').style.color = 'var(--sovereign-gold)';
-            }
-
-            if (stage2Complete) {
-                document.getElementById('stage-2').classList.remove('current');
-                document.getElementById('stage-2').classList.add('completed');
-                document.querySelector('#stage-2 .stage-badge').textContent = '✓ Completed';
-                document.querySelector('#stage-2 .stage-btn').textContent = '✓ Review Stage';
-
-                // Unlock Stage 3
-                document.getElementById('stage-3').classList.remove('locked');
-                document.getElementById('stage-3').classList.add('current');
-                document.querySelector('#stage-3 .stage-badge').textContent = 'Continue';
-                document.querySelector('#stage-3 .stage-badge').style.background = 'rgba(212, 175, 55, 0.2)';
-                document.querySelector('#stage-3 .stage-badge').style.color = 'var(--sovereign-gold)';
-            }
-
-            if (stage3Complete) {
-                document.getElementById('stage-3').classList.remove('current');
-                document.getElementById('stage-3').classList.add('completed');
-                document.querySelector('#stage-3 .stage-badge').textContent = '✓ Completed';
-                document.querySelector('#stage-3 .stage-btn').textContent = '✓ Review Stage';
-
-                // Unlock Stage 4
-                document.getElementById('stage-4').classList.remove('locked');
-                document.getElementById('stage-4').classList.add('current');
-                document.querySelector('#stage-4 .stage-badge').textContent = 'Continue';
-                document.querySelector('#stage-4 .stage-badge').style.background = 'rgba(212, 175, 55, 0.2)';
-                document.querySelector('#stage-4 .stage-badge').style.color = 'var(--sovereign-gold)';
-            }
-
-            if (stage4Complete) {
-                document.getElementById('stage-4').classList.remove('current');
-                document.getElementById('stage-4').classList.add('completed');
-                document.querySelector('#stage-4 .stage-badge').textContent = '✓ Completed';
-                document.querySelector('#stage-4 .stage-btn').textContent = '✓ Review Stage';
-
-                // Show completion section
-                document.getElementById('completion-section').classList.add('show');
-
-                // Scroll to completion
-                setTimeout(() => {
-                    document.getElementById('completion-section').scrollIntoView({ behavior: 'smooth', block: 'center' });
-                }, 500);
-            }
-        }
-
-        // Run on page load
-        updatePathProgress();
-
-        // Update every 5 seconds (in case user has multiple tabs open)
-        setInterval(updatePathProgress, 5000);
-
-        // ===== PREVIEW MODE ACCESS CONTROL =====
-        (function() {
-            const urlParams = new URLSearchParams(window.location.search);
-            const isDeveloperMode = urlParams.get('unlock') === 'all' || localStorage.getItem('devUnlockAll') === 'true';
-
-            if (isDeveloperMode) {
-                const devIndicator = document.createElement('div');
-                devIndicator.style.cssText = `
-                    position: fixed; top: 10px; right: 10px; background: #4CAF50; color: white;
-                    padding: 8px 16px; border-radius: 20px; font-size: 12px; font-weight: bold;
-                    z-index: 10000; box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-                `;
-                devIndicator.textContent = '🔓 DEV MODE';
-                devIndicator.title = 'All stages unlocked. Go to homepage with ?unlock=off to disable.';
-                document.body.appendChild(devIndicator);
-                return;
-            }
-
-            // PREVIEW MODE: Lock ALL stages in Sovereign Path
-            console.log('🔒 Preview Mode: ALL Sovereign Path stages locked');
-
-            const allStages = ['stage-1', 'stage-2', 'stage-3', 'stage-4', 'stage-5'];
-            allStages.forEach(stageId => {
-                const stageCard = document.getElementById(stageId);
-                if (!stageCard) return;
-
-                stageCard.classList.remove('current', 'completed');
-                stageCard.classList.add('locked');
-
-                const badge = stageCard.querySelector('.stage-badge');
-                if (badge) {
-                    badge.textContent = '🔒 Preview Locked';
-                    badge.style.background = 'rgba(244, 67, 54, 0.2)';
-                    badge.style.color = '#F44336';
-                }
-
-                const btn = stageCard.querySelector('.stage-btn');
-                if (btn) {
-                    btn.style.background = '#666';
-                    btn.style.cursor = 'not-allowed';
-                    btn.style.pointerEvents = 'none';
-                    btn.textContent = '🔒 Available in Full Release';
-                    btn.addEventListener('click', (e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        alert('🔒 The Sovereign Path is locked in preview mode.\n\nIt will be available in the full release.');
-                    }, true);
-                }
-
-                const lockBadge = document.createElement('div');
-                lockBadge.style.cssText = `
-                    position: absolute; top: 20px; right: 20px; background: rgba(244, 67, 54, 0.9);
-                    color: white; padding: 6px 14px; border-radius: 20px; font-size: 12px;
-                    font-weight: 700; z-index: 100; box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-                `;
-                lockBadge.innerHTML = '🔒 PREVIEW LOCKED';
-                lockBadge.title = 'Available in full release';
-                stageCard.style.position = 'relative';
-                stageCard.insertBefore(lockBadge, stageCard.firstChild);
-                stageCard.style.opacity = '0.5';
-            });
-
-            // Add banner at top of page
-            const banner = document.createElement('div');
-            banner.style.cssText = `
-                background: linear-gradient(135deg, rgba(244, 67, 54, 0.2), rgba(233, 30, 99, 0.2));
-                border-bottom: 3px solid #F44336;
-                padding: 1.5rem;
-                text-align: center;
-                margin-bottom: 2rem;
-            `;
-            banner.innerHTML = `
-                <h3 style="color: #F44336; margin-bottom: 0.5rem; font-size: 1.3rem;"><span data-icon="lock"></span> The Sovereign Path - Coming in Full Release
-                </h3>
-                <p style="color: #e0e0e0; font-size: 1rem;">
-                    This advanced path will be available in the full release. Explore The Curious Path or The Builder Path in the preview.
-                </p>
-            `;
-            const mainContent = document.querySelector('.main-content');
-            if (mainContent) {
-                mainContent.insertBefore(banner, mainContent.firstChild);
-            }
-
-        })();
-    </script>
 
     <!-- Cross-Path Navigation Component -->
     <div style="background: linear-gradient(135deg, #1a1a1a, #2d2d2d); border-top: 3px solid #D4AF37; padding: 3rem 2rem; margin-top: 4rem;">


### PR DESCRIPTION
Rolls out the approved pragmatist de-gamification pilot (#110) to **curious, builder, sovereign, principled, hurried** — no badges, points, completion %, or stage-locking. Education-first, consistent with the paths now being free (#113). Verified in-browser.

## Per path (index unless noted)
- **curious** — removed stat cards, header progress bar, completion/achievements section + JS, stage-locking (all stages "Open"). Kept the safety-assessment component's own step indicator (form UX, not path gamification).
- **builder** — removed the "Your Progress" dashboard, badge cards, points, stage-locking + preview-mode lock JS; **fixed the 4×`<main>` a11y bug** (one `<main>` now); de-gamified **3 modules** (stage-1/3, stage-2/3, stage-3/3: complete-buttons + badge-award JS/alerts → plain continue links; stage-1/3 banner de-badged to "Stage 1 wrap-up"). Kept the hero positioning line + "12 Modules".
- **sovereign** — removed stats, progress bar, completion/achievements + JS, stage-locking. **Collaborative-security/custody wording untouched.**
- **principled** — removed the bronze/silver/gold/diamond badge tiers + locked CTAs; removed silent completion-tracking in stage-2/module-1. **Kept the Prisoner's Dilemma game scores** (educational, not learner XP).
- **hurried** — removed the steps-completed progress bar + tracking JS; neutralized a stray green checkmark token.

## Verified
All indexes: "Open" stages, no progress/badges/stats, single `<main>`, no console errors. Builder module banner renders as a plain wrap-up; builder index keeps positioning + "12 Modules". JS parses across all 9 changed files.

## Notes
- Pre-existing `--accent-green` / misnamed `--accent-purple` **token definitions** left in place → separate **green/purple brand cleanup** (none newly introduced here).
- principled index/module-1 `<main>` lacks a literal `</main>` (pre-existing; one `<main>` satisfied) → flag for a site-wide normalization pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)