### PR TITLE
feat(sovereign): TBA inversion + three-model rebuild (collaborative-security)

### DIFF
--- a/paths/sovereign/stage-3/collaborative-security.html
+++ b/paths/sovereign/stage-3/collaborative-security.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Collaborative Security vs Assisted Multisig | Sovereign Path Stage 3</title>
-    <meta name="description" content="Understand the critical differences between assisted multisig and collaborative security (often marketed as collaborative custody). Explore single points of failure, recovery scenarios, and choose the right security model for your situation.">
+    <title>Single-Sig, DIY Multisig &amp; Collaborative Security | Stage 3</title>
+    <meta name="description" content="Three Bitcoin custody models compared honestly: single-sig, DIY/self-managed multisig, and collaborative security (self-custody with guardrails, often marketed as collaborative custody). Single points of failure, recovery, and how to think about which fits.">
 
     <style>
         :root {
@@ -90,8 +90,8 @@
 
         .comparison-grid {
             display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 2rem;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1.5rem;
             margin: 2rem 0;
         }
 
@@ -100,6 +100,10 @@
             border: 2px solid var(--border-color);
             border-radius: 1rem;
             padding: 2rem;
+        }
+
+        .model-card.singlesig {
+            border-color: var(--border-color);
         }
 
         .model-card.assisted {
@@ -228,16 +232,16 @@
                 <a href="/paths/sovereign/stage-3/">Stage 3</a> →
                 <span>Collaborative Security</span>
             </div>
-            <h1><span data-icon="lock"></span> Collaborative Security vs Assisted Multisig</h1>
-            <p style="color: var(--text-dim); font-size: 1.1rem;">Choosing the right security model for your Bitcoin holdings</p>
+            <h1><span data-icon="lock"></span> Single-Sig, DIY Multisig &amp; Collaborative Security</h1>
+            <p style="color: var(--text-dim); font-size: 1.1rem;">Three custody models, honest tradeoffs — and how to think about which fits</p>
         </div>
     </header>
 
     <main id="main-content" class="container">
         <div class="intro">
-            <strong>The Critical Question:</strong> Who holds your backup keys, and what happens if you're incapacitated, coerced, or can't access your devices?
+            <strong>The Critical Question:</strong> Who holds your keys, and what happens if you're incapacitated, coerced, or can't access your devices?
             <br><br>
-            This guide helps you understand the trade-offs between "I hold 2 keys, vendor holds 1" (assisted multisig) versus true collaborative security with documented recovery processes.
+            There isn't a single "best" setup — only tradeoffs that fit one person or family and not another. This guide compares <strong>three</strong> models: <strong>single-sig</strong> (one key), <strong>DIY / self-managed multisig</strong> (more keys, but often one person still controls the whole human system — key count is not key control), and <strong>collaborative security</strong> with independent keyholders. Collaborative security is <strong>self-custody with guardrails</strong>: you keep custody and hold a key, while no single party — including you — can move funds alone.
         </div>
 
         <!-- Email vs Keys Identity Clarification -->
@@ -313,43 +317,71 @@
         <h2><span data-icon="chart"></span> Model Comparison: Side by Side</h2>
 
         <div class="comparison-grid">
-            <!-- Assisted Multisig Card -->
-            <div class="model-card assisted">
-                <h3 style="color: var(--accent-blue);">🔵 Assisted Multisig (2-of-3)</h3>
+            <!-- Single-Sig Card -->
+            <div class="model-card singlesig">
+                <h3 style="color: var(--text-light);">⚪ Single-Sig Self-Custody</h3>
                 <p style="margin-bottom: 1rem; color: var(--text-dim);">
-                    <strong>Setup:</strong> You hold 2 keys, vendor holds 1 backup key
+                    <strong>Setup:</strong> One key controls everything. Full custody, full control.
                 </p>
 
                 <div style="margin: 1rem 0;">
                     <strong style="color: var(--accent-green);">✅ Advantages:</strong>
                     <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-dim);">
