### PR TITLE
chore: salvage 5 stranded reference docs from JEA branch

### DIFF
--- a/docs/superpowers/specs/2026-06-09-youth-front-door-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-09-youth-front-door-redesign-design.md
@@ -1,0 +1,149 @@
+# Design Spec — Youth Front-Door Redesign (`youth-families/index.html`)
+
+> **Status:** approved through brainstorming; ready for plan. **Date:** 2026-06-09.
+> Implements the brief `docs/superpowers/specs/2026-06-07-youth-front-door-redesign-brief.md`.
+> **Spec → sign-off → plan → code.** Do not ship code before Dalia signs off on this spec.
+
+---
+
+## 1. Problem statement + measurable success criteria
+
+The Phase-4 youth-pedagogy audit (`reports/pedagogy-youth-audit-2026-06-06.md`) ranked `youth-families/index.html` the **#1 highest-leverage page** on the youth funnel (leverage 17.9). It scores **1/5** on Discovery, Curiosity, Retention, Capability-gain, Real-artifact, and Family-catalyst. Honest capability sentence today: *"the learner can browse and navigate to individual weeks but gains no new financial knowledge."* It is a **directory**: hero → stats → 10 week-cards → educator section. It routes but teaches nothing, and **fails the bright-12-year-old-solo test**.
+
+**Goal:** the front door should **teach one thing and deliver a 60-second micro-win before it routes** — turning a table-of-contents into a reason to care — and work for a 12-year-old alone.
+
+### Success criteria (what "good" looks like)
+
+| Audit criterion | Now | Target after redesign | How the redesign delivers it |
+|---|---|---|---|
+| Discovery | 1 | ≥3 | A live, visceral experiment is the first interactive thing on the page |
+| Curiosity | 1 | ≥3 | Predict→reveal gap ("you guessed X, here's what really happens") |
+| Capability-gain | 1 | ≥3 | Learner leaves knowing *money loses value over time, and why scarcity matters* — a real, sticky mental model |
+| Real-artifact | 1 | ≥3 | The experiment produces a personal result ("$1,040 → buys ~$X") the learner generated |
+| Family-catalyst | 1 (≈1.90 cross-page) | ≥3 | First-class family + educator band with a take-home conversation prompt |
+| Age-fit 12–14 | 2 | ≥4 | Grade-6 reading level; one decision at a time; no jargon before it's earned |
+
+**Non-goals for this spec (scope guard):** this redesigns the **front-door page only**. It does **not** rewrite the 10 week lessons, cut/merge weeks, or physically migrate anything to FSA. Those are captured in §9 as the documented next phase. All 10 week routes and progress tracking are **preserved unchanged**.
+
+---
+
+## 2. Brand-architecture decision (context — approved)
+
+The youth program is ~90% generic personal finance; only Week 3 is Bitcoin-native. It shares DNA with `programa-colombia` (already slated to move BSA→FSA per the 2026-06-09 content inventory). Decision (approved A–D, option **D**):
+
+- **Canonical home = FSA** (beside programa-colombia, as the LATAM/family financial-literacy pillar), **fronted by TSA** (the umbrella router).
+- **BSA keeps the Bitcoin bridge** — the inflation→hard-money moment is the on-ramp from the youth track into BSA's Bitcoin content.
+- **Phasing:** redesign **in place in BSA now**, built **migration-ready**; the physical move to FSA + 301 redirects happens later, alongside programa-colombia, when FSA scaffolds. Nothing moves or breaks in this phase.
+
+**Migration-ready requirements (so the later move is a lift-and-shift, not a rewrite):**
+- Absolute CSS paths only (`/css/brand.css`, `/css/tokens.css`, `/css/design-tokens.css`) — never relative.
+- No BSA-only runtime dependency in the front door. The micro-win's live data uses the public mempool.space endpoint directly (already how Week 3 does it), not a BSA-internal API.
+- Self-contained page; localStorage keys namespaced `yf-*` (already are) carry over.
+
+---
+
+## 3. Visual system (approved: Dark)
+
+Use the **homepage/TSA dark system** — already what this page, TSA, and the BSA homepage use. No new design tokens; extend existing.
+
+- Surfaces: `--dark-bg #16181C`, `--card-bg #101013`, borders `#2a2d34`.
+- Accent: orange→yellow gradient (`#FF7A00`→`#FFD400`) **used sparingly** (CTA, eyebrow, the live "melt" bar). White (`#F7F7F2`) is default text.
+- Type: Inter (sans) + JetBrains Mono (labels/numerics). Rectangular cards, 2px-ish corners, outline secondary buttons.
+- **No green, no purple** (both prior unaccepted drift). The one exception already in the codebase: a muted "live data" status dot may use the success token — keep it subtle.
+- **Cream accent:** the family/educator band is a single **cream-inversion band** (`#F4ECD8` / ink `#1a160f` / gold `#C8922A`), mirroring TSA's family-card pattern — the only cream on the page, to make the parent/educator path visually distinct.
+
+References read: `os.thesovereign.academy` (editorial-asymmetric hero, mono labels), TSA hub `the-sovereign-academy/hub/index.html` (the family-card cream-inversion and hero split this page should echo).
+
+---
+
+## 4. Page layout (approved: B — editorial split)
+
+Top-to-bottom structure:
+
+1. **Header** — existing logo + light nav (keep; ensure logo gradient uses brand tokens, no leftover green).
+2. **Hero — editorial split (2-col, stacks on mobile):**
+   - **Left:** mono eyebrow (`— Money, before it costs you`) · headline *"Learn how money really works — before it costs you."* · 2-line promise (*"A 60-second experiment, then 10 weeks of real money skills you can use this week. Built so a 12-year-old can start alone."*) · primary CTA **Try the experiment →** (scrolls/focuses the micro-win) + secondary **See the 10 weeks** · trust line (*no login · nothing to install · your progress stays on your device*).
+   - **Right:** the **live micro-win card** (§5), above the fold.
+3. **The 10-week path** — the existing 10 week-cards, restyled to the dark system and labeled "one connected plan, not 10 pages." **All 10 routes preserved.** This replaces the current `program-stats` band (the stats add nothing — cut).
+4. **Family + educator band** — cream-inversion band: *"Doing this with your family or class?"* with a take-home conversation prompt line, plus two entries: **For families** (how to do it together at home) and **For educators** (links existing `educator/` + the HubSpot training call). This satisfies the family-catalyst criterion and the brief's family-hub requirement.
+5. **Footer** — corrected to the locked convention (§7).
+
+Mobile: hero stacks promise → micro-win → CTAs; weeks become a single column; family band full-width.
+
+---
+
+## 5. The micro-win (approved: MW-A — inflation-melt)
+
+A self-contained, ~60-second **predict → reveal → bridge** interaction. Reuses and adapts Week 3's working engine (`/js/youth-engine.js` + the live-supply verify card); the front-door version is a trimmed, single-screen variant.
+
+### Interaction flow
+1. **Prompt:** *"You save **$20 every week** for a year and never touch it. After a year, will it buy more, the same, or less?"*
+2. **Predict:** three chips — `more` · `same` · `less`. Learner must pick before the reveal (predict-then-measure; locks engagement and creates the curiosity gap).
+3. **Reveal (the "melt"):** a $1,040 "saved" amount is shown; an animated bar/desaturation shows purchasing power eroding to roughly **$1,040 × (1 − r)** over the year, where `r` is a **recent, cited inflation rate** held in a single configurable constant with a source comment (e.g. a recent US CPI YoY figure). The number is framed as illustrative, not a forecast. Result line: *"$1,040 saved → buys about $X of stuff."*
+4. **Name it:** *"That's **inflation** — money slowly buying less."* (Concept is *experienced first, named second* — age-band pedagogy.)
+5. **Bridge (the Bitcoin on-ramp):** a live card — *"One kind of money is built so no one can make more of it: only **21,000,000** bitcoin will ever exist."* The **21M / current-supply figure is fetched live from mempool.space** (as Week 3 already does), sanitized via `safeInt()`. CTA: *"See how that works →"* → routes to **Week 3 (Saving + scarcity)**, which holds the fuller Bitcoin/21M treatment and is the natural next step (the BSA bridge).
+6. **Route on:** primary CTA becomes **Start Week 1 →**; the result persists to `localStorage` (`yf-microwin`) so a returning learner sees their prior result.
+
+### Truth / honesty constraints (per global rule "verify truth of content")
+- The inflation rate `r` must be a **real, sourced figure** (comment the source + date); never invented. Prefer framing as predict→measure with a labeled, dated rate over asserting a precise outcome.
+- The 21M supply line is factual; the live current-supply number must come from a live source and be sanitized. Never hardcode a stale supply number.
+- No claim that Bitcoin "beats inflation" or any investment-advice framing — inform, not convince. The bridge states the *scarcity property*, not a recommendation.
+
+### Accessibility
+- Keyboard-operable chips (`role="radio"` group), `prefers-reduced-motion` disables the melt animation and shows the end-state directly, AA contrast on all text (verify computed values, not screenshots), live-region announcement of the reveal.
+
+---
+
+## 6. Age-band plan (12–14, must pass solo)
+
+- **Reading level grade ~6.** Short sentences, concrete nouns ($20, a year, buys less), no finance jargon before it's earned. "Inflation," "scarcity," "purchasing power" are each *experienced, then named* — never assumed.
+- **One decision at a time** in the micro-win (single predict chip-set, not a form).
+- **No dependence on US-specific context** in the front door (paychecks/FAFSA/credit live in later weeks, not here) — keeps it usable for the LATAM/family audience and the eventual ES port.
+- Resolve the current **"ages 13–25" mismatch**: hero/meta reframed to *"for young people and their families,"* with the explicit promise *"built so a 12-year-old can start alone."* Remove the "13–25" and "schools, community centers, and libraries" framing from the hero (educator framing moves to the family/educator band).
+
+---
+
+## 7. Footer correction (locked convention)
+
+Replace the current footer (`© 2026 The Sovereign Academy · Educational content only…`) with the locked convention:
+
+> **Created by Dalia · bitcoinsovereign.academy**
+
+Keep an "Educational content only · Not financial advice" line. Keep cross-property links if desired, but the attribution line is non-negotiable. (When the page later migrates to FSA, this becomes the FSA footer variant `Creado por Dalia · …` for ES.)
+
+---
+
+## 8. Benchmark-borrow + measurement
+
+- **Code.org onboarding** — borrow the "do one real thing in the first 30 seconds" front-door pattern (the micro-win), *without* any badge/streak reward loop.
+- **Brilliant curiosity hook** — borrow the predict-before-reveal mechanic (the chips), *without* importing gamified progress mechanics.
+- **Unbounded mode (voice-spec §11):** NO quizzes, badges, streaks, XP, or completion %. The micro-win's "win" is intrinsic (you saw a true thing + generated a result), not a points hook. The existing Week-9 "Independence Quiz" and similar are out of scope here.
+
+**Measurement (first-party only, `js/analytics.js`):**
+- `microwin_view` (card in viewport), `microwin_predict` (chip chosen, which one), `microwin_reveal` (reached the melt), `microwin_bridge_click` (Bitcoin on-ramp), `week_start` (existing, per week).
+- North-star for this page: **% of front-door visitors who complete the micro-win** and **% who then click into any week**. No third-party trackers; anonymized.
+
+---
+
+## 9. Downstream (NOT in this spec — documented so it isn't lost)
+
+These were decided in brainstorming but belong to later phases:
+
+- **Content sourcing for the weeks** (future youth-program work): keep BSA Week 3 (Bitcoin bridge), Week 1 (needs/wants game), Week 6 (spending traps) + the `youth-engine` infra; borrow FSA's compound-growth + budget-tracker + debt-payoff *engines* under a youth vocabulary wrapper; borrow Colombia's `experimento-dos-economias` (canonical copy = BSA) + the predict→consequences→reflect shell + cross-week shared-state engine.
+- **Cut/merge candidates:** Week 8 (FAFSA, US-adult), Week 10 (multi-gen wealth, adult); merge Week 7; rebuild text-only Weeks 2 & 4.
+- **Migration to FSA:** move youth-families + programa-colombia together to FSA, 301 from BSA, add to the TSA hub router — when FSA scaffolds.
+
+---
+
+## 10. Constraints honored (checklist)
+
+- [x] `yf-progress` + `yf-visits` localStorage preserved (untouched).
+- [x] All 10 week routes preserved; no path removed.
+- [x] No rebuild-from-scratch; redesign the existing page.
+- [x] "Ages 13–25" vs 12-year-old-solo mismatch fixed.
+- [x] Footer corrected to `Created by Dalia · bitcoinsovereign.academy`.
+- [x] Absolute CSS paths only; migration-ready.
+- [x] Dark/homepage system; no new tokens; no green/purple.
+- [x] Unbounded mode (no quizzes/badges/streaks/%).
+- [x] Content truth: inflation rate sourced+dated; live supply sanitized; no investment advice.
+- [x] Data-attribute auto-init pattern for any new interactive component; verify with before/after screenshots + computed-contrast checks.

