### PR TITLE
Deep-dives: brand orange→yellow fade — titles + section headings + hero accent (Option A)

### DIFF
--- a/css/deep-dive-brand.css
+++ b/css/deep-dive-brand.css
@@ -1,30 +1,41 @@
 /* ============================================================================
-   Deep-dive brand gradient title
+   Deep-dive brand fade  (linked only on /deep-dives/ pages; scoped to body.bsa-deepdive)
    ----------------------------------------------------------------------------
-   Scope: linked ONLY on /deep-dives/ pages. Restores the canonical orange→yellow
-   brand gradient (--bsa-grad) on the PAGE TITLE (h1), which is otherwise forced
-   solid by the global `h1,h2,h3 { background:none !important; -webkit-text-fill-color:initial !important }`
-   rule in css/path-bsa-brand-fix.css (loaded via css/icons.css).
+   Goal: every deep dive carries the canonical orange→yellow brand fade in a few
+   deliberate doses, without the blanket flat-orange that was washing the pages out.
 
-   We deliberately scope to h1 only (the title) so section sub-headings (h2/h3)
-   stay solid — keeping the gradient "sparing" per the homepage canonical, while
-   giving each deep dive the brand title. The `html body` prefixes + the title
-   container selectors raise specificity above the .module-header/.path-header
-   !important rules in the brand-fix sheets.
+   1) HEADINGS — page title (h1) and section headings (h2/h3) use the brand gradient
+      (--bsa-grad). This is the main, consistent dose and reads cleanly on any bg.
+   2) HERO/HEADER CARD — the one bordered hero per page (.module-header / .hero) loses
+      its blanket orange border (→ neutral) and gains a single gradient edge at the top
+      as its signature accent. Borderless sub-page headers just get the heading fade.
 
-   Gradient value is the literal --bsa-grad from brand-consistency.css (inlined so
-   this works on deep-dive pages that don't load that sheet, e.g. JEA).
+   Specificity: the `html body.bsa-deepdive` prefix (0,1,2+) beats the global
+   `h1,h2,h3 { background:none !important; -webkit-text-fill-color:initial !important }`
+   solid-heading rule in css/path-bsa-brand-fix.css. Gradient value is the literal
+   --bsa-grad from brand-consistency.css (inlined so it works on deep-dive pages that
+   don't load that sheet, e.g. JEA). The rest of the site is untouched.
    ========================================================================== */
 
-html body h1,
-html body .header h1,
-html body .hero h1,
-html body .hero-header h1,
-html body .path-header h1,
-html body .module-header h1 {
+html body.bsa-deepdive h1,
+html body.bsa-deepdive h2,
+html body.bsa-deepdive h3 {
   background: linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%) !important;
   -webkit-background-clip: text !important;
   background-clip: text !important;
   -webkit-text-fill-color: transparent !important;
-  color: #FFD400; /* fallback for browsers without background-clip:text support */
+  color: #FFD400; /* fallback where background-clip:text is unsupported */
+}
+
+html body.bsa-deepdive :is(.module-header, .hero) {
+  position: relative;
+  overflow: hidden;
+  border-color: #2A2A2A !important;
+}
+html body.bsa-deepdive :is(.module-header, .hero)::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 4px;
+  background: linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%);
 }

--- a/css/deep-dive-brand.css
+++ b/css/deep-dive-brand.css
@@ -1,0 +1,30 @@
+/* ============================================================================
+   Deep-dive brand gradient title
+   ----------------------------------------------------------------------------
+   Scope: linked ONLY on /deep-dives/ pages. Restores the canonical orange→yellow
+   brand gradient (--bsa-grad) on the PAGE TITLE (h1), which is otherwise forced
+   solid by the global `h1,h2,h3 { background:none !important; -webkit-text-fill-color:initial !important }`
+   rule in css/path-bsa-brand-fix.css (loaded via css/icons.css).
+
+   We deliberately scope to h1 only (the title) so section sub-headings (h2/h3)
+   stay solid — keeping the gradient "sparing" per the homepage canonical, while
+   giving each deep dive the brand title. The `html body` prefixes + the title
+   container selectors raise specificity above the .module-header/.path-header
+   !important rules in the brand-fix sheets.
+
+   Gradient value is the literal --bsa-grad from brand-consistency.css (inlined so
+   this works on deep-dive pages that don't load that sheet, e.g. JEA).
+   ========================================================================== */
+
+html body h1,
+html body .header h1,
+html body .hero h1,
+html body .hero-header h1,
+html body .path-header h1,
+html body .module-header h1 {
+  background: linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%) !important;
+  -webkit-background-clip: text !important;
+  background-clip: text !important;
+  -webkit-text-fill-color: transparent !important;
+  color: #FFD400; /* fallback for browsers without background-clip:text support */
+}