-                        <li>Easy to set up</li>
-                        <li>Vendor can't steal (needs your 2 keys)</li>
-                        <li>Lose 1 key? Vendor helps recover</li>
-                        <li>Lower cost</li>
+                        <li>Simplest to set up and understand</li>
+                        <li>No coordination, no third parties</li>
+                        <li>Fully sovereign — no one else involved</li>
+                        <li>Cheapest (just a hardware wallet)</li>
                     </ul>
                 </div>
 
                 <div style="margin: 1rem 0;">
                     <strong style="color: var(--accent-red-text, var(--accent-red));">❌ Vulnerabilities:</strong>
                     <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-dim);">
-                        <li><strong>Single point of failure: YOU</strong></li>
+                        <li><strong>One key = one point of failure</strong></li>
+                        <li>One lost/stolen backup = funds gone</li>
                         <li>Illness/incapacity = no access</li>
-                        <li>Coercion ("sign with your 2 keys")</li>
-                        <li>Travel confiscation (if you carry both)</li>
-                        <li>No documented recovery for heirs</li>
-                        <li>Vendor key requires trusting their process</li>
+                        <li>Coercion (one person, one signature)</li>
+                        <li>No built-in path for heirs</li>
+                    </ul>
+                </div>
+
+                <div style="background: var(--primary-dark); padding: 1rem; border-radius: 0.5rem; margin-top: 1rem;">
+                    <strong style="color: var(--text-light);">Honest read:</strong>
+                    <p style="margin: 0.5rem 0 0; color: var(--text-dim); font-size: 0.9rem;">Fine for smaller amounts and disciplined holders who document and <em>test</em> recovery — but everything rests on one person not making one mistake.</p>
+                </div>
+            </div>
+
+            <!-- DIY / Self-Managed Multisig Card -->
+            <div class="model-card assisted">
+                <h3 style="color: var(--accent-blue);">🔵 DIY / Self-Managed Multisig</h3>
+                <p style="margin-bottom: 1rem; color: var(--text-dim);">
+                    <strong>Setup:</strong> Multiple keys (e.g. 2-of-3), but you hold enough to sign alone — or you're the only one who understands the setup.
+                </p>
+
+                <div style="margin: 1rem 0;">
+                    <strong style="color: var(--accent-green);">✅ Advantages:</strong>
+                    <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-dim);">
+                        <li>Survives one lost or stolen key</li>
+                        <li>Full sovereignty — no outside party</li>
+                        <li>No ongoing service fees</li>
+                        <li>Good for careful, technical users</li>
+                    </ul>
+                </div>
+
+                <div style="margin: 1rem 0;">
+                    <strong style="color: var(--accent-red-text, var(--accent-red));">❌ The hidden catch:</strong>
+                    <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-dim);">
+                        <li><strong>Key count ≠ key control.</strong> Technically multisig, humanly centralized</li>
+                        <li>Single point of failure is still <strong>you</strong></li>
+                        <li>Coercion / incapacity still hit one person</li>
+                        <li>If only you understand it, recovery dies with you</li>
+                        <li>Multisig handled alone can <em>create</em> new failure points</li>
                     </ul>
                 </div>
 
                 <div style="background: rgba(33, 150, 243, 0.1); padding: 1rem; border-radius: 0.5rem; margin-top: 1rem;">
-                    <strong style="color: var(--accent-blue);">Best For:</strong>
-                    <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-dim); font-size: 0.9rem;">
-                        <li>Individual holders</li>
-                        <li>Lower amounts (under $100K)</li>
-                        <li>Short-medium term (1-5 years)</li>
-                        <li>Low geopolitical risk</li>
-                    </ul>
+                    <strong style="color: var(--accent-blue);">Honest read:</strong>
+                    <p style="margin: 0.5rem 0 0; color: var(--text-dim); font-size: 0.9rem;">Real sovereignty and real resilience against a lost key — but only if the setup is documented, the recovery is tested, and someone besides you could carry it out.</p>
                 </div>
             </div>
 
@@ -357,40 +389,33 @@
             <div class="model-card collaborative">
                 <h3 style="color: var(--accent-green);">🟢 Collaborative Security</h3>
                 <p style="margin-bottom: 1rem; color: var(--text-dim);">