--- a/docs/superpowers/validation/2026-06-08-week3-validation-packet.md
+++ b/docs/superpowers/validation/2026-06-08-week3-validation-packet.md
@@ -1,0 +1,236 @@
+# Week 3 Validation Packet — "Saving Strategies" flagship
+
+**Purpose:** decide whether the Week 3 sensory flagship is good enough to become the
+**pattern replicated across the other 9 youth weeks (T2–T6).** Validate the pattern on
+ONE week with real people before scaling it. Do not replicate until this passes.
+
+**Date prepared:** 2026-06-08 · **Status:** uncommitted draft (no production/git changes)
+
+---
+
+## 1. Live URL (test the real thing, not localhost)
+
+**https://bitcoinsovereign.academy/youth-families/week-03/**
+
+- Confirmed live `200` and serving the elevated build (animated reveal-gap + Race→Melt).
+- **Test on a phone first.** The page is designed mobile-first; the "pass-the-phone"
+  share beat and the haptic buzz only feel real on a handset. Do at least one teen
+  session on a phone.
+- Have testers use a **fresh browser / private window** so a prior tester's saved goal
+  isn't sitting in `localStorage`.
+
+### What the page contains (so observers know what they're watching)
+1. **Step 1 · Predict** — goal builder (what / cost / weekly) → "how many weeks?" guess
+   you must *lock* → "Reveal the math →" → animated gap: *you vs. real*, "N weeks longer
+   than you thought."
+2. **Step 2 · Verify** — "Where do you put $1,000 for 10 years?" → drawer / savings →
+   Race→Melt animation (prices outrun your money; the bill desaturates) → then a **live**
+   "fewer than 21 million bitcoin" check pulling real supply data.
+3. **Step 3 · Keep** — a printable **My Savings Goal** sheet (their numbers + footer).
+4. **Step 4 · Share** — "Show a parent your savings goal. Ask them: what did YOU save up
+   for at my age, and how long did it really take?"
+
+### The three things we are actually measuring (the audit's weakest "moat" criteria)
+- **Real-artifact (1.50)** — do they actually *keep* the Savings Goal sheet?
+- **Family-conversation (1.90)** — does the share beat actually start a real parent↔teen talk?
+- **Learner-derived discovery (2.11)** — does predict-before-reveal create a genuine "aha"?
+- Plus a known gap: **does a 12–14-year-old get through it solo?** (track skews 15–17.)
+
+---
+
+## 2. Teen test script — 15 minutes (moderated, think-aloud)
+
+> Recruit 12–17. **At least one tester must be 12–14** (that's the gap we're checking).
+> Phone preferred. Record screen + audio if you can, or have a silent observer with the
+> checklist in §5. Script for the moderator is in plain text; *(observe …)* lines are for you.
+
+**0:00 — Setup (1 min)**
+- "I'm testing this web page, not you. There are no wrong answers. Please **think out
+  loud** — say whatever you're looking at, confused by, or reacting to."
+- Open the URL in a fresh tab. Hand them the phone. Say nothing else unless they stall >20s.
+
+**0:01 — First impression + goal (3 min)**
+- "Take a look. What is this page for? What would you do first?"
+- "Pick something real you actually want to save for, and fill it in."
+- *(observe: do they understand the three inputs without help? what goal/price do they pick?)*
+
+**0:04 — Predict (3 min)**
+- Let them reach the "how many weeks?" question. **Do not hint.**
+- *(observe: do they make a genuine guess BEFORE revealing, or try to skip/compute first?)*
+- After they hit "Reveal the math," ask: "What just happened? Were you close?"
+- *(observe: do they notice the gap? do they say the insight in their own words?)*
+
+**0:07 — Consequence (3 min)**
+- "Try the next part — where would you put $1,000 for 10 years?" Let them pick and watch.
+- "In your own words, what did that animation just show you?"
+- *(observe: do they grasp 'same dollars, buys less'? do they try the other option too?)*
+
+**0:10 — Keep (2 min)**
+- "Is there a way to keep the plan you made?" *(do NOT point at the button.)*
+- *(observe: do they find Print/Save on their own? do they actually keep it?)*
+
+**0:12 — Share (2 min)**
+- Have them read the "Pass the phone" prompt aloud.
+- "Would you actually do this? Who would you show? Would you ask them that question?"
+- *(observe: genuine intent vs. polite "sure." Note the named person if any.)*
+
+**0:14 — Wrap (1 min)**
+- "One thing you liked, one thing that was confusing or boring?" Then §6 questions.
+
+---
+
+## 3. Educator test script — 15 minutes (pedagogical review)
+
+> Recruit a teacher / youth-program facilitator. Lens = soundness, accuracy, classroom
+> fit, age range. They review as a professional, not as a learner.
+
+**0:00 — Setup (1 min)**
+- "Review this as if deciding whether to use it with your students. Think out loud."
+
+**0:01 — Full walkthrough (5 min)**
+- Have them go through all four beats once, doing the activities.
+
+**0:06 — Pedagogy probes (7 min)** — ask each:
+- "Does the **predict-before-reveal** moment do real teaching work, or is it a gimmick?"
+- "Is each step **one concept**, or is anything overloaded?"
+- "Is the inflation framing (~3%/yr, 0.5% savings, 'same dollars buy less') **accurate and
+  defensible** to a parent or colleague?"
+- "Could a **12–14-year-old** do this **without you** explaining it? Where would they stall?"
+- "What's the **real time-on-task** in a classroom — and does it fit a period / homework slot?"
+- "What **misconception** could a student leave with after this lesson?"
+- "What is **missing** that you'd need before assigning it?"
+
+**0:13 — Fit decision (2 min)**
+- "Would you use it? As in-class, homework, or a family-night activity? What would stop you?"
+
+---
+
+## 4. Parent review script — 10 minutes (the family hand-off)
+
+> The parent↔teen hand-off is the locked identity of this platform — this script tests
+> whether it actually fires, and whether a parent trusts the content. Ideally run this
+> **right after** a teen session, using the same teen, so the hand-off is real.
+
+**0:00 — Setup (1 min)**
+- "Your teen just used a saving lesson. I want to see what happens when they bring it to you."
+
+**0:01 — Receive the hand-off (3 min)**
+- Teen shows the parent their saved Savings Goal and asks the prompt question
+  ("what did YOU save up for at my age, and how long did it really take?").
+- *(observe the actual conversation — does it happen naturally? does the parent engage?
+  does it go beyond one sentence?)*
+
+**0:04 — Parent review of the content (4 min)** — ask:
+- "Is anything here **inaccurate, hyped, or pushing crypto** in a way that worries you?"
+- "Is it **age-appropriate** for your kid?"
+- "Does it **respect your role** as the parent, or try to go around you?"
+- "What part of this lesson would you want your child to **remember five years from now**?"
+
+**0:08 — Continue? (2 min)**
+- "Would you go through more weeks of this **with your kid**? What, if anything, would stop you?"
+
+---
+
+## 5. Observation checklist (fill during the TEEN session)
+
+Mark ✓ / ✗ / partial, and jot a note. Each line maps to a beat or a moat criterion.
+
+| # | Observation | ✓/✗ | Note |
+|---|---|---|---|
+| 1 | Understood the goal builder **without help** | | |
+| 2 | Entered a **real, personal** goal (not a placeholder) | | |
+| 3 | Made a **genuine prediction before** revealing (didn't skip) | | |
+| 4 | **Noticed/reacted** to the guess-vs-real gap | | |
+| 5 | Tried the consequence choice and **watched** the animation | | |
+| 6 | Could **explain the takeaway** ("same dollars buy less") in own words | | |
+| 7 | **Found Print/Save** for the Savings Goal **unprompted** | | |
+| 8 | **Actually kept** the artifact (saved/printed) | | |
+| 9 | Read the share prompt and expressed **real intent** to show a parent | | |
+| 10 | Completed **all four beats** | | |
+| 11 | *(12–14 tester only)* finished **with no adult explaining the page** | | |
+| 12 | Any **dead end, bug, or confusion** (where + what) | | |
+| 13 | Any **boredom / drop-off** moment (where) | | |
+| 14 | Total time on page (unrushed): ____ min | | |
+| 15 | **Visible surprise moment** — a noticeable surprise, realization, or prediction-error reaction (e.g. "Wait, really?", laughter, rechecking inputs, changing their estimate, visible curiosity) | | |
+| 16 | **Artifact ownership** — did they seem to *care* about the artifact? Score 1–4 (legend below) | ___/4 | |
+
+**#16 artifact-ownership scale:** 1 = saved only because prompted · 2 = saved voluntarily ·
+3 = discussed or modified it · 4 = expressed a desire to revisit it later.
+
+---
+
+## 6. Post-test questions (ask the teen; note exact words)
+
+1. **(Discovery)** "Before you saw the real number of weeks — how far off was your guess,
+   and did that surprise you?"
+2. **(Comprehension)** "If a friend kept $1,000 in a drawer for 10 years, what would you
+   tell them happens to it?"
+3. **(Real-artifact)** "Do you still have your savings goal saved? Where would you actually
+   put it so you'd see it?"
+4. **(Family-conversation)** "On a scale of 1–5, how likely are you to actually show a
+   parent and ask them that question? Why that number?"
+5. **(Affect / continue)** "Would you want to do the next week like this? What would make
+   it better?"
+6. **(Retention)** "If I asked you about this lesson next week, what do you think you'd
+   remember?"
+7. **(Transfer)** "Can you think of a situation in your own life where this lesson might
+   matter?"
+
+---
+
+## 7. Pass / fail criteria — is Week 3 ready to become the pattern?
+
+### Minimum sample before deciding
+- **≥3 teens**, including **≥1 in the 12–14 band**
+- **≥1 educator**
+- **≥1 parent**, with at least **1 real hand-off** observed (parent + teen together)
+
+> Small-n is fine — this is qualitative validation, not a metrics test. But do not decide
+> off a single teen, and **do not skip the 12–14 tester** (that's a known risk).
+
+### Learner mix — recruit a realistic range, not just the keen ones
+**Do not recruit only highly engaged students.** If possible, include:
+- one **naturally engaged** learner,
+- one **average** learner,
+- one learner who is **not especially interested** in money, economics, or Bitcoin.
+
+The goal is to validate the pattern with a realistic range of learners, not only the most
+motivated ones — a pattern that only works for the keenest kid won't scale to 9 weeks.
+
+### PASS — all of these must hold
+- **Discovery:** a majority of teens make a real prediction before revealing **and**
+  articulate the gap insight in their own words (post-Q1).
+- **Comprehension:** a majority correctly explain the Race→Melt takeaway unprompted
+  (checklist #6 / Q2) — "same dollars buy less."
+- **Real-artifact:** a majority **keep** the Savings Goal with no or minimal prompting
+  (checklist #7–#8) — this is the weakest audit criterion (1.50); it must clearly move.
+- **Family-conversation:** **≥1 genuine parent↔teen conversation actually happens** from
+  the share beat, **and** the parent says they'd continue (§4 close).
+- **12–14 accessibility:** the 12–14 tester completes **all four beats solo** (checklist #11).
+- **Trust/accuracy:** **zero** unresolved accuracy, hype, or "goes around the parent"
+  flags from the educator or parent.
+- **Effort:** teens finish in **≤20 min** unrushed, with no dead ends or blocking bugs.
+
+### FAIL / FIX-FIRST — any of these means do NOT replicate yet
+- Teens routinely **skip the prediction** or treat it as busywork → the discovery beat isn't landing.
+- Teens **can't explain** the consequence in their own words → the animation entertains but doesn't teach.
+- Teens **don't keep** the artifact → the moat mechanic (1.50) didn't move; fix the Keep step.
+- The share beat is **ignored or feels forced** → the family mechanic (1.90) didn't move.
+- The **12–14 tester needs hand-holding** → the page still skews 15–17; do the age-band pass first.
+- Educator or parent flags **inaccuracy or hype** → fix content before it propagates to 9 weeks.
+
+### Decision rule
+- **All PASS gates hold →** lock the pattern. Proceed to **T2 (Week 10 dashboard)** and
+  replicate the Predict→Verify→Keep→Share + sensory treatment across the remaining weeks.
+- **Any gate fails →** fix Week 3 first, re-test the failed gate, **then** decide.
+  Replicating a flawed pattern across 9 weeks multiplies the flaw 9×; one fix here is
+  cheaper than nine fixes later.
+
+---
+
+### Notes for the runner
+- Keep the moderator quiet — silence surfaces real confusion; hints hide it.
+- Capture **exact quotes**, not summaries (esp. Q2 and Q4).
+- One page = one tester per session; reset the browser between testers.
+- This packet validates the **pattern**, not just this page. What you confirm here is what
+  you're committing to build 9 more times.

--- a/reports/cut-salvage-audit-2026-06-11.md
+++ b/reports/cut-salvage-audit-2026-06-11.md
@@ -1,0 +1,88 @@
+# Cut Salvage Audit — 2026-06-11 (READ-ONLY)
+
+> Every file marked "Cut" (or Top-10 Cut/Merge) in `BSA-Content-Inventory-2026-06-09-REAUDIT.xlsx`, opened and read in full context. **Nothing has been deleted, moved, rewritten, or archived.** No action until Dalia approves.
+>
+> Method: each file opened and read; content value judged separately from technical quality; cross-checked against TASKS.md, docs/NEXT-SESSION.md, memory/, sitemap.xml, git history, and the current `index.html` versions where duplication was claimed.
+
+## Headline findings
+
+1. **Two "Cut" files contain unreleased, unique content** — `enhancements.html` (6 interactive features absent from the live demo) and `index-backup.html` (12 beginner explainer sections absent from the live demo). Blind deletion loses real pedagogy.
+2. **The inventory is already stale on 8 of 12 items**: 6 files already have `noindex` (the inventory's own "next step"), `monetary-alternatives.html` is already a live redirect on main, and `wealth-advisors.html` was already deleted (`685bb5dd`).
+3. **`_engine-playground.html` must not be deleted now** — NEXT-SESSION.md's T5 instructions explicitly say to re-open it as the engine API reference. Inventory "Cut" directly conflicts with the active plan.
+4. **Sitemap contradicts noindex** on 3 pages (`multi_persona_dashboard`, `persona_selector`, `ai-agents`) — they are noindexed *and* submitted to search engines. Cheap, safe fix.
+
+---
+
+## Per-file audit
+
+| # | File | Inventory reason for Cut | Actual content (after opening) | Unique value | Risk if kept public | Recommended | Salvage destination | Confidence | Dalia decides? |
+|---|------|--------------------------|--------------------------------|--------------|---------------------|-------------|---------------------|------------|----------------|
+| 1 | `paths/sovereign/stage-3/monetary-alternatives.html` | Duplicate of alternatives-to-bitcoin (Q1/V5) | **Already a 16-line noindex redirect stub on main** (`fc37bb89`) — meta-refresh + JS replace + canonical to the surviving module | Preserves inbound links/bookmarks to the old URL | None — noindexed, redirects instantly | **Keep** (as redirect; the Cut already happened correctly) | n/a | High | No |
+| 2 | `certificates/multi_persona_dashboard.html` | Generic licensing-template demo, non-BSA brand | Confirmed: 8 generic persona cards (student/parent/policymaker/educator/entrepreneur/investor/developer/journalist) + "4 example tenants" white-label pitch framing. Already noindexed. **Still in sitemap.xml** | The 8-persona taxonomy with per-persona level/time/format preferences — possible raw material for a licensing pitch, but superseded by the locked 7-segment system | Low (noindexed) but sitemap inclusion is contradictory; off-brand purple if anyone lands on it | **Archive** (graveyard) after sitemap removal — unless the institutional licensing pitch is alive, in which case rebuild branded | `_graveyard/` (monorepo) or delete after Q below | Med | **Yes** — is the white-label/licensing pitch still a live ambition? |
+| 3 | `certificates/persona_selector.html` | Same template family, wrong canonical | Confirmed: same 8 personas with 3 learning goals each; placeholder buttons. Already noindexed. **Still in sitemap.xml** | Per-persona learning-goal lists are marginally richer than #2; nothing the 7-segment Find-Your-Path doesn't cover | Same as #2 | **Archive** with #2 (same decision) | Same as #2 | Med | **Yes** — same question as #2 |
+| 4 | `ai-agents/index.html` | Internal dev tool, not public | Confirmed: BETA dashboard with buttons driving the real MCP audit-agent stack (`mcp-client.js`, `orchestrator.js`, `advanced-agents.js`) — the nightly audit loop in CLAUDE.md. Already noindexed. **Still in sitemap.xml** | It is a *working UI to live infrastructure*, not dead content | Low (noindexed); confusing if discovered; reveals internal tooling surface | **Keep Reference** — remove from sitemap; optionally move under an admin-gated path later. Do not delete a working ops tool | stays put (or `tools/`-style internal area) | High | **Yes** — keep public-but-noindexed, or restrict access? |
+| 5 | `dalia/icon-explorations.html` | Internal design review artifact | Confirmed: Phase-1 icon review (sub-project #2.7), round-2 candidates for about.html title slot + 4 Core Values cards, citing locked spec §7.4, with explicit "no icon at all" reasoning. Already noindexed | **Design-decision rationale** — documents *why* icon choices were made/rejected; review round may not be extracted anywhere else | None (noindexed, unlinked) | **Salvage then Archive** — verify the picks were implemented on about.html; extract the decision + rationale to design docs/memory, then graveyard | decision summary → `docs/superpowers/specs/` design-history note or `memory/`; file → `_graveyard/` | Med-High | **Yes** — confirm icon round-2 decisions were finalized |
+| 6 | `dalia/logo-explorations.html` | Internal design review artifact | Confirmed: the **Diamond System v2 rationale** — diamond=BSA / stroke=Dalia, what was kept from the source motif, why the system works solo and combined. Already noindexed | **The only place the locked logo convention's *reasoning* is written down.** CLAUDE.md/memory state the lock, not the why | None (noindexed, unlinked) | **Salvage then Archive** — extract rationale (≈10 lines) into `memory/` or a design-history doc, then graveyard | rationale → `memory/context/` or docs design-history; file → `_graveyard/` | High | No (salvage is unambiguous; final resting place is yours) |
+| 7 | `tools/domain-dashboard.html` | Internal admin tool, no educational content | Confirmed: domain-health dashboard shell; stat cards show "–", "Last updated: Never" — appears never wired to real data. Already noindexed, NOT in sitemap | None found — no educational content, no working data feed | None (noindexed, not in sitemap, unlinked) | **Delete** (the only near-unconditional one) — after a grep confirms no tooling/scripts reference it | n/a | Med-High | Light approval |
+| 8 | `interactive-demos/bitcoin-key-generator-visual/enhancements.html` | Dev fragment "ENHANCED FEATURES TO ADD TO MAIN FILE" | Confirmed dev fragment — **but contains 6 functions absent from the live index.html**: live SHA-256 "hash your name" playground, hash-prediction challenge, copy-to-clipboard, quiz, plus a "Bitcoin keys = house" analogy block | **Unreleased interactive features.** The hashing playground + house analogy are genuinely good beginner pedagogy. ⚠️ The quiz must NOT be merged — violates unbounded mode (no quizzes) | **INDEXABLE** (no noindex) — a broken-looking fragment is publicly crawlable | **Salvage/Merge** — port hashing playground + analogy into `index.html`, skip the quiz, then delete | `interactive-demos/bitcoin-key-generator-visual/index.html` | High | **Yes** — approve which features merge (recommend: playground + analogy; not quiz) |
+| 9 | `interactive-demos/bitcoin-key-generator-visual/index-backup.html` | "Backup duplicate confirmed in prior audit" | **NOT a pure duplicate.** The current index.html is a different, more technical rewrite (BIP39/32/44/84 flow). The backup holds 12 explainer sections absent from current: What is a Private Key, ECC explainer + curve drawing, why words instead of numbers, hashing as one-way function, key-security principles, "What You'll Learn" framing | Beginner-level conceptual explainers that the technical rewrite dropped | **INDEXABLE** — duplicate-content SEO risk + stale version publicly crawlable | **Salvage/Merge** — review the 12 sections, port keepers into index.html (or a beginner intro section), then delete + add `*-backup.html` to .gitignore | `index.html` (same demo) or a deep-dive | High | **Yes** — approve which explainers survive |
+| 10 | `youth-families/_engine-playground.html` | "Dev scratch, 0 real content → Cut ok" | 59-line harness exercising **every** engine primitive (Predict/Verify/Keep/Share/Scenario/Plan) with a clean branching demo story + live mempool.space verify. Untracked (local only) | **The only one-page demonstration of the full youth-engine API.** NEXT-SESSION.md T5 instructions: "re-open the local harness … to see the engine API in action" | None — untracked, never deployed | **Keep Reference** until T5+T6 ship. Then either commit as `docs/`-adjacent engine reference (with noindex) or delete once weeks 1–9 serve as live examples | stays local; eventual home = your call post-T5 | High | **Yes** — eventual home, but *after* T5/T6 |
+| 11 | `answers/what-is-bitcoin-self-custody.html` (Top-10 **Merge**) | Compare/merge with sovereign content | Thin programmatic-SEO page. "Quick Answer" doesn't answer the question (describes Bitcoin generally, not self-custody). Related-question links → **3 nonexistent pages**; CTA → `/bitcoin-security-review/` which **doesn't exist**. FAQPage schema present. The `answers/` dir has 13 siblings of the same generation, sitemap carries 12 `answers/` URLs | The URL/intent (high-value search query) and the FAQPage schema pattern — not the prose | **Live, indexed, broken-funnel page**: dead links + dead CTA on a custody query — credibility risk for the exact audience BSA targets | **Rebuild** (don't merge as-is): rewrite the answer in voice-spec register, point CTA at a real offer (e.g. emergency-kit or calendar-first), fix/remove dead links. Audit the 13 siblings the same way | rebuild in place | High | **Yes** — rebuild vs. cut the whole `answers/` generation |
+| 12 | `institutional/wealth-advisors.html` (Top-10 **Merge**) | URL conflict with `wealth-advisors/` dir | **File already deleted** in `685bb5dd` (canonical conflict resolved). Sitemap still lists the slash-less URL | n/a | Stale sitemap entry only | **Done** — just remove the stale sitemap entry | n/a | High | No |
+
+---
+
+## 1 · Do Not Delete Yet
+
+| File | Why |
+|------|-----|
+| `youth-families/_engine-playground.html` | Active dev dependency — NEXT-SESSION T5 says to use it; only full engine API demo |
+| `…/bitcoin-key-generator-visual/enhancements.html` | 6 unreleased features; salvage hashing playground + analogy first |
+| `…/bitcoin-key-generator-visual/index-backup.html` | 12 explainer sections absent from current demo; salvage first |
+| `dalia/logo-explorations.html` | Only written rationale for the locked Diamond System; extract first |
+| `dalia/icon-explorations.html` | Decision record possibly not extracted; verify about.html implementation first |
+| `paths/sovereign/stage-3/monetary-alternatives.html` | It IS the redirect — deleting breaks inbound links |
+| `ai-agents/index.html` | Working UI to live MCP audit infrastructure |
+| `certificates/multi_persona_dashboard.html` + `persona_selector.html` | Pending licensing-pitch decision |
+| `answers/what-is-bitcoin-self-custody.html` | Indexed page on a target query; rebuild beats delete |
+
+## 2 · Safe to Delete (no unique content value)
+
+| File | Condition |
+|------|-----------|
+| `tools/domain-dashboard.html` | Only after `grep -r domain-dashboard` confirms no script/tool references it. Never wired to data, noindexed, not in sitemap, no educational content |
+
+(That's the whole list. Everything else has salvage value, an open decision, or is already correctly handled.)
+
+## 3 · Salvage Queue (ranked by value)
+
+1. **`index-backup.html` explainer sections** → current key-generator demo. Beginner ECC/private-key/hashing explainers; directly improves a live P-audience demo.
+2. **`enhancements.html` hashing playground + house analogy** → same demo. Interactive predict-style beat; on-pedagogy. (Exclude the quiz — unbounded mode.)
+3. **`logo-explorations.html` Diamond System rationale** → `memory/` or design-history doc. Small effort, preserves locked-convention reasoning.
+4. **`icon-explorations.html` round-2 decisions** → design-history note, after confirming about.html implementation.
+5. **`persona_selector.html` per-persona learning goals** → only if licensing pitch revived; otherwise skip.
+
+## 4 · Conflicts to Reconcile
+
+1. **`_engine-playground.html`:** Inventory says Cut · NEXT-SESSION.md says "re-open the local harness" for T5 · TASKS.md C1 carries "decide playground fate" · inventory's own incubator-quarantine rule is overridden by its "dev scratch exception" — on false premises ("0 real content" is wrong; it demonstrates the entire API). **Resolution proposed: Keep Reference until T5/T6, then decide.**
+2. **noindex already done (6 files):** Inventory next-steps demand noindex for certificates ×2, ai-agents, icon/logo explorations, domain-dashboard — all already have it. Inventory is stale; re-audit agent likely saw an older tree.
+3. **Sitemap vs noindex (3 files):** `multi_persona_dashboard`, `persona_selector`, `ai-agents` are noindexed yet listed in sitemap.xml. Contradictory signals to crawlers.
+4. **`monetary-alternatives.html`:** Inventory "Cut / merge the PR" — PR already merged (`fc37bb89`); file is now the redirect and must be kept.
+5. **`wealth-advisors.html`:** Inventory "Merge / resolve conflict" — already resolved + deleted (`685bb5dd`); stale slash-less sitemap entry remains.
+6. **Quiz in `enhancements.html` vs unbounded mode:** the inventory's "merge features then delete" must exclude the quiz (CLAUDE.md: no quizzes).
+7. **`answers/` generation:** sitemap carries 12 `answers/` URLs; the audited one has dead links + dead CTA; 13 siblings unaudited. Inventory only flagged one for Merge.
+8. **TASKS.md C3 note (this week):** flagged the playground reconciliation — superseded by this audit's resolution proposal.
+
+## 5 · Proposed next batch (read-only / archive-only — awaiting approval)
+
+No deletions. In order:
+
+1. **Sitemap hygiene (edit, no content change):** remove `multi_persona_dashboard`, `persona_selector`, `ai-agents`, and stale `wealth-advisors` (slash-less) entries from sitemap.xml.
+2. **Add noindex to the 2 indexable fragments** (`enhancements.html`, `index-backup.html`) so stale content stops being crawlable *while* salvage is pending.
+3. **Salvage extraction (new files only):** Diamond System rationale → memory/design-history; icon round-2 decision note (after about.html verification).
+4. **Salvage merge proposals as branches** (not merged without review): key-generator explainers + hashing playground.
+5. **Archive moves to `_graveyard/`** — only after items 3–4 land and you approve each file individually.
+6. **Decide-with-Dalia queue:** licensing pitch (certificates ×2) · ai-agents access model · `answers/` rebuild-vs-cut · index-backup section picks.
+
+---
+*Audit was read-only. No file was deleted, moved, rewritten, archived, or noindexed during this audit.*

--- a/reports/repo-audit-2026-06-08.md
+++ b/reports/repo-audit-2026-06-08.md
@@ -1,0 +1,196 @@
+# Bitcoin Sovereign Academy — Full Repository Audit
+
+> Read-only audit, 2026-06-08. No files changed. Objective: a cleaner, more focused, more profitable site — not a more feature-rich one.
+> Method: codebase map (`.ca/map.md`) + the 208-page scored content inventory (`reports/bsa-content-inventory-2026-06-08.xlsx`) + 5 parallel evidence-based scans (dead code, link graph, unused assets, path strategy, conversion/homepage). Link graph honored `vercel.json` `cleanUrls` + rewrites (a naive disk checker over-reports ~245 false breaks).
+
+---
+
+## Executive summary — the 8 highest-leverage moves
+
+| # | Move | Type | Why it matters |
+|---|------|------|----------------|
+| 1 | **Fix the broken revenue links** — `field-manual/`, `learn/self-custody-master/`, `tools/multisig-demo/` are linked from all 3 paid-kit pages and **404** | Critical / Revenue | The money pages point at pages that don't exist |
+| 2 | **Reframe the homepage hero to the positioning** — it reads "learn Bitcoin," not "custody & inheritance for families and advisors"; **no bilingual affordance at all** | Revenue / Positioning | The #1 entry point contradicts the locked identity |
+| 3 | **Collapse 7 learning paths → 3 + 1 essay collection** (merge Hurried into Curious; demote Principled + Builder) | Consolidation / UX | Kills the system's biggest redundancy and refocuses on the funnel |
+| 4 | **Finish Sovereign's 3 live "Content in development" stage indexes** (incl. Inheritance) | Critical | A credibility leak on the single most monetizable, on-positioning path |
+| 5 | **Add products / youth-families / programa-colombia / institutional to `sitemap.xml`** (3 months stale, omits all of them) | Revenue / SEO | The monetization pages and the entire LATAM surface are invisible to search |
+| 6 | **Correct the stale "Dead Code" note in `CLAUDE.md` + memory** before anyone acts on it | Critical / Safety | It lists live checkout JS as "dead" — deleting per the note breaks payments |
+| 7 | **Delete the confirmed dead assets** (~17 JS + 3 CSS + all untracked backups/mockups) | Deletion / Maintenance | ~360 KB of dead code; 3 parallel header-config files are a foot-gun |
+| 8 | **Give the homepage + 88 dead-end education pages one next step each** (capture or offer) | Revenue / UX | The widest part of the funnel currently leaks |
+
+---
+
+## 1. Critical fixes (do first — broken/blocking)
+
+1. **Paid-kit dead links (revenue-blocking).** All three `products/*` pages link to pages that 404:
+   - `products/self-custody-starter-kit/` → `/field-manual/` and `/learn/self-custody-master/`
+   - `products/advisor-bitcoin-client-kit/` → `/field-manual/?tier=advisor`
+   - `products/family-bitcoin-recovery-kit/` → `/tools/multisig-demo/` (a real multisig demo exists at `/paths/sovereign/stage-2/module-1.html` — the link points at a dead path)
+   → Build the targets or repoint the links. These are on the pages where money changes hands.
+
+2. **`bitcoin-security-review/` — 16 broken inbound links** (highest-fanout missing target). Every `answers/*` page + `articles/bitcoin-complete-guide.html` links to it; it doesn't exist. Create it or redirect.
+
+3. **`answers/` cluster — ~90 broken links from slug truncation.** Files saved with truncated slugs; cross-links use the full slug. Regenerate filenames to match (or fix the generator) + create the 7 missing topic pages (`what-is-a-seed-phrase`, `how-to-set-up-hardware-wallet`, `bitcoin-inheritance-planning`, …). Clears the majority of the 112 broken links in one pass.
+
+4. **`paths/pragmatist/stage-1` nav chain is broken.** module-1 "next" and module-3 links point to bogus root-absolute URLs (`https://bitcoinsovereign.academy/module-1.html`), so **modules 2 & 4 are unreachable** — a learner literally cannot progress. (Pragmatist is slated for demotion anyway, but this is a live break today.)
+
+5. **Sovereign ships drafts in production.** `paths/sovereign/stage-2/index.html`, `stage-3/index.html`, `stage-4/index.html` show "▇ Content in development" placeholders — including **Inheritance Planning**, the heart of the positioning. Finish or hide until ready.
+
+6. **Stale "Dead Code" memory is dangerous.** `CLAUDE.md` + `MEMORY.md` list `js/checkout.js` and `js/stripe-checkout.js` as "superseded by /api/pay," but both are still `<script>`-loaded by live pages (`checkout.html`, `membership.html`, `membership-success.html`). The `gemini-*` files are also live (the Claude tutor aliases `window.geminiService` and reuses the gemini UI). **Correct the note before any cleanup agent acts on it.**
+
+---
+
+## 2. Revenue opportunities (ranked)
+
+1. **Surface the actual positioning on the homepage.** Hero says "Bitcoin education, without the confusion" / title "Learn Bitcoin." "Families" and "advisors" appear nowhere above the fold; custody/inheritance only as a mid-sentence list item. The meta description is on-positioning but the visible hero isn't. Rewrite the hero around custody + inheritance + a clear families/advisors split. (See §5.)
+2. **Open the advisor on-ramp.** The advisor/family value prop is half the positioning, but the only booking CTA (`meetings.hubspot.com/dalia-platt`) is buried in the Institutional dropdown. Put a "For Advisors" / "Book a custody consult" path in the main flow.
+3. **Make the site bilingual where it claims to be.** Homepage is `lang="en"`, no `hreflang`, no switcher, no link to `/programa-colombia/` or `/es/`. A LATAM visitor gets zero Spanish signal on the front door. Add a language switcher + hreflang; link the Colombia program.
+4. **Fix SEO discoverability of money + LATAM pages.** `sitemap.xml` (stale, Mar 8) omits **all 3 kits, youth-families, programa-colombia, institutional**. Regenerate it. Free revenue/traffic.
+5. **Continue the kit-routing layer (PR #55) but go wider.** Even with PR #55, only ~20 of 145 education pages link to a kit. The DIY self-custody → $49-kit pattern is proven; extend it (script-driven) to the rest of the eligible pages.
+6. **Re-add email capture to the homepage.** Capture is on 177 pages — but not the #1 entry point (removed 2026-05-02). The highest-traffic page has the weakest capture.
+7. **Resolve the membership-vs-kit muddle.** Membership tiers (Free / Sats-earn-back ~$37 / Sovereign Lifetime $399) still carry pre-"unbounded-mode" badge/earn-back framing that conflicts with the no-badges convention and competes with the cleaner one-time kits. Pick the primary monetization spine (recommend: kits + advisor consults; demote earn-back).
+
+---
+
+## 3. Conversion map
+
+```
+ENTRY (SEO/social)                AWARENESS            EDUCATION (70% of site)        CAPTURE              OFFER                     CONVERSION
+─────────────────                 ─────────            ──────────────────────        ───────              ─────                     ──────────
+Homepage (no capture, generic) ─┐  7 path landings ──┐  ~110 path modules ──────────┐  email-capture on    kits linked from        3 kit pages
+50 demos (strong SEO) ──────────┤  demo catalog ─────┤  50 demos ───────────────────┤  177 pages + exit-   8 pages (main) /         + onramp-chooser
+10 deep-dives ──────────────────┤  (route inward,    │  10 deep-dives               │  intent modal        ~20 (PR #55)             + 2 path modules
+youth-families (DEAD END) ──────┘   rarely to offers) │                              │  (NOT on homepage)   membership (muddy)       = 6 of 208 pages
+programa-colombia (orphan,                            │  88 pages: no offer,         │                      advisor booking:         convert
+ not in sitemap) ─────────────────────────────────────┘  no next step ──────────────┘                      1 dropdown link only
+```
+
+**Entry points:** homepage, 50-demo catalog (strongest indexed surface), 7 path landings, deep-dives. **Email capture:** broadly deployed (177 pages, `/api/subscribe`, local store; Substack URL blank) — but absent on the homepage. **Membership:** 3 tiers via `membership.html` + 2-section free gate (`js/module-gate.js`). **Products:** 3 kits ($49 / $149 / $499), card + Lightning, in the homepage "Kits" dropdown but thinly linked from content. **Advisor:** 17 "Adviser Referral" pages + a single HubSpot booking link in the Institutional dropdown; family kit correctly frames TBA collaborative custody (not an upsell). **Conversion stage:** only **6 of 208 pages**.
+
+**Biggest leaks:** (a) `youth-families/index.html` — zero capture/offer/next-step on a named entry page; (b) homepage — no capture, no bilingual, generic hero; (c) 88 education pages with no offer; (d) sitemap omits the money + LATAM surfaces.
+
+---
+
+## 4. Learning-path evaluation → consolidate 7 to 3 (+1 collection)
+
+Business-value engines: **Curious** (Q3.87 / BV4.70) and **Sovereign** (Q3.39 / BV4.26) map straight to the priority funnels. **Builder** (BV2.83) and **Principled** (BV3.00) are the lowest value and off the custody/advisor core.
+
+**Overlap matrix (High cells):** Curious↔Hurried = **High** (identical beginner job, only pacing differs — the system's strongest redundancy). Curious↔Sovereign / Curious↔Pragmatist / Hurried↔Pragmatist / Builder↔Sovereign = Med.
+
+| Path | Verdict | Rationale |
+|------|---------|-----------|
+| **Curious** | **Keep — flagship** | Best-scored, only bilingual path, the beginner funnel. Strip gamification (6 badge/% flags). |
+| **Sovereign** | **Keep — core, finish drafts** | The positioning made literal (custody/inheritance/multisig). Crown-jewel assets (collaborative-security Q5, scam-defense, proofs-not-promises). Fix 3 draft stage indexes. |
+| **Hurried** | **Merge into Curious** as a "Fast Track" pace | High overlap; keep the BV-4.12 content, drop the standalone path. |
+| **Pragmatist** | **Simplify / fold** | Lowest quality (3.27); fold generic modules into Curious, keep ~3 business-owner modules as a lens. Rewrite `bank-friction` (Q2). |
+| **Principled** | **Demote to a deep-dives essay collection** | High-quality but off-core (BV3.00, teaches no custody). Keep content, pull from the primary path lineup. |
+| **Skeptic** | **Keep but reposition** as a top-of-funnel objection hook that routes into Curious | Unique job (myth-rebuttal); thin funnel footprint. |
+| **Builder** | **Demote — maintain only** | Developer funnel = non-priority; lowest BV (2.83); heaviest gamification debt. Keep live, stop investing. |
+
+**End state: Curious (beginner, bilingual) + Sovereign (family/advisor/custody) + Skeptic (awareness hook) + a Deep-Dives essay collection (Principled + the 3 Pragmatist business modules). Builder demoted to maintain-only.**
+
+---
+
+## 5. Homepage: gaps vs positioning + recommended architecture
+
+**Positioning:** *"Bitcoin custody and inheritance for families and advisors. Bilingual. LATAM-fluent."*
+
+**Gaps found:** generic hero ("learn Bitcoin"); no "families"/"advisors" above the fold; **no bilingual/ES affordance at all**; two split primary CTAs (`/start-simple.html` vs `/start/`); generic `<title>`; advisor on-ramp buried; 6 nav items → 17 dropdown links with a Learn/Paths taxonomy overlap; `/programa-colombia/` linked from neither homepage nor sitemap. Positives: the "Find Your Path" widget is a clean progressive 2-question flow (not 7-options overload); readability/design tokens are on-brand; mobile nav is ARIA-wired.
+
+**Recommended homepage architecture (single-decision, audience-routed):**
+
+```
+[ Language switcher EN | ES ]  ← top-right, persistent (positioning requirement)
+
+HERO (one promise, on-positioning)
+  H1: "Protect your Bitcoin — and pass it on."
+  Sub: Custody, recovery, and inheritance for families and advisors. Bilingual. LATAM-fluent.
+  ONE primary CTA + one audience split:
+    → "I hold my own Bitcoin"  (families/self-custody → Sovereign path + Self-Custody Kit)
+    → "I advise clients"        (advisors → consult booking + Advisor Packet)
+
+TRUST STRIP: Don't Trust, Verify · No personal data · Open source · TBA collaborative custody
+
+3 DOORS (not 7 paths, not 6 dropdowns):
+  1. Learn Bitcoin (Curious, bilingual)      → beginner funnel
+  2. Secure & inherit it (Sovereign)         → family custody + kits
+  3. For advisors                            → consult + Advisor Packet
+
+PROOF: interactive demos (the strongest SEO surface) — 3 featured + "see all"
+EMAIL CAPTURE (re-add): one honest offer (e.g. the scam-defense / verify checklist lead magnet)
+FOOTER: Created by Dalia · bilingual · Colombia program link
+```
+
+Collapse the 5 dropdowns to **3 doors + a thin utility nav**. Kill the Learn/Paths taxonomy overlap. Surface the kits and the Colombia program. Make the bilingual switch the first thing a LATAM visitor sees.
+
+---
+
+## 6. UX simplifications
+
+- **Nav:** 6 items / 17 dropdown links → 3 doors + utility. Remove the Learn-vs-Paths duplication.
+- **One start flow, not two:** `/start-simple.html` and `/start/` both exist as "start" CTAs — pick one.
+- **Strip gamification platform-wide** to honor unbounded mode: 14 badge/"X Modules Completed"/"% Progress"/"Congratulations!" instances, concentrated in Curious (6) and Builder (5), plus the membership earn-back framing.
+- **Give interactive demos a forward step:** 24 of 26 dead-end pages are demos — they have a JS back-link but no "next demo / back to your path" CTA. (The kit-routing PR #55 already adds one to ~10; extend to the rest.)
+- **Fix the ~19 "crypto"-blur term instances** flagged across paths (no-crypto-blur convention).
+
+---
+
+## 7. Content consolidations (merge, with redirects)
+
+- `paths/sovereign/stage-3/alternatives-to-bitcoin.html` (45KB) **↔** `monetary-alternatives.html` (28KB) — same topic → **merge**.
+- `deep-dives/first-principles/original-question-everything.html` (132KB) **↔** `first-principles/index.html` (136KB) — near-identical journey → **merge** (also a dead-end + orphan).
+- `deep-dives/philosophy-economics/time-preference.html` (thin) **↔** `austrian-economics/time-preference-fundamentals.html` (deeper) → **merge**.
+- `interactive-demos/sat-stacking-calculator/` **↔** the stronger DCA calculator → **merge**.
+- 7 truncated/missing `answers/*` topics → consolidate the generator output.
+
+---
+
+## 8. Recommended deletions (3 confidence tiers)
+
+**SAFE (untracked, gitignored, zero refs):**
+- All 21 `*.backup` files (root + `interactive-demos/*/` + `community/`, `fsa/`)
+- `apps/` (stale `.html.backup` snapshot dir), the `… _files/` "Save Page As" dir
+- `_compare-*.html` (3), `_mockup-sovereign-style.html`, `youth-families/_engine-playground.html`
+- `interactive-demos/bitcoin-key-generator-visual/index-backup.html` + `enhancements.html`
+- Confirmed-dead JS: `js/bitcoin-data-fallback.js`, `js/bitcoin-data-simple.js`, `mcp-integration/agent-bridge.js`
+- **Confirmed-dead JS (zero refs, no runtime loader)** — ~17 files / ~328KB: `ab-home.js`, `dynamic-content.js`, `i18n.js`, `learning-path.js`, `learning-path-navigator.js`, `link-normalizer.js`, `mcp-content-loader.js`, `mcp-service.js`, `mobile-interactions.js`, `onboarding-flow.js`, `payment-access-control.js`, `site-nav.js`, `widgets/quiz.js`, and the dead pair `path-bsa-brand-fix.js` + `css/path-bsa-brand-fix.css`
+- **Confirmed-dead CSS:** `css/homepage-bsa-brand-fix.css`, `css/onboarding-flow.css`
+
+**PROBABLY (tracked, unreferenced — verify intent):**
+- Root `dashboard.html` (an orphan "Productivity" page unrelated to BSA), `0001-*.patch`, `_headers` (stale Netlify config Vercel ignores), `vercel-subdomain.json` ("backup"), `vercel-security.json` + `nginx-security.conf` (generator outputs, not deployed)
+- ~37 root-level report `.md` files (CONTENT_AUDIT_*, DATABASE_* ×4, SECURITY_* ×3, DEPLOYMENT_* ×3, …) → triage into `docs/archive/`, not the repo root
+
+**NEEDS-REVIEW (decide the page first, then the asset):**
+- `checkout.html` + `js/checkout.js` (page is orphaned; product pages moved to `/assets/snippets/kit-checkout.js`)
+- `js/stripe-checkout.js` (LIVE on membership pages — retire only if you retire the Stripe-on-membership flow)
+- `ai-agents/index.html` + `mcp-integration/mcp-client.js` (page orphaned; script still referenced by it)
+- `js/widgets/network-stats.js` + `news-ticker.js` (only on `tests/widget-demo.html`), `js/gemini-service.js` (only on `admin/content-generator.html`)
+- ⚠️ **Do NOT delete** `start-simple.html` — it's a live homepage CTA target. **Do NOT delete** `js/membership-btcpay.js` or `css/youth-engine.css` — runtime-injected, live.
+
+**Maintenance risk to fix:** three parallel header configs (`vercel.json` = authoritative; `_headers` = dead Netlify; `nginx-security.conf` = dead nginx). `tools/security-headers.js` regenerates `vercel-security.json` + `nginx-security.conf` into the root — so running it spawns stale duplicates. Consolidate to `vercel.json`.
+
+---
+
+## 9. Unused JS / CSS (summary)
+
+~17 JS files (~328KB) and 3 CSS files (~32KB) confirmed dead (no `<script>`/`<link>`, no runtime loader, not referenced by another JS). Largest payoff: `onboarding-flow.js` (40K), `learning-path.js` (40K), `mobile-interactions.js` (36K). **Watch-outs (do not delete):** `membership-btcpay.js` (injected by `lightning-payment.js`), `youth-engine.css` (`document.write`), `widgets/api-handler.js` (loaded by widget JS). **Mismatch to check:** `css/dynamic-content.css` is linked by `index.html` but its companion `js/dynamic-content.js` is dead — screenshot the homepage to see if the CSS styles anything live before keeping. Full file-by-file table in the agent findings.
+
+---
+
+## 10. Broken links / missing / orphans (counts)
+
+- **112 broken internal links → 27 distinct missing targets** (≈90 in the `answers/` cluster). Plus 3 broken assets (incl. `dalia/index.html` → its own missing `profile.jpg`).
+- **27 missing pages** — top: `bitcoin-security-review/` (16 inbound), 7 `answers/*` topics, `field-manual/`, `learn/self-custody-master/`, `tools/multisig-demo/`, `guides/` index.
+- **50 orphaned pages** — concerning content orphans: `articles/bitcoin-complete-guide.html`, `deep-dives/bitcoin-capital/bitcoin-backed-loans.html`, `paths/sovereign-journey-intro.html`, `programa-colombia/semana-1/` + `experimento-dos-economias/`, the 4 `guides/*` pages, several `institutional/*`. (Admin/cert/utility orphans are intentional.)
+- **26 dead-end content pages** (no forward link) — 24 are interactive demos; 17 confirmed "none found" Primary CTA in the inventory.
+
+---
+
+## Suggested sequencing
+
+**Week 1 (stop the bleeding):** §1 critical fixes — kit dead links, `bitcoin-security-review`, pragmatist nav, sovereign drafts, correct the dead-code memory. Regenerate `sitemap.xml`.
+**Week 2 (focus):** Homepage hero + bilingual switch + 3-door nav (spec-first, A–D mockups per the locked convention — do not code blind). Merge Hurried→Curious; demote Principled/Builder.
+**Week 3 (profit):** Extend kit-routing; re-add homepage capture; open the advisor on-ramp; strip gamification.
+**Ongoing:** deletions (SAFE tier first), content merges, root-dir triage.
+
+*All recommendations stop at the plan. No site changes made.*

--- a/youth-families/_engine-playground.html
+++ b/youth-families/_engine-playground.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Youth Engine Playground (dev)</title>
+  <style>
+    :root { --dark-bg:#16181c; --card-bg:#101010; --border-color:#2a2a2a; --text-primary:#F7F7F2; --text-secondary:#b3b3b3; --primary-orange:#FF7A00; --success:#28a745; }
+    body { background:#16181c; color:#F7F7F2; font-family:'Inter',system-ui,sans-serif; max-width:760px; margin:0 auto; padding:2rem 1.25rem 6rem; line-height:1.6; }
+    h1 { font-size:1.6rem; } h2 { font-size:1.15rem; margin-top:2rem; color:#FF7A00; }
+    .dev-actions { display:flex; gap:.5rem; flex-wrap:wrap; margin:.5rem 0 1rem; }
+  </style>
+  <link rel="stylesheet" href="/css/youth-engine.css">
+</head>
+<body class="bsa-skin">
+  <h1>Youth Engine Playground <span style="color:#b3b3b3;font-size:.8rem">(dev harness — not linked)</span></h1>
+  <p class="yf-muted">Exercises every PREDICT→VERIFY→KEEP→SHARE primitive + the scenario engine + Week-10 plan aggregator.</p>
+
+  <h2>① Predict</h2>
+  <div class="yf-predict" data-key="yf-w3-predict" data-question="A $120 game, saving $15/week — how many weeks until you can buy it?" data-unit="weeks"></div>
+  <div class="dev-actions"><button class="yf-btn" onclick="YouthLoop.reveal('yf-w3-predict', 8, {unit:'weeks', note:'$120 ÷ $15 = 8 weeks. The wait is the cost.'})">▶ Trigger reveal (actual = 8)</button></div>
+
+  <h2>② Verify</h2>
+  <div class="yf-verify" data-claim="about 19.9 million bitcoin exist right now" data-live="supply" data-source="mempool.space (live)"></div>
+
+  <h2>③ Keep (artifact)</h2>
+  <div class="dev-actions">
+    <button class="yf-btn" onclick="YouthArtifact.save('yf-w3-goal', {goal:'Nintendo Switch', cost:'$120', weekly_save:'$15', target_weeks:'8'})">▶ Save a Savings-Goal artifact</button>
+  </div>
+  <div class="yf-artifact" data-key="yf-w3-goal" data-title="My Savings Goal"></div>
+
+  <h2>④ Share (pass-the-phone)</h2>
+  <div class="yf-share" data-key="yf-w3-share" data-prompt="Show a parent your savings goal. Ask them: what did YOU save up for at my age, and how long did it take?"></div>
+
+  <h2>⑤ Scenario (branching)</h2>
+  <div class="yf-scenario" data-graph="demoStory" data-start="intro"></div>
+
+  <h2>⑥ Week-10 Plan aggregator</h2>
+  <div class="yf-plan"></div>
+
+  <script>
+    window.demoStory = {
+      intro: {
+        text: '<p class="story-text">You get $40 for your birthday. A game you want is $35.</p><p class="story-text">What do you do?</p>',
+        choices: [
+          { title: 'Buy the game now', desc: 'You want it. Treat yourself.', next: 'spend' },
+          { title: 'Save $20, spend $20', desc: 'A little of both.', next: 'split' }
+        ]
+      },
+      spend: { outcome: 'mixed', title: 'You bought it', text: '<p>Fun for a week. Two weeks later your friend wants to split a $25 pizza — and you have $5.</p>',
+        learning: ['Spending it all leaves no buffer for the next choice.', 'Every yes to one thing is a no to another — that is opportunity cost.'] },
+      split: { outcome: 'good', title: 'You kept a buffer', text: '<p>You still got something you wanted AND had $20 when the pizza came up.</p>',
+        learning: ['Saving part of every windfall keeps future options open.', 'You did not predict the pizza — a buffer protects you from surprises.'] }
+    };
+  </script>
+  <script src="/js/bitcoin-data-reliable.js"></script>
+  <script src="/js/youth-engine.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What

Salvages **5 feature-only files** that lived solely on `feature/jurisdictional-exposure-audit` so they aren't lost when that branch is retired. **Pure additions** — no existing file is modified, so none of the live deep-dives / account / TBA-inversion / path-landmark fixes (#116–#128) are touched.

## Why this branch, not a merge

Triage of `feature/jurisdictional-exposure-audit` (9 commits since it diverged 2026-06-16) found:
- The **JEA system + free-deep-dives gates are already 100% on `main`** (brought forward via #127). Net diff = empty.
- Almost everything else on the branch is **stale** — `deep-dives/**`, `css/deep-dive-brand.css`, `account.html` (re-adds the removed subscription dashboard), `collaborative-security.html` (pre-#121 inversion), ~40 path files (revert the `<main>` landmark fix #116). A blind merge would revert #116, #117, #121, #122–#128.

So instead of merging, only the genuinely-new, zero-risk reference/planning docs are extracted.

## Files

| File | Why keep |
|---|---|
| `reports/repo-audit-2026-06-08.md` | MEMORY.md already cites it as if on main; it never landed |
| `reports/cut-salvage-audit-2026-06-11.md` | Per-file read of every "Cut" candidate; open decisions pending |
| `docs/superpowers/specs/2026-06-09-youth-front-door-redesign-design.md` | Youth front-door redesign spec, awaiting sign-off |
| `docs/superpowers/validation/2026-06-08-week3-validation-packet.md` | Week-3 validation plan before replicating to 9 weeks |
| `youth-families/_engine-playground.html` | Cut-salvage audit explicitly protects it as the T5 engine reference (served, unlinked draft) |

**Held back:** `youth-families/_redesign-mockups/{decision,layouts}.html` — served HTML scratch superseded by the spec above; left on the branch (recoverable until retirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)