--- a/deep-dives/austrian-economics/economic-calculation-problem.html
+++ b/deep-dives/austrian-economics/economic-calculation-problem.html
@@ -336,6 +336,7 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>

--- a/deep-dives/austrian-economics/economic-calculation-problem.html
+++ b/deep-dives/austrian-economics/economic-calculation-problem.html
@@ -338,7 +338,7 @@
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Header -->

--- a/deep-dives/austrian-economics/index.html
+++ b/deep-dives/austrian-economics/index.html
@@ -107,7 +107,7 @@
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="hero">

--- a/deep-dives/austrian-economics/index.html
+++ b/deep-dives/austrian-economics/index.html
@@ -105,6 +105,7 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>

--- a/deep-dives/austrian-economics/praxeology-human-action.html
+++ b/deep-dives/austrian-economics/praxeology-human-action.html
@@ -337,6 +337,7 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>

--- a/deep-dives/austrian-economics/praxeology-human-action.html
+++ b/deep-dives/austrian-economics/praxeology-human-action.html
@@ -339,7 +339,7 @@
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Header -->

--- a/deep-dives/austrian-economics/sound-money-theory.html
+++ b/deep-dives/austrian-economics/sound-money-theory.html
@@ -336,6 +336,7 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>

--- a/deep-dives/austrian-economics/sound-money-theory.html
+++ b/deep-dives/austrian-economics/sound-money-theory.html
@@ -338,7 +338,7 @@
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Header -->

--- a/deep-dives/austrian-economics/time-preference-fundamentals.html
+++ b/deep-dives/austrian-economics/time-preference-fundamentals.html
@@ -410,6 +410,7 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>

--- a/deep-dives/austrian-economics/time-preference-fundamentals.html
+++ b/deep-dives/austrian-economics/time-preference-fundamentals.html
@@ -412,7 +412,7 @@
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <!-- Header -->

--- a/deep-dives/first-principles/digital-scarcity.html
+++ b/deep-dives/first-principles/digital-scarcity.html
@@ -133,7 +133,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to First Principles</a>
         <div class="header">

--- a/deep-dives/first-principles/digital-scarcity.html
+++ b/deep-dives/first-principles/digital-scarcity.html
@@ -131,6 +131,7 @@
         }
     </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/first-principles/index.html
+++ b/deep-dives/first-principles/index.html
@@ -895,7 +895,7 @@
   }
 }</script>    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body>
+<body class="bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="header">

--- a/deep-dives/first-principles/index.html
+++ b/deep-dives/first-principles/index.html
@@ -893,7 +893,8 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
+}</script>    <link rel="stylesheet" href="/css/deep-dive-brand.css">
+</head>
 <body>
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">

--- a/deep-dives/first-principles/original-question-everything.html
+++ b/deep-dives/first-principles/original-question-everything.html
@@ -895,7 +895,7 @@
   }
 }</script>    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body>
+<body class="bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="header">

--- a/deep-dives/first-principles/original-question-everything.html
+++ b/deep-dives/first-principles/original-question-everything.html
@@ -893,7 +893,8 @@
     "@type": "Audience",
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
-}</script></head>
+}</script>    <link rel="stylesheet" href="/css/deep-dive-brand.css">
+</head>
 <body>
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">

--- a/deep-dives/first-principles/why-money-fails.html
+++ b/deep-dives/first-principles/why-money-fails.html
@@ -77,6 +77,7 @@
         }
     </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/first-principles/why-money-fails.html