-                    <strong>Setup:</strong> Quorum model with documented processes, third-party key holders, and recovery procedures
+                    <strong>Setup:</strong> Independent keyholders (e.g. 2-of-3: you, a service, a wallet provider). You stay the legal owner and initiate transactions; no single party — including you — can move funds alone. <em>Self-custody with guardrails, often marketed as "collaborative custody."</em>
                 </p>
 
                 <div style="margin: 1rem 0;">
                     <strong style="color: var(--accent-green);">✅ Advantages:</strong>
                     <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-dim);">
-                        <li>No single key is a point of failure</li>
-                        <li>Documented recovery processes</li>
-                        <li>Geographic distribution of keys</li>
-                        <li>Estate planning integration</li>
-                        <li>Coercion resistance (needs multiple parties)</li>
-                        <li>Professional processes &amp; procedures</li>
+                        <li>Designed to reduce single points of failure</li>
+                        <li>You keep custody — holding one key in 2-of-3 is not giving it up</li>
+                        <li>Documented, tested recovery for incapacity &amp; inheritance</li>
+                        <li>Geographically distributed, independent keyholders</li>
+                        <li>Coercion resistance — one signature isn't enough</li>
                     </ul>
                 </div>
 
                 <div style="margin: 1rem 0;">
                     <strong style="color: var(--accent-orange);">⚠️ Trade-offs:</strong>
                     <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-dim);">
-                        <li>More complex to set up</li>
-                        <li>Higher costs (professional services)</li>
-                        <li>Requires coordination with third parties</li>
-                        <li>More documentation needed</li>
+                        <li>Less unilateral control (by design)</li>
+                        <li>Coordination with other keyholders</li>
+                        <li>Ongoing service fees</li>
+                        <li>You must choose providers you trust</li>
                     </ul>
                 </div>
 
-                <div style="background: rgba(76, 175, 80, 0.1); padding: 1rem; border-radius: 0.5rem; margin-top: 1rem;">
-                    <strong style="color: var(--accent-green);">Best For:</strong>
-                    <ul style="margin: 0.5rem 0 0 1.5rem; color: var(--text-dim); font-size: 0.9rem;">
-                        <li>Large holdings (over $100K)</li>
-                        <li>Multi-generational wealth</li>
-                        <li>Business/entity funds</li>
-                        <li>High geopolitical risk areas</li>
-                        <li>Elderly or health-compromised holders</li>
-                    </ul>
+                <div style="background: rgba(255, 152, 0, 0.1); padding: 1rem; border-radius: 0.5rem; margin-top: 1rem;">
+                    <strong style="color: var(--accent-orange);">Still depends on assumptions:</strong>
+                    <p style="margin: 0.5rem 0 0; color: var(--text-dim); font-size: 0.9rem;">The outside keyholders must be <strong>independent, reachable, and not aligned against you</strong>. The benefit isn't more keys — it's structure around the keys: independent holders, clear documentation, tested recovery, and family involvement where it makes sense.</p>
                 </div>
             </div>
         </div>
@@ -399,11 +424,11 @@
 
         <div class="risk-matrix">
             <h3 style="color: var(--accent-orange); margin-top: 0;">Scenario-Based Risk Assessment</h3>
-            <p style="color: var(--text-dim); margin-bottom: 1.5rem;">How does each model handle real-world threats?</p>
+            <p style="color: var(--text-dim); margin-bottom: 1rem;">How do the two multisig models handle real-world threats? <strong style="color: var(--text-light);">Single-sig fails every scenario below</strong> — one key means one point of failure — so the honest contrast is between DIY multisig and collaborative security.</p>
 
             <div class="risk-item" style="font-weight: 600; background: rgba(212, 175, 55, 0.1);">
                 <div>Scenario</div>
-                <div>Assisted Multisig</div>
+                <div>DIY / Self-Managed Multisig</div>
                 <div>Collaborative Security</div>
             </div>
 
@@ -448,7 +473,7 @@
 
         <div class="quiz-container">
             <h3 style="color: var(--sovereign-gold); margin-top: 0;">Answer 5 Quick Questions</h3>
