### PR TITLE
fix(seo): remove false Spanish hreflang on /dalia/ (no ES version exists)

### DIFF
--- a/dalia/index.html
+++ b/dalia/index.html
@@ -15,10 +15,8 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@dalia_platt">
 
-  <!-- Canonical + alternates -->
+  <!-- Canonical (no Spanish version of this page exists; ?lang=es was a no-op) -->
   <link rel="canonical" href="https://bitcoinsovereign.academy/dalia/">
-  <link rel="alternate" hreflang="en" href="https://bitcoinsovereign.academy/dalia/">
-  <link rel="alternate" hreflang="es" href="https://bitcoinsovereign.academy/dalia/?lang=es">
 
   <!-- BSA brand kit + hub-specific styles -->
   <link rel="stylesheet" href="/css/brand.css">


### PR DESCRIPTION
## What
Queue item #2 (scope the Spanish claim down). I audited every Spanish/bilingual claim and language toggle site-wide first.

**Finding: the bilingual claim is mostly *accurate*, not overstated.** Real, live Spanish content exists:
- `paths/curious/stage-1/es/module-1..3.html` (3 modules)
- `programa-colombia/semana-1..10/` (10-week Colombia program, `lang="es-CO"`)
- `institutional/corporations/colombia/…` (ES institutional)
- Native Spanish Nostr posts

The Curious module language toggles + hreflang are correct (ES targets exist).

**The one genuine overclaim** was on `/dalia/`: it declared `hreflang="es"` → `/dalia/?lang=es`, but the page has no i18n — `?lang=es` serves identical English. That's a false "Spanish version exists" signal to search engines (hreflang/duplicate-content error).

## Change
Removed the `en`/`es` hreflang pair on `dalia/index.html` (kept the canonical). One-line-class fix; restore a real alternate only when a localized `/dalia/` page is actually built.

## Not changed (and why)
- **"Bilingual. LATAM-fluent." identity copy** — substantiated by the content above and locked canonical (CLAUDE.md). Left as-is per "verify truth" + "don't redesign locked conventions without ask." If you still want it qualified, say the word and I'll propose wording.
- **`js/i18n.js`** (374 lines, never loaded anywhere) — dead but not a *claim*; left for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)