+++ b/deep-dives/first-principles/why-money-fails.html
@@ -79,7 +79,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to First Principles</a>
         <div class="header">

--- a/deep-dives/foundational-layer-thesis/dashboard.html
+++ b/deep-dives/foundational-layer-thesis/dashboard.html
@@ -93,6 +93,7 @@
   @media (max-width: 720px) { body { padding: 16px; } h1 { font-size: 26px; } .verdict { grid-template-columns: 1fr 1fr; gap: 16px; padding: 20px; } .verdict-box { text-align: left; grid-column: span 2; } }
 </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
 <div class="container">

--- a/deep-dives/foundational-layer-thesis/dashboard.html
+++ b/deep-dives/foundational-layer-thesis/dashboard.html
@@ -95,7 +95,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
 <div class="container">
 <header>
   <div class="eyebrow">THE SOVEREIGN ACADEMY · FALSIFICATION FRAMEWORK · v4</div>

--- a/deep-dives/foundational-layer-thesis/executive-tldr.html
+++ b/deep-dives/foundational-layer-thesis/executive-tldr.html
@@ -147,7 +147,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
 
 <nav class="top">
   <div class="inner">

--- a/deep-dives/foundational-layer-thesis/executive-tldr.html
+++ b/deep-dives/foundational-layer-thesis/executive-tldr.html
@@ -145,6 +145,7 @@
   }
 </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
 

--- a/deep-dives/foundational-layer-thesis/index.html
+++ b/deep-dives/foundational-layer-thesis/index.html
@@ -96,7 +96,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
 
 <nav class="top">
   <div class="inner">

--- a/deep-dives/foundational-layer-thesis/index.html
+++ b/deep-dives/foundational-layer-thesis/index.html
@@ -94,6 +94,7 @@
   }
 </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
 

--- a/deep-dives/foundational-layer-thesis/newcomer-onepager.html
+++ b/deep-dives/foundational-layer-thesis/newcomer-onepager.html
@@ -119,7 +119,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
 
 <nav class="top">
   <div class="inner">

--- a/deep-dives/foundational-layer-thesis/newcomer-onepager.html
+++ b/deep-dives/foundational-layer-thesis/newcomer-onepager.html
@@ -117,6 +117,7 @@
   }
 </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
 

--- a/deep-dives/index.html
+++ b/deep-dives/index.html
@@ -201,6 +201,7 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>

--- a/deep-dives/index.html
+++ b/deep-dives/index.html
@@ -203,7 +203,7 @@
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="breadcrumb">

--- a/deep-dives/jurisdictional-exposure-audit/audit/index.html
+++ b/deep-dives/jurisdictional-exposure-audit/audit/index.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="/deep-dives/jurisdictional-exposure-audit/css/jea.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body>
+<body class="bsa-deepdive">
 <nav class="jea-top">
   <div class="inner">
     <a class="brand" href="/deep-dives/jurisdictional-exposure-audit/">JURISDICTIONAL EXPOSURE AUDIT</a>

--- a/deep-dives/jurisdictional-exposure-audit/audit/index.html
+++ b/deep-dives/jurisdictional-exposure-audit/audit/index.html
@@ -10,6 +10,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/deep-dives/jurisdictional-exposure-audit/css/jea.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body>
 <nav class="jea-top">

--- a/deep-dives/jurisdictional-exposure-audit/index.html
+++ b/deep-dives/jurisdictional-exposure-audit/index.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="/deep-dives/jurisdictional-exposure-audit/css/jea.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body>
+<body class="bsa-deepdive">
 <nav class="jea-top">
   <div class="inner">
     <a class="brand" href="/deep-dives/jurisdictional-exposure-audit/">JURISDICTIONAL EXPOSURE AUDIT</a>

--- a/deep-dives/jurisdictional-exposure-audit/index.html
+++ b/deep-dives/jurisdictional-exposure-audit/index.html
@@ -9,6 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/deep-dives/jurisdictional-exposure-audit/css/jea.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body>
 <nav class="jea-top">