-            <p style="color: var(--text-dim); margin-bottom: 2rem;">We'll recommend the best security model for your situation</p>
+            <p style="color: var(--text-dim); margin-bottom: 2rem;">There's no universal "best" — this just points to which model is worth exploring, and what to bring to a conversation about it.</p>
 
             <!-- Question 1 -->
             <div class="quiz-question">
@@ -531,7 +556,7 @@
             </div>
 
             <button class="btn" onclick="calculateRecommendation()" style="margin-top: 1.5rem; width: 100%;">
-                Get My Recommendation →
+                See What This Suggests →
             </button>
 
             <div id="quiz-result" style="display: none; margin-top: 2rem; padding: 2rem; background: var(--secondary-dark); border-radius: 1rem; border: 2px solid var(--sovereign-gold);">
@@ -658,25 +683,32 @@
         <h2><span data-icon="books"></span> Next Steps</h2>
 
         <div style="background: var(--secondary-dark); border: 2px solid var(--border-color); border-radius: 1rem; padding: 2rem; margin: 2rem 0;">
-            <h3 style="margin-top: 0;">If You Choose Assisted Multisig:</h3>
+            <h3 style="margin-top: 0;">If you do it yourself (single-sig or self-managed multisig):</h3>
             <ul style="margin: 1rem 0 0 1.5rem; color: var(--text-dim);">
-                <li>Set up 2-of-3 with Unchained, Casa, or Nunchuk</li>
+                <li>Set up 2-of-3 with Unchained, Casa, or Nunchuk — or fully self-hosted with Sparrow</li>
                 <li>Store keys in separate locations (never together)</li>
-                <li>Document your setup (encrypted, secure location)</li>
-                <li>Test recovery process at least once</li>
-                <li><strong>Create a "letter to heirs"</strong> explaining how to contact vendor</li>
+                <li>Document your setup in plain language (encrypted, secure location)</li>
+                <li><strong>Test a real recovery</strong> — having a setup is not the same as having tested it</li>
+                <li>Make sure one other trusted person could actually carry it out if you couldn't</li>
             </ul>
         </div>
 
         <div style="background: var(--secondary-dark); border: 2px solid var(--border-color); border-radius: 1rem; padding: 2rem; margin: 2rem 0;">
-            <h3 style="margin-top: 0;">If You Choose Collaborative Security:</h3>
+            <h3 style="margin-top: 0;">If you want collaborative security:</h3>
+            <p style="color: var(--text-dim); margin: 0 0 1rem;">A note on how it's priced: with a collaborative-security <em>service</em> — for example, The Bitcoin Adviser, where I advise — the setup, the estate/inheritance protocol, <strong>education for you and your family</strong>, and ongoing support are normally <strong>included in the service fee</strong>, not sold as separate add-ons. That's a different path from doing it yourself with a kit; neither is a step toward the other.</p>
             <ul style="margin: 1rem 0 0 1.5rem; color: var(--text-dim);">
-                <li>Research providers: TBA by Choice, Onramp, or attorney-based solutions</li>
-                <li>Understand quorum requirements (typically 2-of-3 or 3-of-5)</li>
-                <li>Establish relationships with key holders (attorney, trusted advisor, family office)</li>
-                <li>Document inheritance &amp; incapacity procedures</li>
-                <li>Schedule annual reviews of the setup</li>
+                <li>Look for <strong>independent</strong> keyholders who aren't aligned against you</li>
+                <li>Understand the quorum (typically 2-of-3) — you stay the legal owner and initiate transactions</li>
+                <li>Confirm documented inheritance &amp; incapacity procedures and continuity reviews</li>
+                <li>Compare more than one qualified provider before you commit</li>
             </ul>
+        </div>
+
+        <!-- Calendar-first CTA -->
+        <div style="background: var(--secondary-dark); border: 2px solid var(--sovereign-gold); border-radius: 1rem; padding: 2rem; margin: 2rem 0; text-align: center;">
+            <h3 style="margin-top: 0;">Deciding between these is the hard part</h3>
+            <p style="color: var(--text-dim); max-width: 640px; margin: 0.5rem auto 1.5rem;">There's no universally "best" setup — only tradeoffs that fit one family and not another. The keys, the documentation, the recovery test, and who you trust to hold a key are worth talking through before you move real funds.</p>
+            <a href="https://meetings.hubspot.com/dalia-platt" class="btn" style="background: var(--sovereign-gold); color: var(--primary-dark); border: 2px solid var(--sovereign-gold);">Book a call with Dalia →</a>
         </div>
 
         <div style="text-align: center; margin: 3rem 0;">
