### PR TITLE
bitcoin-capital: neutralize the one residual LMC-steer line (Dalia-approved)

### DIFF
--- a/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
@@ -914,7 +914,7 @@
         <tr><td>Debifi</td><td>N/A</td><td>N/A (institutional)</td><td>—</td><td>3-of-4 multisig</td></tr>
       </tbody>
     </table>
-    <p>LMC has the lowest direct cost. But direct cost alone is the wrong frame. The decision involves cost, margin-call risk, custody quality, term structure, and what you're using the funds for. The calculator will handle all of these dimensions.</p>
+    <p>Direct cost is the wrong frame for this decision. It involves cost, margin-call risk, custody quality, term structure, the BTC exposure LMC embeds, and what you're using the funds for — the calculator weighs all of these dimensions.</p>
   </div>
 </section>
 


### PR DESCRIPTION
The loans page's conflicted-product handling is already strong and live (disclosure banner, LMC presented last as specialized, heavy caveats). This reworks the single remaining line that led with the founder-owned product being cheapest.

Before: "LMC has the lowest direct cost. But direct cost alone is the wrong frame…"
After: "Direct cost is the wrong frame for this decision. It involves cost, margin-call risk, custody quality, term structure, the BTC exposure LMC embeds, and what you're using the funds for…"

One-line, conflict-free off main (the parallel branch didn't touch this line). Other bitcoin-capital cleanups (brand-fade link, verify Ledn numbers, 'Verified math'→'modeled', mortgages Sources appendix) deferred until the branch's loans improvements are brought to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)