--- a/deep-dives/jurisdictional-exposure-audit/library/index.html
+++ b/deep-dives/jurisdictional-exposure-audit/library/index.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="/deep-dives/jurisdictional-exposure-audit/css/jea.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body>
+<body class="bsa-deepdive">
 <nav class="jea-top">
   <div class="inner">
     <a class="brand" href="/deep-dives/jurisdictional-exposure-audit/">JURISDICTIONAL EXPOSURE AUDIT</a>

--- a/deep-dives/jurisdictional-exposure-audit/library/index.html
+++ b/deep-dives/jurisdictional-exposure-audit/library/index.html
@@ -9,6 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/deep-dives/jurisdictional-exposure-audit/css/jea.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body>
 <nav class="jea-top">

--- a/deep-dives/jurisdictional-exposure-audit/library/united-states/index.html
+++ b/deep-dives/jurisdictional-exposure-audit/library/united-states/index.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="/deep-dives/jurisdictional-exposure-audit/css/jea.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body>
+<body class="bsa-deepdive">
 <nav class="jea-top">
   <div class="inner">
     <a class="brand" href="/deep-dives/jurisdictional-exposure-audit/">JURISDICTIONAL EXPOSURE AUDIT</a>

--- a/deep-dives/jurisdictional-exposure-audit/library/united-states/index.html
+++ b/deep-dives/jurisdictional-exposure-audit/library/united-states/index.html
@@ -9,6 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/deep-dives/jurisdictional-exposure-audit/css/jea.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body>
 <nav class="jea-top">

--- a/deep-dives/money-banking/cantillon-effect.html
+++ b/deep-dives/money-banking/cantillon-effect.html
@@ -89,6 +89,7 @@
         }
     </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/money-banking/cantillon-effect.html
+++ b/deep-dives/money-banking/cantillon-effect.html
@@ -91,7 +91,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to Money & Banking</a>
         <div class="header">

--- a/deep-dives/money-banking/central-banking-explained.html
+++ b/deep-dives/money-banking/central-banking-explained.html
@@ -64,6 +64,7 @@
         }
     </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/money-banking/central-banking-explained.html
+++ b/deep-dives/money-banking/central-banking-explained.html
@@ -66,7 +66,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to Money & Banking</a>
         <div class="header">

--- a/deep-dives/money-banking/history-of-money.html
+++ b/deep-dives/money-banking/history-of-money.html
@@ -61,6 +61,7 @@
         }
     </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/money-banking/history-of-money.html
+++ b/deep-dives/money-banking/history-of-money.html
@@ -63,7 +63,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to Money & Banking</a>
         <div class="header">

--- a/deep-dives/money-banking/index.html
+++ b/deep-dives/money-banking/index.html
@@ -251,6 +251,7 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>

--- a/deep-dives/money-banking/index.html
+++ b/deep-dives/money-banking/index.html
@@ -253,7 +253,7 @@
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
         <div class="hero">

--- a/deep-dives/philosophy-economics/index.html
+++ b/deep-dives/philosophy-economics/index.html
@@ -43,7 +43,7 @@
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
   <main id="main-content" class="container">
     <h1>Philosophy &amp; Economics</h1>

--- a/deep-dives/philosophy-economics/index.html
+++ b/deep-dives/philosophy-economics/index.html
@@ -41,6 +41,7 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>

--- a/deep-dives/philosophy-economics/property-rights.html
+++ b/deep-dives/philosophy-economics/property-rights.html
@@ -39,7 +39,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to Philosophy & Economics</a>
         <div class="header">

--- a/deep-dives/philosophy-economics/property-rights.html
+++ b/deep-dives/philosophy-economics/property-rights.html
@@ -37,6 +37,7 @@
         @media (max-width: 768px) { .header h1 { font-size: 1.8rem; } }
     </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/philosophy-economics/time-preference.html
+++ b/deep-dives/philosophy-economics/time-preference.html
@@ -45,6 +45,7 @@
         }
     </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/philosophy-economics/time-preference.html
+++ b/deep-dives/philosophy-economics/time-preference.html
@@ -47,7 +47,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to Philosophy & Economics</a>
         <div class="header">