@@ -724,53 +756,52 @@
 
             if (collaborativeScore >= 8) {
                 recommendation = `
-                    <h3 style="color: var(--accent-green); margin-bottom: 1rem;">✅ Collaborative Security Recommended</h3>
+                    <h3 style="color: var(--accent-green); margin-bottom: 1rem;">🟢 Your answers point toward collaborative security</h3>
                     <p style="margin-bottom: 1rem;">
-                        Based on your answers, collaborative security is the best fit for your situation. Your holdings, time horizon, and risk profile justify the added complexity.
+                        Incapacity, inheritance, coercion, or travel risk are exactly what collaborative security is built for — self-custody with guardrails, where no single party (including you) can move funds alone. It isn't "more secure by default"; it's resilient against one-person failure when the setup is designed and maintained well.
                     </p>
                     <div style="background: rgba(76, 175, 80, 0.1); padding: 1rem; border-radius: 0.5rem; margin: 1rem 0;">
-                        <strong>Key Benefits for You:</strong>
+                        <strong>What it's designed to do:</strong>
                         <ul style="margin: 0.5rem 0 0 1.5rem;">
-                            <li>Protection against incapacity and coercion</li>
-                            <li>Clear inheritance path for heirs</li>
-                            <li>Geographic distribution reduces travel risk</li>
-                            <li>Professional processes and documentation</li>
+                            <li>Reduce single points of failure (no one signs alone)</li>
+                            <li>Give heirs a documented, tested recovery path</li>
+                            <li>Distribute keys across independent parties and places</li>
                         </ul>
                     </div>
-                    <strong>Next Step:</strong> Research providers like TBA by Choice, Onramp, or attorney-based solutions.
+                    <p style="margin-bottom: 0;"><strong>Next step:</strong> talk it through before you move real funds. <a href="https://meetings.hubspot.com/dalia-platt" style="color: var(--sovereign-gold);">Book a call with Dalia →</a></p>
                 `;
             } else if (collaborativeScore >= 4) {
                 recommendation = `
-                    <h3 style="color: var(--accent-orange); margin-bottom: 1rem;">⚖️ Either Model Could Work</h3>
+                    <h3 style="color: var(--accent-orange); margin-bottom: 1rem;">⚖️ Either could fit — it's about tradeoffs, not size</h3>
                     <p style="margin-bottom: 1rem;">
-                        Your situation falls in the middle. Assisted multisig is simpler and cheaper, but collaborative security offers better long-term protection.
+                        DIY / self-managed multisig keeps everything in your hands with no ongoing fees. Collaborative security trades some unilateral control for resilience against one-person failure. Neither is a "step up" from the other — they're different tradeoffs.
                     </p>
                     <div style="background: rgba(255, 152, 0, 0.1); padding: 1rem; border-radius: 0.5rem; margin: 1rem 0;">
-                        <strong>Consider These Questions:</strong>
+                        <strong>Questions worth sitting with:</strong>
                         <ul style="margin: 0.5rem 0 0 1.5rem;">
-                            <li>Do you have a trusted attorney or advisor who could hold a key?</li>
-                            <li>Is the added cost worth the peace of mind?</li>
-                            <li>Will your holdings likely grow beyond $250K?</li>
+                            <li>If something happened to you tomorrow, could someone else actually recover the funds?</li>
+                            <li>Have you documented and <em>tested</em> recovery — not just set it up?</li>
+                            <li>Is there a trusted, independent party who could hold a key?</li>
                         </ul>
                     </div>
-                    <strong>Next Step:</strong> Start with assisted multisig, but plan to upgrade to collaborative security as your holdings grow.
+                    <p style="margin-bottom: 0;"><strong>Next step:</strong> if you want a second set of eyes on the tradeoff, <a href="https://meetings.hubspot.com/dalia-platt" style="color: var(--sovereign-gold);">book a call with Dalia →</a></p>
                 `;
             } else {
                 recommendation = `
-                    <h3 style="color: var(--accent-blue); margin-bottom: 1rem;">🔵 Assisted Multisig Recommended</h3>
+                    <h3 style="color: var(--accent-blue); margin-bottom: 1rem;">🔵 DIY / self-managed multisig looks like enough — if you do it honestly</h3>
                     <p style="margin-bottom: 1rem;">
-                        For your current situation, assisted multisig (2-of-3 with a vendor backup) is the most practical choice. It's simpler, more affordable, and provides good security.
+                        For where you are now, self-managed multisig (e.g. 2-of-3 you control) gives you real sovereignty and survives a single lost key. The catch: the single point of failure is still you — so it only counts if the setup is documented and the recovery is actually tested.
                     </p>
                     <div style="background: rgba(33, 150, 243, 0.1); padding: 1rem; border-radius: 0.5rem; margin: 1rem 0;">
-                        <strong>Key Actions:</strong>
+                        <strong>Do these, not just the setup:</strong>
                         <ul style="margin: 0.5rem 0 0 1.5rem;">
-                            <li>Choose a reputable vendor (Unchained, Casa, Nunchuk)</li>
-                            <li>Store your 2 keys in separate secure locations</li>
-                            <li>Create a "letter to heirs" with vendor contact info</li>
-                            <li>Test your recovery process</li>
+                            <li>Store each key in a separate, secure location</li>
+                            <li>Write the full recovery steps in plain language</li>
+                            <li>Make sure one other person could carry them out</li>
+                            <li><strong>Test a real recovery</strong> before you rely on it</li>
                         </ul>
                     </div>
-                    <strong>Future Planning:</strong> As your holdings grow or your situation changes, consider upgrading to collaborative security.
+                    <p style="margin-bottom: 0;">If "could someone else recover this?" worries you, that's exactly when collaborative security is worth a look — <a href="https://meetings.hubspot.com/dalia-platt" style="color: var(--sovereign-gold);">talk it through with Dalia →</a></p>
                 `;
             }
 


