### PR TITLE
fix(paths): close/normalize <main> landmark across 39 path pages

### DIFF
--- a/paths/hurried/stage-1/module-1.html
+++ b/paths/hurried/stage-1/module-1.html
@@ -722,7 +722,7 @@
                 Next: Immediate Custody →
             </a>
         </nav>
-    </div>
+    </main>
 
     <script>
         // Checklist functionality

--- a/paths/hurried/stage-1/module-2.html
+++ b/paths/hurried/stage-1/module-2.html
@@ -575,7 +575,7 @@
             <div class="progress-indicator">Step 2 of 6 • Stage 1: Get &amp; Secure</div>
             <a href="/paths/hurried/stage-1/module-3.html" class="nav-link">Next: Emergency Backup →</a>
         </nav>
-    </div>
+    </main>
 
     <script>
         document.querySelectorAll('.checklist input[type="checkbox"]').forEach(checkbox => {

--- a/paths/hurried/stage-1/module-3.html
+++ b/paths/hurried/stage-1/module-3.html
@@ -475,7 +475,7 @@
             <div class="progress-indicator">Step 3 of 6 • Stage 1 Complete!</div>
             <a href="/paths/hurried/stage-2/module-4.html" class="nav-link">Start Stage 2 →</a>
         </nav>
-    </div>
+    </main>
 
     <script>
         document.querySelectorAll('.checklist input[type="checkbox"]').forEach(checkbox => {

--- a/paths/hurried/stage-2/module-4.html
+++ b/paths/hurried/stage-2/module-4.html
@@ -488,7 +488,7 @@
             <div class="progress-indicator">Step 4 of 6 • Stage 2: Test &amp; Use</div>
             <a href="/paths/hurried/stage-2/module-5.html" class="nav-link">Next: Transaction Safety →</a>
         </nav>
-    </div>
+    </main>
 
     <script>
         document.querySelectorAll('.checklist input[type="checkbox"]').forEach(checkbox => {

--- a/paths/hurried/stage-2/module-5.html
+++ b/paths/hurried/stage-2/module-5.html
@@ -485,7 +485,7 @@
             <div class="progress-indicator">Step 5 of 6 • Stage 2: Test &amp; Use</div>
             <a href="/paths/hurried/stage-3/module-6.html" class="nav-link">Next: Upgrade to Multisig →</a>
         </nav>
-    </div>
+    </main>
 
     <script>
         document.querySelectorAll('.checklist input[type="checkbox"]').forEach(checkbox => {

--- a/paths/hurried/stage-3/module-6.html
+++ b/paths/hurried/stage-3/module-6.html
@@ -414,7 +414,7 @@
             <div class="progress-indicator">Step 6 of 7 • Stage 2: Test &amp; Use</div>
             <a href="/paths/hurried/stage-3/module-7.html" class="nav-link">Next: Multisig Security →</a>
         </nav>
-    </div>
+    </main>
 
     <script>
         document.querySelectorAll('.checklist input[type="checkbox"]').forEach(checkbox => {

--- a/paths/hurried/stage-3/module-7.html
+++ b/paths/hurried/stage-3/module-7.html
@@ -423,7 +423,7 @@
             <div class="progress-indicator">Step 7 of 7 • Stage 3: Graduate</div>
             <a href="/paths/hurried/" class="nav-link">🏠 Back to Path Home →</a>
         </nav>
-    </div>
+    </main>
 
     <script>
         document.querySelectorAll('.checklist input[type="checkbox"]').forEach(checkbox => {

--- a/paths/pragmatist/stage-1/module-2.html
+++ b/paths/pragmatist/stage-1/module-2.html
@@ -424,7 +424,7 @@
         <div style="text-align: center; margin: 3rem 0;">
             <a class="btn" href="/paths/pragmatist/stage-1/module-3.html">Continue to Module 3 →</a>
         </div>
-    </div>
+    </main>
 
     <!-- Interactive Reflection JavaScript -->
     <script>

--- a/paths/pragmatist/stage-1/module-3.html
+++ b/paths/pragmatist/stage-1/module-3.html
@@ -476,7 +476,7 @@
         <div style="text-align: center; margin: 3rem 0;">
             <a class="btn" href="/paths/pragmatist/stage-1/module-4.html">Continue to Module 4 →</a>
         </div>
-    </div>
+    </main>
 
     <!-- Interactive Reflection JavaScript -->
     <script>

--- a/paths/pragmatist/stage-1/module-4.html
+++ b/paths/pragmatist/stage-1/module-4.html
@@ -621,7 +621,7 @@
                 Next: Security &amp; Best Practices →
             </a>
         </div>
-    </div>
+    </main>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/pragmatist/stage-2/module-5-security.html
+++ b/paths/pragmatist/stage-2/module-5-security.html
@@ -475,7 +475,7 @@
         <div style="text-align: center; margin: 3rem 0;">
             <a class="btn" href="/paths/pragmatist/stage-2/module-6-lightning.html">Continue to Module 6 →</a>
         </div>
-    </div>
+    </main>
 
     <!-- Interactive Reflection JavaScript -->
     <script>

--- a/paths/pragmatist/stage-2/module-6-lightning.html
+++ b/paths/pragmatist/stage-2/module-6-lightning.html
@@ -489,7 +489,7 @@
                 Next: Economics &amp; Strategy →
             </a>
         </div>
-    </div>
+    </main>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/pragmatist/stage-2/module-7-economics.html
+++ b/paths/pragmatist/stage-2/module-7-economics.html
@@ -271,7 +271,7 @@
                 Next: Privacy &amp; Tax →
             </a>
         </div>
-    </div>
+    </main>
 
     <script src="/js/icon-library.js"></script>
     <script>

--- a/paths/pragmatist/stage-3/module-8-privacy-tax.html
+++ b/paths/pragmatist/stage-3/module-8-privacy-tax.html
@@ -338,7 +338,7 @@
                 Next: Bitcoin in Your Life →
             </a>
         </div>
-    </div>
+    </main>
 
     <script src="/js/icon-library.js"></script>
     <script>

--- a/paths/pragmatist/stage-3/module-9-real-life.html
+++ b/paths/pragmatist/stage-3/module-9-real-life.html
@@ -363,7 +363,7 @@
                 ✓ Complete Path
             </a>
         </div>
-    </div>
+    </main>
 
     <script src="/js/icon-library.js"></script>
     <script>

--- a/paths/principled/capstone/index.html
+++ b/paths/principled/capstone/index.html
@@ -366,7 +366,7 @@
                 Return to Path Overview
             </a>
         </div>
-    </div>
+    </main>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/principled/index.html
+++ b/paths/principled/index.html
@@ -836,7 +836,7 @@
                 you understand it.
             </p>
         </section>
-    </div>
+    </main>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/principled/stage-1/index.html
+++ b/paths/principled/stage-1/index.html
@@ -252,7 +252,7 @@
             <h3 style="color: var(--accent-bronze); margin-bottom: 1rem;">Complete all 3 modules to unlock Stage 2</h3>
             <p style="color: var(--text-dim);">Stage 2 explores incentives, cooperation, and the tragedy of the commons.</p>
         </div>
-    </div>
+    </main>
 
     <script>
         // Track module completion

--- a/paths/principled/stage-1/module-1.html
+++ b/paths/principled/stage-1/module-1.html
@@ -853,7 +853,7 @@
                 Next: Entropy &amp; Corruption →
             </a>
         </nav>
-    </div>
+    </main>
 
     <script>
         // Demo State

--- a/paths/principled/stage-1/module-2.html
+++ b/paths/principled/stage-1/module-2.html
@@ -830,7 +830,7 @@
                 Next: The Role of Rules →
             </a>
         </nav>
-    </div>
+    </main>
 
     <script>
         // Simulation State

--- a/paths/principled/stage-1/module-3.html
+++ b/paths/principled/stage-1/module-3.html
@@ -881,7 +881,7 @@
                 Next: Stage 2 →
             </a>
         </nav>
-    </div>
+    </main>
 
     <script>
         // Demo State

--- a/paths/principled/stage-2/index.html
+++ b/paths/principled/stage-2/index.html
@@ -246,7 +246,7 @@
             <h3 style="color: var(--accent-bronze); margin-bottom: 1rem;">Complete all 3 modules to unlock Stage 3</h3>
             <p style="color: var(--text-dim);">Stage 3 explores the information revolution and the tools that made trustless systems possible.</p>
         </div>
-    </div>
+    </main>
 
     <script>
         // Track module completion

--- a/paths/principled/stage-2/module-1.html
+++ b/paths/principled/stage-2/module-1.html
@@ -872,7 +872,7 @@
                 Next: The Corruption Curve →
             </a>
         </nav>
-    </div>
+    </main>
 
     <script>
         // Game State

--- a/paths/principled/stage-2/module-2.html
+++ b/paths/principled/stage-2/module-2.html
@@ -814,7 +814,7 @@
                 Next: Trust &amp; Accountability →
             </a>
         </nav>
-    </div>
+    </main>
 
     <script>
         // Demo State

--- a/paths/principled/stage-2/module-3.html
+++ b/paths/principled/stage-2/module-3.html
@@ -880,7 +880,7 @@
                 Complete Module 3 →
             </a>
         </nav>
-    </div>
+    </main>
 
     <script>
         // Demo: Surveillance System Animation

--- a/paths/principled/stage-3/index.html
+++ b/paths/principled/stage-3/index.html
@@ -199,7 +199,7 @@
             <h3 style="color: var(--accent-bronze); margin-bottom: 1rem;">Complete all 3 modules to unlock Stage 4</h3>
             <p style="color: var(--text-dim);">Stage 4 explores Bitcoin as an emergent system—order from energy and incentives.</p>
         </div>
-    </div>
+    </main>
 
     <script>
         // Track module completion

--- a/paths/principled/stage-3/module-1.html
+++ b/paths/principled/stage-3/module-1.html
@@ -1063,7 +1063,7 @@
                 Complete Module 1 →
             </a>
         </nav>
-    </div>
+    </main>
 
     <script>
         // Simple hash function for demo (not cryptographically secure)

--- a/paths/principled/stage-3/module-2.html
+++ b/paths/principled/stage-3/module-2.html
@@ -1005,7 +1005,7 @@
                 Continue to Module 3: The Cost of Truth →
             </a>
         </div>
-    </div>
+    </main>
 
     <script>
         // ===== Centralized Ledger Demo =====

--- a/paths/principled/stage-3/module-3.html
+++ b/paths/principled/stage-3/module-3.html
@@ -1024,7 +1024,7 @@
                 Continue to Stage 4: Bitcoin as an Emergent System →
             </a>
         </div>
-    </div>
+    </main>
 
     <script>
         // ===== Energy Cost Calculator =====

--- a/paths/principled/stage-4/index.html
+++ b/paths/principled/stage-4/index.html
@@ -172,7 +172,7 @@
             <h3 style="color: var(--accent-bronze); margin-bottom: 1rem;">Complete all 3 modules to unlock Stage 5</h3>
             <p style="color: var(--text-dim);">Stage 5 explores Bitcoin's impact beyond money—energy civilization, verification culture, and the future of human coordination.</p>
         </div>
-    </div>
+    </main>
 
     <script>
         // Track module completion

--- a/paths/principled/stage-4/module-1.html
+++ b/paths/principled/stage-4/module-1.html
@@ -887,7 +887,7 @@
                 Continue to Module 2: Incentives and Game Theory →
             </a>
         </div>
-    </div>
+    </main>
 
     <script>
         // ===== Entropy Simulator =====

--- a/paths/principled/stage-4/module-2.html
+++ b/paths/principled/stage-4/module-2.html
@@ -972,7 +972,7 @@
                 Continue to Module 3: Bitcoin as a Living Organism →
             </a>
         </div>
-    </div>
+    </main>
 
     <script>
         // ===== Strategy Payoff Calculator =====

--- a/paths/principled/stage-4/module-3.html
+++ b/paths/principled/stage-4/module-3.html
@@ -1063,7 +1063,7 @@
                 Continue to Stage 5: Beyond Money →
             </a>
         </div>
-    </div>
+    </main>
 
     <script>
         // ===== Homeostasis Simulator =====

--- a/paths/principled/stage-5/index.html
+++ b/paths/principled/stage-5/index.html
@@ -251,7 +251,7 @@
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
     <script>
         // Track module completion

--- a/paths/principled/stage-5/module-1.html
+++ b/paths/principled/stage-5/module-1.html
@@ -710,7 +710,7 @@
                 Continue to Module 2: Verification Culture →
             </a>
         </div>
-    </div>
+    </main>
 
     <script>
         // ===== Interactive Reflection System =====

--- a/paths/principled/stage-5/module-2.html
+++ b/paths/principled/stage-5/module-2.html
@@ -498,7 +498,7 @@
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
-    <div class="module-container" id="main-content">
+    <main class="module-container" id="main-content">
         <div class="module-header">
             <div class="module-icon"><span data-icon="search"></span> </div>
             <h1 class="module-title">Verification Culture</h1>
@@ -861,7 +861,7 @@
             <a href="module-1.html" class="btn btn-secondary">← Previous: Energy Civilization</a>
             <a href="module-3.html" class="btn btn-primary">Next: The Future of Human Coordination →</a>
         </div>
-    </div>
+    </main>
 
     <script>
         // Tab switching functionality

--- a/paths/principled/stage-5/module-3.html
+++ b/paths/principled/stage-5/module-3.html
@@ -592,7 +592,7 @@
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
-    <div class="module-container" id="main-content">
+    <main class="module-container" id="main-content">
         <div class="module-header">
             <div class="module-icon"><span data-icon="network"></span> </div>
             <h1 class="module-title">The Future of Human Coordination</h1>
@@ -1054,7 +1054,7 @@
             <a href="module-2.html" class="btn btn-secondary">← Previous: Verification Culture</a>
             <a href="../index.html" class="btn btn-primary">Complete Principled Path ✓</a>
         </div>
-    </div>
+    </main>
 
     <script>
         // Interactive Reflection System

--- a/paths/sovereign-journey-intro.html
+++ b/paths/sovereign-journey-intro.html
@@ -447,6 +447,7 @@
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
+    <main id="main-content">
     <!-- Hero Section -->
     <section class="hero">
         <div class="hero-content">
@@ -467,7 +468,7 @@
 
     <!-- Historical Timeline -->
     <section class="timeline-section">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="section-header">
                 <h2>The Rhymes of History</h2>
                 <p>
@@ -586,7 +587,7 @@
 
     <!-- The Pattern -->
     <section class="pattern-section">
-        <main id="main-content-2" class="container">
+        <div class="container">
             <div class="section-header">
                 <h2>The Pattern</h2>
                 <p>Different countries. Different decades. Same story.</p>
@@ -623,7 +624,7 @@
 
     <!-- The Choice -->
     <section class="choice-section">
-        <main id="main-content-3" class="container">
+        <div class="container">
             <div class="section-header">
                 <h2>Your Choice, Your Consequences</h2>
                 <p>
@@ -678,7 +679,7 @@
 
     <!-- Call to Action -->
     <section class="cta-section">
-        <main id="main-content-4" class="container">
+        <div class="container">
             <div class="cta-box">
                 <h2>Before You Learn the Tools...</h2>
                 <p style="font-size: 1.2rem; color: var(--text-dim); margin: 1.5rem 0;">
@@ -766,6 +767,7 @@
             </div>
         </div>
     </section>
+    </main>
 
     <script>
         // Add scroll reveal animations

--- a/paths/sovereign/stage-3/alternatives-to-bitcoin.html
+++ b/paths/sovereign/stage-3/alternatives-to-bitcoin.html
@@ -767,7 +767,7 @@
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <!-- Navigation -->
     <nav class="module-nav">
-        <main id="main-content" class="container">
+        <div class="container">
             <div class="nav-content">
                 <a href="../" class="back-link">← Sovereign Path</a>
                 <span class="module-meta-badge"><span data-icon="timer"></span> 10–12 minutes</span>
@@ -775,9 +775,10 @@
         </div>
     </nav>
 
+    <main id="main-content">
     <!-- Socratic Opening Question -->
     <section class="intro-section">
-        <main id="main-content-2" class="container">
+        <div class="container">
             <div class="socratic-opener">
                 <div class="question-icon">🤔</div>
                 <h1 class="opening-question">
@@ -807,7 +808,7 @@
 
     <!-- Animation Reveal -->
     <section class="animation-section" id="animation-reveal">
-        <main id="main-content-3" class="container">
+        <div class="container">
             <h2 style="text-align: center; color: var(--sovereign-gold); margin-bottom: 2rem; font-size: 1.8rem;">
                 Four Competing Visions of Digital Money
             </h2>
@@ -828,7 +829,7 @@
 
     <!-- System Cards -->
     <section class="section" id="systems">
-        <main id="main-content-4" class="container">
+        <div class="container">
             <div class="section-header">
                 <h2>⚖️ The Four Models</h2>
                 <p>Each digital money system makes fundamental trade-offs. Swipe to explore.</p>
@@ -888,7 +889,7 @@
 
     <!-- Interactive Matrix -->
     <section class="section">
-        <main id="main-content-5" class="container">
+        <div class="container">
             <div class="section-header">
                 <h2><span data-icon="search"></span> Interactive Comparison Matrix</h2>
                 <p>Tap each cell to reveal trade-off insights</p>
@@ -950,7 +951,7 @@
 
     <!-- Socratic Prompts -->
     <section class="section">
-        <main id="main-content-6" class="container">
+        <div class="container">
             <div class="reflection-section" id="reflectionSection">
                 <h3 class="reflection-question" id="reflectionQuestion">
                     Who should control how much money exists?
@@ -977,7 +978,7 @@
 
     <!-- Bitcoin's Design Choice -->
     <section class="section">
-        <main id="main-content-7" class="container">
+        <div class="container">
             <div class="bitcoin-choice-section">
                 <h2>🧩 Bitcoin's Design Choice</h2>
                 <p>
@@ -1019,7 +1020,7 @@
 
     <!-- Deep Dive CTA -->
     <section class="section" id="cbdc-deep-dive">
-        <main id="main-content-8" class="container">
+        <div class="container">
             <div class="deep-dive-cta" onclick="window.location.href='/modules/cbdc-vs-bitcoin.html'">
                 <h3><span data-icon="lock"></span> Want to Explore Further? <span class="locked-badge">Premium</span></h3>
                 <p>
@@ -1032,7 +1033,7 @@
 
     <!-- Takeaway Summary -->
     <section class="section">
-        <main id="main-content-9" class="container">
+        <div class="container">
             <div class="takeaway-card">
                 <h3>✅ Key Takeaway</h3>
                 <ul class="takeaway-list">
@@ -1049,6 +1050,7 @@
             </div>
         </div>
     </section>
+    </main>
 
     <script>
         // Interactive matrix tooltips


### PR DESCRIPTION
## What
S8 phase-2 from the session queue: fix the `<main>` landmark bug across the learning paths.

A historical `<div class="container">` → `<main id="main-content">` search-replace left `<main>` **unclosed** on most path module pages, and **duplicated** it (4–9 illegal landmarks) on two pages. `html-validate` flagged this as real, cascading invalidity:

```
409:6  error  Unclosed element '<main>'                            close-order
725:6  error  Stray end tag '</div>'                               close-order
815:2  error  End tag '</body>' seen but there were open elements  close-order
```

## Scope (39 files)
| Path | Files | Fix |
|------|-------|-----|
| principled | 22 | 20 orphan `</div>`→`</main>`; 2 stage-5 `<div id=main-content>`→`<main>` |
| pragmatist | 8 | orphan `</div>`→`</main>` |
| hurried | 7 | orphan `</div>`→`</main>` |
| sovereign/stage-3/alternatives-to-bitcoin | 1 | 9 dup `<main>`→`<div>`, wrap one real landmark |
| sovereign-journey-intro (root) | 1 | 4 dup `<main>`→`<div>`, wrap one real landmark |

Curious, builder, skeptic, observer were already clean. `monetary-alternatives.html` is a correct redirect stub (untouched).

## Why it was broader than the handoff noted
The handoff named curious/sovereign/principled, but the same bug class also hit pragmatist and hurried. Fixing only the named paths would have left an identical-bug landmine, so all affected pages are fixed in one pass.

## Correctness
- **Cat A (35 files):** a single `</div>`→`</main>` rename. DOM is byte-identical except that one tag → rendering unchanged; the landmark now spans exactly what the original container did.
- **Cat B (2 files):** bogus mains restored to `<div class="container">` (their `</div>` closers already matched), content wrapped in one `<main id="main-content">`, nav/scripts left outside.

## Verification
- Every `paths/**.html` now has **0 or 1 balanced** `<main>`.
- `html-validate` before/after on a sampled file: the 4 `close-order` errors are **gone**, no new errors (remaining items are pre-existing `no-inline-style`/trailing-whitespace, unrelated).
- Gating/preview not relevant — pure static-markup structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)