--- a/deep-dives/philosophy-economics/voluntaryism-bitcoin.html
+++ b/deep-dives/philosophy-economics/voluntaryism-bitcoin.html
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to Philosophy & Economics</a>
         <div class="header">

--- a/deep-dives/philosophy-economics/voluntaryism-bitcoin.html
+++ b/deep-dives/philosophy-economics/voluntaryism-bitcoin.html
@@ -30,6 +30,7 @@
         @media (max-width: 768px) { .header h1 { font-size: 1.8rem; } }
     </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/sovereign-tools/index.html
+++ b/deep-dives/sovereign-tools/index.html
@@ -41,6 +41,7 @@
     "audienceType": "Students interested in Bitcoin and cryptocurrency"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>

--- a/deep-dives/sovereign-tools/index.html
+++ b/deep-dives/sovereign-tools/index.html
@@ -43,7 +43,7 @@
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
   <main id="main-content" class="container">
     <h1>Sovereign Tools</h1>

--- a/deep-dives/sovereign-tools/multisig-guide.html
+++ b/deep-dives/sovereign-tools/multisig-guide.html
@@ -42,6 +42,7 @@
     </style>
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/sovereign-tools/multisig-guide.html
+++ b/deep-dives/sovereign-tools/multisig-guide.html
@@ -44,7 +44,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to Sovereign Tools</a>
         <div class="header">

--- a/deep-dives/sovereign-tools/privacy-best-practices.html
+++ b/deep-dives/sovereign-tools/privacy-best-practices.html
@@ -38,6 +38,7 @@
         @media (max-width: 768px) { .header h1 { font-size: 1.8rem; } }
     </style>
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/sovereign-tools/privacy-best-practices.html
+++ b/deep-dives/sovereign-tools/privacy-best-practices.html
@@ -40,7 +40,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to Sovereign Tools</a>
         <div class="header">

--- a/deep-dives/sovereign-tools/running-a-node.html
+++ b/deep-dives/sovereign-tools/running-a-node.html
@@ -36,6 +36,7 @@
     </style>
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
     <link rel="stylesheet" href="/css/brand-consistency.css">
+    <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
 <body class="bsa-skin">
     <div class="container">

--- a/deep-dives/sovereign-tools/running-a-node.html
+++ b/deep-dives/sovereign-tools/running-a-node.html
@@ -38,7 +38,7 @@
     <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
 </head>
-<body class="bsa-skin">
+<body class="bsa-skin bsa-deepdive">
     <div class="container">
         <a href="./" class="back-link">← Back to Sovereign Tools</a>
         <div class="header">


### PR DESCRIPTION
Per Dalia: the deep dives were too much *flat* orange and not enough of the signature bright-orange→yellow fade. Option A spreads the fade in deliberate doses across **all** deep-dive pages via one shared sheet (`css/deep-dive-brand.css` + a `body.bsa-deepdive` class).

## What it does
- **Headings (h1 + h2/h3):** the page title and every section heading now use the canonical `--bsa-grad` orange→yellow fade. Text gradient reads cleanly on any background and beats the global solid-heading `!important` rule in `path-bsa-brand-fix.css`.
- **Hero/header card (`.module-header` / `.hero`):** its blanket orange border → neutral `#2A2A2A`, plus a single 4px gradient **top-accent** as the page's signature edge.
- **Everything else:** untouched. Rest of the site (paths, demos, homepage) unaffected.

## Why this shape
Matches your homepage canonical ("default to neutral borders; reserve color"). Flooding every border with the gradient (the louder option) was rejected — it works against "use sparingly" and squares rounded corners. So: pull the blanket orange back, spend the fade where it reads (headings) + one hero accent per page.

## Scope / exclusions
- Applied to **30** deep-dive pages. **bitcoin-capital** (3) excluded — active WIP in another session.
- FLT's title is an SVG image (no text `h1`); its section `h2/h3` still pick up the fade.

## Verification (computed styles + screenshots)
austrian `h1/h2/h3` render the gradient (transparent fill); `.module-header` border neutral with a 4px gradient `::before` top-accent; section headings ("1. Scarcity", "2. Durability") visibly faded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)