### PR DESCRIPTION
Implements **option B** of the TBA-inversion spec ([PR #119](https://github.com/Sovereigndwp/bitcoin-sovereign-academy/pull/119)), which you signed off on. Page: `paths/sovereign/stage-3/collaborative-security.html`.

## What changed
- **Three-model rebuild** (locked rule): the comparison grid is now **Single-Sig / DIY-Self-Managed Multisig / Collaborative Security** (was two models). The DIY column teaches the critical middle — *"key count ≠ key control: technically multisig, humanly centralized."* Risk matrix relabeled to DIY vs Collaborative with a "single-sig fails all of these" note.
- **Calendar-first inversion**: the "Research providers: TBA by Choice, Onramp…" vendor lists and the three quiz **"X Recommended"** verdicts are replaced with a *"book a call with Dalia"* CTA (`meetings.hubspot.com/dalia-platt`). Also fixes the wrong **"TBA by Choice"** name.
- **Free-inclusion disclosure**: with a collaborative-security *service* (e.g. The Bitcoin Adviser, where I advise) the education/docs/inheritance/support are **included in the fee**, not add-ons; DIY kits are the separate self-custody route — neither a step toward the other.
- **Guardrails framing**: collaborative security is "self-custody with guardrails," "designed to **reduce** single points of failure" (not eliminate), "holding one key in 2-of-3 is not giving up custody," + the required collusion-assumption caveat. Dropped the holdings-based "upgrade as you grow" framing.
- Kept the existing COI disclosure aside (already on origin/main).

## Voice-check
The copy is drawn from your locked TBA rulesets — **edit any wording directly here on the PR**.

## Verification
- 0 banned strings (`TBA by Choice` / `eliminate` / `collaborative custody` except the one permitted gloss).
- `<main>` 1/1 and `<div>` balanced; `html-validate` shows no close-order/landmark/title errors (remaining lint is pre-existing inline-style/whitespace).
- Static content — no gating involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)