### PR TITLE
fix(bitcoin-capital): Ledn truth-reconcile, de-green, footers, mortgages sources

### DIFF
--- a/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Bitcoin-Backed Loans: A First-Principles Deep Dive | Bitcoin Sovereign Academy</title>
-<meta name="description" content="Centralized Bitcoin-only lending — providers, structures, and how to pick the right product. Comparative analysis of 9 lenders, hedge misconception decoded, options strategies comparison.">
+<meta name="description" content="Centralized Bitcoin-only lending, providers, structures, and how to pick the right product. Comparative analysis of 9 lenders, hedge misconception decoded, options strategies comparison.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/bitcoin-capital/bitcoin-backed-loans.html">
 <meta property="og:title" content="Bitcoin-Backed Loans: A First-Principles Deep Dive">
 <meta property="og:description" content="Pick the right BTC lender for your situation. 9 providers compared. Math-driven decision framework.">
@@ -16,7 +16,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Bitcoin-Backed Loans: A First-Principles Deep Dive",
-  "description": "Comparative analysis of centralized Bitcoin-only lending — 9 providers, custody architectures, hedge analysis, options strategies.",
+  "description": "Comparative analysis of centralized Bitcoin-only lending, 9 providers, custody architectures, hedge analysis, options strategies.",
   "author": { "@type": "Organization", "name": "Bitcoin Sovereign Academy" },
   "publisher": { "@type": "Organization", "name": "Bitcoin Sovereign Academy" },
   "datePublished": "2026-05-11",
@@ -191,11 +191,11 @@
   .part p { color: var(--dim); margin-bottom: 1.1rem; max-width: 70ch; }
   .part p strong { color: var(--light); font-weight: 600; }
   .part p em { color: var(--primary-soft); font-style: italic; }
-  .part ul, .part ol {
+  .part ul .part ol {
     color: var(--dim); margin-left: 1.5rem;
     margin-bottom: 1.25rem; max-width: 68ch;
   }
-  .part ul li, .part ol li { margin-bottom: 0.5rem; }
+  .part ul li .part ol li { margin-bottom: 0.5rem; }
   .part code {
     font-family: var(--mono); font-size: 0.86em;
     background: var(--dark3); padding: 0.15em 0.4em;
@@ -224,7 +224,7 @@
     overflow: hidden;
     font-size: 0.88rem;
   }
-  .data-table th, .data-table td {
+  .data-table th .data-table td {
     padding: 0.7rem 0.9rem;
     border-bottom: 1px solid var(--border);
     text-align: left;
@@ -346,9 +346,9 @@
     overflow-x: auto;
     white-space: pre;
   }
-  .ascii-tree .root, .ascii-tree .start { color: var(--primary); font-weight: 600; }
+  .ascii-tree .root .ascii-tree .start { color: var(--primary); font-weight: 600; }
   .ascii-tree .branch { color: var(--light); font-weight: 600; }
-  .ascii-tree .leaf, .ascii-tree .answer { color: var(--muted); }
+  .ascii-tree .leaf .ascii-tree .answer { color: var(--muted); }
   .ascii-tree .yes { color: var(--primary); }
   .ascii-tree .no { color: var(--red); }
 
@@ -365,7 +365,7 @@
 
   @media (max-width: 768px) {
     .header-nav { display: none; }
-    .container, .container-narrow { padding: 0 1rem; }
+    .container .container-narrow { padding: 0 1rem; }
     .hero { padding: 3rem 1rem 2rem; }
     section.part { padding: 3rem 0; }
     .provider-card { padding: 1.5rem; }
@@ -403,7 +403,7 @@
   <div class="disclosure-inner">
     <span class="disclosure-icon">ⓘ</span>
     <div class="disclosure-text">
-      <strong>Heads-up before you read.</strong> BSA's founder Dalia advises at The Bitcoin Adviser (TBA), the company behind <strong>Loan My Coins</strong> — one of the nine BTC-backed lenders compared in this piece. We've made a deliberate choice to scrutinize LMC the same way we scrutinize every other product, including pointing out where it isn't the right fit. The math is the math regardless of who built the product.
+      <strong>Heads-up before you read.</strong> BSA's founder Dalia advises at The Bitcoin Adviser (TBA), the company behind <strong>Loan My Coins</strong>, one of the nine BTC-backed lenders compared in this piece. We've made a deliberate choice to scrutinize LMC the same way we scrutinize every other product, including pointing out where it isn't the right fit. The math is the math regardless of who built the product.
     </div>
     <button class="disclosure-dismiss" id="disclosure-dismiss" aria-label="Dismiss disclosure">Dismiss ×</button>
   </div>
@@ -418,7 +418,7 @@
   </div>
   <div class="eyebrow">A First-Principles Deep Dive</div>
   <h1>A Bitcoin-backed loan is not one product. <span>It's a bundle of trade-offs.</span></h1>
-  <p class="lede">Denomination, custody, rehypothecation, margin risk, tax timing, and human behavior — every BTC-backed loan involves all of them. The loan that looks cheapest can be the most expensive mistake. This deep dive gives you the framework, the modeled math, and a decision tree so you can match a product to your situation.</p>
+  <p class="lede">Denomination, custody, rehypothecation, margin risk, tax timing, and human behavior, every BTC-backed loan involves all of them. The loan that looks cheapest can be the most expensive mistake. This deep dive gives you the framework, the modeled math, and a decision tree so you can match a product to your situation.</p>
   <div class="hero-meta">
     <span><strong>~30 min</strong> read</span>
     <span><strong>14 sections</strong></span>
@@ -435,7 +435,7 @@
   </div>
 </section>
 
-<!-- PART I — ONTOLOGY -->
+<!-- PART I, ONTOLOGY -->
 <section class="part" id="ontology">
   <div class="container-narrow">
     <div class="part-label">Part I · Ontology</div>
@@ -444,27 +444,27 @@
     <ol>
       <li><strong>The loan denominator.</strong> What is the borrower's obligation denominated in? If it's USD, the borrower owes a fixed dollar amount and the collateral's USD value is the variable that creates margin-call dynamics. If it's BTC, the obligation is in BTC and price-based liquidation is mathematically impossible.</li>
       <li><strong>The custody model.</strong> Who holds the keys to the pledged Bitcoin during the loan term? This single choice determines whether the borrower is a creditor with claims (pooled lender custody) or a co-owner with cryptographic veto power (multisig with borrower-held key). 2022 made the cost of getting this wrong unambiguous.</li>
-      <li><strong>The rehypothecation policy.</strong> Can the lender lend out the pledged collateral while the loan is outstanding? This is one of the structural features that figured prominently in the 2022 failures of Celsius, BlockFi, Voyager, and Genesis — collateral that was supposed to back loans got pulled into counterparty cascades. (Each of those failures had its own specific triggers — 3AC exposure, FTX/Alameda contagion, deposit-run dynamics — so the structural pattern is more usefully read as a recurring set of vulnerabilities than a single tidy diagnosis.)</li>
+      <li><strong>The rehypothecation policy.</strong> Can the lender lend out the pledged collateral while the loan is outstanding? This is one of the structural features that figured prominently in the 2022 failures of Celsius, BlockFi, Voyager, and Genesis: collateral that was supposed to back loans got pulled into counterparty cascades. (Each of those failures had its own specific triggers (3AC exposure, FTX/Alameda contagion, deposit-run dynamics), so the structural pattern is more usefully read as a recurring set of vulnerabilities than a single tidy diagnosis.)</li>
     </ol>
     <p>Most public coverage focuses on rates and LTV. Those matter, but they're downstream of the three structural choices. A 9% loan from a rehypothecating lender holding your BTC in a pooled wallet is a fundamentally different product from a 14% loan with no rehypothecation and 2-of-3 multisig custody. <strong>Comparing them on rate alone is the kind of mistake the 2022 cohort's customers made.</strong></p>
     <p>The remainder of this deep dive treats these three axes as primary and rates/LTV as secondary.</p>
   </div>
 </section>
 
-<!-- PART II — TAXONOMY -->
+<!-- PART II, TAXONOMY -->
 <section class="part" id="taxonomy">
   <div class="container-narrow">
     <div class="part-label">Part II · Taxonomy</div>
     <h2>The map: every loan fits somewhere</h2>
     <p>Two independent design choices give us a 2×4 matrix that every BTC-backed lending product sits in cleanly.</p>
 
-    <h4>Axis 1 — Loan denominator</h4>
+    <h4>Axis 1, Loan denominator</h4>
     <ul>
       <li><strong>BTC-denominated</strong> (you pledge BTC, receive BTC, owe BTC)</li>
       <li><strong>Fiat-denominated</strong> (you pledge BTC, receive USD/USDC, owe USD)</li>
     </ul>
 
-    <h4>Axis 2 — Custody model (most to least sovereign)</h4>
+    <h4>Axis 2, Custody model (most to least sovereign)</h4>
     <ul>
       <li><strong>Self-custody DLC</strong> (borrower retains sole key authority via on-chain contracts)</li>
       <li><strong>Collaborative 2-of-3 / 3-of-4 multisig</strong> (borrower holds 1 of N keys, no single-party control)</li>
@@ -477,54 +477,54 @@
         <tr><th>Custody / Denominator</th><th>BTC-Denominated</th><th>Fiat-Denominated</th></tr>
       </thead>
       <tbody>
-        <tr><td>Self-custody DLC</td><td>—</td><td><strong>Lava</strong></td></tr>
+        <tr><td>Self-custody DLC</td><td>-</td><td><strong>Lava</strong></td></tr>
         <tr><td>Collaborative multisig</td><td><strong>LMC</strong> (2-of-3)</td><td><strong>Unchained</strong> (2-of-3), <strong>Debifi</strong> (3-of-4)</td></tr>
-        <tr><td>Qualified custodian (no rehypothecation per current public policy)</td><td>—</td><td><strong>Ledn</strong>, <strong>Arch</strong></td></tr>
-        <tr><td>Qualified custodian (rehypothecation in contract terms)</td><td>—</td><td><strong>SALT</strong></td></tr>
-        <tr><td>Exchange / hybrid / pooled</td><td>—</td><td><strong>Bitfinex</strong> (exchange), <strong>Coinbase/Morpho</strong> (hybrid wrapped)</td></tr>
+        <tr><td>Qualified custodian (no rehypothecation per current public policy)</td><td>-</td><td><strong>Ledn</strong>, <strong>Arch</strong></td></tr>
+        <tr><td>Qualified custodian (rehypothecation in contract terms)</td><td>-</td><td><strong>SALT</strong></td></tr>
+        <tr><td>Exchange / hybrid / pooled</td><td>-</td><td><strong>Bitfinex</strong> (exchange), <strong>Coinbase/Morpho</strong> (hybrid wrapped)</td></tr>
       </tbody>
     </table>
 
-    <p>The taxonomy makes one thing immediately obvious: <strong>among the providers reviewed here, LMC is the only BTC-denominated structure.</strong> Every other provider issues fiat-denominated loans, which creates margin-call dynamics by design. This is the structural reason LMC has no fiat-denominated margin calls — not generosity, mathematics. <em>(There may be private bilateral or offshore products that also denominate in BTC; this matrix covers the public retail-accessible providers.)</em></p>
+    <p>The taxonomy makes one thing immediately obvious: <strong>among the providers reviewed here, LMC is the only BTC-denominated structure.</strong> Every other provider issues fiat-denominated loans, which creates margin-call dynamics by design. This is the structural reason LMC has no fiat-denominated margin calls. Not generosity, mathematics. <em>(There may be private bilateral or offshore products that also denominate in BTC; this matrix covers the public retail-accessible providers.)</em></p>
     <p>The second observation: among reviewed providers, there is no Bitcoin-denominated, self-custody DLC option today. That looks like an obvious gap. I would not be surprised if someone tries to fill it soon.</p>
   </div>
 </section>
 
-<!-- PART III — LANDSCAPE -->
+<!-- PART III, LANDSCAPE -->
 <section class="part" id="landscape">
   <div class="container-narrow">
     <div class="part-label">Part III</div>
     <h2>The 2026 provider landscape</h2>
     <p>Nine providers worth knowing, organized by depth of treatment.</p>
 
-    <h4>Tier 1 — Four distinct structural archetypes (deep coverage)</h4>
+    <h4>Tier 1, Four distinct structural archetypes (deep coverage)</h4>
     <ul>
-      <li><strong>Ledn</strong> — BTC-for-fiat, qualified custodian, regulated mainstream</li>
-      <li><strong>Unchained Capital</strong> — BTC-for-fiat, collaborative multisig, sovereignty-leaning centralized</li>
-      <li><strong>Lava</strong> — BTC-for-fiat, self-custody DLC, newest model</li>
-      <li><strong>Loan My Coins (LMC)</strong> — BTC-for-BTC, TBA collaborative multisig, 5% upfront fee — <em>the most specialized product, presented last</em></li>
+      <li><strong>Ledn</strong>, BTC-for-fiat, qualified custodian, regulated mainstream</li>
+      <li><strong>Unchained Capital</strong>, BTC-for-fiat, collaborative multisig, sovereignty-leaning centralized</li>
+      <li><strong>Lava</strong>, BTC-for-fiat, self-custody DLC, newest model</li>
+      <li><strong>Loan My Coins (LMC)</strong>, BTC-for-BTC, TBA collaborative multisig, 5% upfront fee, <em>the most specialized product, presented last</em></li>
     </ul>
-    <p>Every other BTC-backed lender is a variant of one of these. We present them in order of mainstream familiarity to specialized use case — LMC last because it is structurally different from the other three and works in a narrower set of borrower profiles.</p>
+    <p>Every other BTC-backed lender is a variant of one of these. We present them in order of mainstream familiarity to specialized use case, LMC last because it is structurally different from the other three and works in a narrower set of borrower profiles.</p>
 
-    <h4>Tier 2 — Matrix-only coverage</h4>
+    <h4>Tier 2, Matrix-only coverage</h4>
     <ul>
-      <li><strong>Coinbase via Morpho</strong> — hybrid centralized custody + DeFi smart contract; $2.17B originated by April 2026</li>
-      <li><strong>SALT Lending</strong> — multi-asset; rehypothecation explicitly permitted in terms; longest track record (2016)</li>
-      <li><strong>Arch Lending</strong> — Anchorage Digital custody, no rehypothecation, $100M Lloyd's insurance</li>
-      <li><strong>Bitfinex Borrow</strong> — exchange margin lending; 2–120 day terms; 2016 hack precedent</li>
-      <li><strong>Debifi</strong> — non-custodial 3-of-4 multisig; institutional focus; Sygnum Bank partnership (MultiSYG, H1 2026)</li>
+      <li><strong>Coinbase via Morpho</strong>, hybrid centralized custody + DeFi smart contract; $2.17B originated by April 2026</li>
+      <li><strong>SALT Lending</strong>, multi-asset; rehypothecation explicitly permitted in terms; longest track record (2016)</li>
+      <li><strong>Arch Lending</strong>, Anchorage Digital custody, no rehypothecation, $100M Lloyd's insurance</li>
+      <li><strong>Bitfinex Borrow</strong>, exchange margin lending; 2–120 day terms; 2016 hack precedent</li>
+      <li><strong>Debifi</strong>, non-custodial 3-of-4 multisig; institutional focus; Sygnum Bank partnership (MultiSYG, H1 2026)</li>
     </ul>
 
     <h4>Out of scope and why</h4>
     <ul>
-      <li>Multi-asset crypto lenders (Nexo, Binance Loans) — dilute the Bitcoin focus</li>
-      <li>DeFi BTC lending (Sovryn Zero, flash loans) — separate deep dive eventually</li>
-      <li>Institutional undercollateralized credit (TrueFi, Maple, Goldfinch, Clearpool) — not retail-relevant</li>
+      <li>Multi-asset crypto lenders (Nexo, Binance Loans), dilute the Bitcoin focus</li>
+      <li>DeFi BTC lending (Sovryn Zero, flash loans), separate deep dive eventually</li>
+      <li>Institutional undercollateralized credit (TrueFi, Maple, Goldfinch, Clearpool), not retail-relevant</li>
     </ul>
   </div>
 </section>
 
-<!-- PART IV — PROVIDER DEEP-DIVES -->
+<!-- PART IV, PROVIDER DEEP-DIVES -->
 <section class="part" id="providers">
   <div class="container-narrow">
     <div class="part-label">Part IV</div>
@@ -534,7 +534,7 @@
     <!-- LEDN -->
     <div class="provider-card">
       <div class="provider-header">
-        <h3>Ledn — BTC-for-fiat, qualified custodian</h3>
+        <h3>Ledn, BTC-for-fiat, qualified custodian</h3>
         <div class="provider-tags">
           <span class="tag tag-fiat">Fiat-denominated</span>
           <span class="tag tag-custodian">Qualified custodian</span>
@@ -557,16 +557,16 @@
         <li>$1,000 USD-equivalent BTC minimum (calculator shows $500 floor)</li>
         <li>24-hour typical funding time after approval</li>
         <li>No credit check, no required monthly payments, no prepayment penalty</li>
-        <li>Collateral held in custody with Ledn or trusted partners — <strong>per Ledn's current public policy, never lent out to earn interest</strong></li>
+        <li>Collateral held in custody with Ledn or trusted partners, <strong>per Ledn's current public policy, never lent out to earn interest</strong></li>
         <li>Illustrative cost at $250K / 24 months at 10.99% APR (the $250K–$500K size tier): <strong>~$54,950</strong> (interest accrued, payable at maturity or any time)</li>
       </ul>
 
       <div class="callout">
-        <p><strong>What changed since earlier coverage:</strong> Some prior third-party comparisons split Ledn into "Custodied" (no rehypothecation, ~13.9% APR) and "Standard" (rehypothecation allowed, ~12.4% APR) variants. <strong>Ledn's current public page presents a single Custodied-model product</strong> with rates tiered by loan size — <strong>11.49% under $250K, 10.99% $250K–$500K, 10.49% $500K–$1M, 9.99% $1M–$2M, 9.25% $2M+</strong> (Ledn, June 2026) — and an explicit statement that collateral is "never lent out to earn interest." If you are evaluating an older quote that references the two-variant structure, verify the current product directly before signing.</p>
+        <p><strong>What changed since earlier coverage:</strong> Some prior third-party comparisons split Ledn into "Custodied" (no rehypothecation, ~13.9% APR) and "Standard" (rehypothecation allowed, ~12.4% APR) variants. <strong>Ledn's current public page presents a single Custodied-model product</strong> with rates tiered by loan size, <strong>11.49% under $250K, 10.99% $250K–$500K, 10.49% $500K–$1M, 9.99% $1M–$2M, 9.25% $2M+</strong> (Ledn, June 2026), and an explicit statement that collateral is "never lent out to earn interest." If you are evaluating an older quote that references the two-variant structure, verify the current product directly before signing.</p>
       </div>
 
       <div class="callout">
-        <p><strong>With a single no-rehypothecation model, the borrower's real job is verification, not tier-picking.</strong> Ledn states collateral is never lent out — which removes the rehypothecation risk that sank several 2022 lenders, <em>if the statement holds</em>. So the question to ask isn't "Custodied or Standard?" (that choice no longer exists) but "how is the no-rehypothecation claim evidenced?" Ledn provides periodic third-party-audited attestation, not real-time on-chain proof — so the residual single point of failure is BitGo plus Ledn's funding partner. Weigh that against the rate you're quoted, and re-confirm the current product structure directly before signing.</p>
+        <p><strong>With a single no-rehypothecation model, the borrower's real job is verification, not tier-picking.</strong> Ledn states collateral is never lent out, which removes the rehypothecation risk that sank several 2022 lenders, <em>if the statement holds</em>. So the question to ask isn't "Custodied or Standard?" (that choice no longer exists) but "how is the no-rehypothecation claim evidenced?" Ledn provides periodic third-party-audited attestation, not real-time on-chain proof, so the residual single point of failure is BitGo plus Ledn's funding partner. Weigh that against the rate you're quoted, and re-confirm the current product structure directly before signing.</p>
       </div>
 
       <div class="fit-grid">
@@ -584,25 +584,25 @@
           <ul>
             <li>Sovereignty-first priority (use multisig instead)</li>
             <li>Want zero margin-call exposure (use LMC instead)</li>
-            <li>Want to hold your own key — Ledn is a qualified-custodian model; the borrower holds no key</li>
+            <li>Want to hold your own key, Ledn is a qualified-custodian model; the borrower holds no key</li>
           </ul>
         </div>
       </div>
 
-      <p><strong>Custody:</strong> BitGo holds keys (qualified custodian, $250M insurance, audited cold storage). Borrower has no key. Proof-of-funds via periodic third-party-audited attestation, not real-time on-chain. <strong>Single point of failure: BitGo + Ledn's funding partner.</strong> Mitigated by Ledn's stated no-rehypothecation policy and custodial insurance — but evidenced by attestation, not real-time on-chain proof.</p>
+      <p><strong>Custody:</strong> BitGo holds keys (qualified custodian, $250M insurance, audited cold storage). Borrower has no key. Proof-of-funds via periodic third-party-audited attestation, not real-time on-chain. <strong>Single point of failure: BitGo + Ledn's funding partner.</strong> Mitigated by Ledn's stated no-rehypothecation policy and custodial insurance, but evidenced by attestation, not real-time on-chain proof.</p>
     </div>
 
     <!-- UNCHAINED -->
     <div class="provider-card">
       <div class="provider-header">
-        <h3>Unchained Capital — Commercial (B2B) BTC-for-fiat, collaborative multisig</h3>
+        <h3>Unchained Capital, Commercial (B2B) BTC-for-fiat, collaborative multisig</h3>
         <div class="provider-tags">
           <span class="tag tag-fiat">Fiat-denominated</span>
           <span class="tag tag-multisig">2-of-3 multisig</span>
           <span class="tag tag-custodian">Commercial / B2B</span>
         </div>
       </div>
-      <p><strong>Structurally:</strong> the sovereignty-leaning alternative to Ledn. Same fiat disbursement, same fiat-denominated margin-call dynamics, but custody is 2-of-3 multisig with the borrower holding 1 key. <strong>Note: as of late 2025/2026, Unchained pivoted from retail personal loans to a commercial (B2B) loans product</strong> — same architecture, B2B-only positioning.</p>
+      <p><strong>Structurally:</strong> the sovereignty-leaning alternative to Ledn. Same fiat disbursement, same fiat-denominated margin-call dynamics, but custody is 2-of-3 multisig with the borrower holding 1 key. <strong>Note: as of late 2025/2026, Unchained pivoted from retail personal loans to a commercial (B2B) loans product</strong>, same architecture, B2B-only positioning.</p>
 
       <h4>Publicly listed terms (as of November 2025 pricing page)</h4>
       <ul>
@@ -613,18 +613,18 @@
         <li>Interest-only monthly payments; principal due with final interest payment</li>
         <li>Funded in as little as 2 business days</li>
         <li>US only, with state restrictions</li>
-        <li>Cost at $250K / 12 months (one term): <strong>~$40,500</strong> (interest + origination). For 24 months: renewal required, adding another origination fee — ~$80K total.</li>
+        <li>Cost at $250K / 12 months (one term): <strong>~$40,500</strong> (interest + origination). For 24 months: renewal required, adding another origination fee, ~$80K total.</li>
       </ul>
 
       <div class="callout">
-        <p><strong>What changed:</strong> Unchained previously offered tiered personal loan rates (9.99%–11.49%). That product appears to have been discontinued in favor of the commercial loans positioning. <strong>If you're a retail/personal borrower, this product may no longer fit your use case</strong> — verify directly with Unchained whether a personal product is still available. Track record: <strong>$1B+ in loan originations, 1,000+ loans, zero lost bitcoin</strong> (per company claim).</p>
+        <p><strong>What changed:</strong> Unchained previously offered tiered personal loan rates (9.99%–11.49%). That product appears to have been discontinued in favor of the commercial loans positioning. <strong>If you're a retail/personal borrower, this product may no longer fit your use case</strong>, verify directly with Unchained whether a personal product is still available. Track record: <strong>$1B+ in loan originations, 1,000+ loans, zero lost bitcoin</strong> (per company claim).</p>
       </div>
 
       <div class="fit-grid">
         <div class="fit-card fit-good">
           <h4>Best fit when</h4>
           <ul>
-            <li>Business or commercial borrower (LLC, S-Corp, etc.) — the new positioning</li>
+            <li>Business or commercial borrower (LLC, S-Corp, etc.), the new positioning</li>
             <li>Loan size $150K+ (minimum is binding)</li>
             <li>Want 2-of-3 multisig with personal/company-held key authority but in a regulated US lender</li>
             <li>Existing Unchained vault customer transitioning to business needs</li>
@@ -641,24 +641,24 @@
         </div>
       </div>
 
-      <p><strong>Custody:</strong> 2-of-3 multisig — borrower + Unchained + Fortis Bank (as the key partner in the commercial product). Unchained pioneered this architecture for retail Bitcoin custody in 2017–18 and adapted it for the loan product. Battle-tested across nearly a decade of Bitcoin operations. Borrower verifies collateral on-chain at any time using a key they control.</p>
+      <p><strong>Custody:</strong> 2-of-3 multisig, borrower + Unchained + Fortis Bank (as the key partner in the commercial product). Unchained pioneered this architecture for retail Bitcoin custody in 2017–18 and adapted it for the loan product. Battle-tested across nearly a decade of Bitcoin operations. Borrower verifies collateral on-chain at any time using a key they control.</p>
     </div>
 
     <!-- LAVA -->
     <div class="provider-card">
       <div class="provider-header">
-        <h3>Lava — BTC-for-fiat, self-custody via DLC</h3>
+        <h3>Lava, BTC-for-fiat, self-custody via DLC</h3>
         <div class="provider-tags">
           <span class="tag tag-fiat">Fiat-denominated</span>
           <span class="tag tag-selfcustody">Self-custody DLC</span>
         </div>
       </div>
-      <p><strong>Structurally:</strong> the newest and most sovereignty-extreme model. Uses <strong>Discreet Log Contracts (DLCs)</strong> — Bitcoin-native smart contract constructs that let the borrower retain full key authority over the collateral. Lava never holds the keys.</p>
+      <p><strong>Structurally:</strong> the newest and most sovereignty-extreme model. Uses <strong>Discreet Log Contracts (DLCs)</strong>, Bitcoin-native smart contract constructs that let the borrower retain full key authority over the collateral. Lava never holds the keys.</p>
 
       <h4>Company-quoted terms (pending direct confirmation)</h4>
       <ul>
-        <li><strong>LTV: 50%–60%</strong> — third-party comparisons cite both figures; verification email pending direct confirmation with Lava</li>
-        <li><strong>Step-up APR</strong> starting at 5% (month 1), climbing toward 11.5% by month 12 — exact ramp schedule per Lava's public materials</li>
+        <li><strong>LTV: 50%–60%</strong>, third-party comparisons cite both figures; verification email pending direct confirmation with Lava</li>
+        <li><strong>Step-up APR</strong> starting at 5% (month 1), climbing toward 11.5% by month 12, exact ramp schedule per Lava's public materials</li>
         <li>Approximate year-1 average APR: <strong>~8%</strong> (illustrative, depends on Lava's published step schedule)</li>
         <li>$100 USD minimum (lowest in category), $1B+ ceiling</li>
         <li>Open-ended terms</li>
@@ -687,13 +687,13 @@
         </div>
       </div>
 
-      <p><strong>Custody:</strong> Self-custody DLC. Lava never has keys. Strongest proof-of-funds in the market — fully on-chain, fully transparent. <strong>The trade-off: if the borrower loses their key, BTC is permanently lost.</strong> No recovery mechanism. This is the structural cost of maximum sovereignty.</p>
+      <p><strong>Custody:</strong> Self-custody DLC. Lava never has keys. Strongest proof-of-funds in the market, fully on-chain, fully transparent. <strong>The trade-off: if the borrower loses their key, BTC is permanently lost.</strong> No recovery mechanism. This is the structural cost of maximum sovereignty.</p>
     </div>
 
-    <!-- LMC — REFRAMED: STRUCTURAL DIFFERENCE, NOT JUST A DIRECTIONAL BET -->
+    <!-- LMC, REFRAMED: STRUCTURAL DIFFERENCE, NOT JUST A DIRECTIONAL BET -->
     <div class="provider-card specialized">
       <div class="provider-header">
-        <h3>Loan My Coins (LMC) — BTC-for-BTC, collaborative multisig <span style="color:var(--yellow);font-size:0.85em;">(structurally distinct)</span></h3>
+        <h3>Loan My Coins (LMC), BTC-for-BTC, collaborative multisig <span style="color:var(--yellow);font-size:0.85em;">(structurally distinct)</span></h3>
         <div class="provider-tags">
           <span class="tag tag-btc">BTC-denominated</span>
           <span class="tag tag-multisig">2-of-3 multisig</span>
@@ -702,7 +702,7 @@
       </div>
 
       <div class="callout">
-        <p><strong>The structural fact most readers need to understand first:</strong> LMC's BTC-denominated structure removes fiat-denominated margin-call risk by mathematics. That is a real and meaningful advantage. But it does not remove all risk — it transforms it. When a borrower takes LMC and sells the received BTC for fiat, they have <strong>structurally taken a forward-short on BTC</strong>. They owe BTC at term end. Whether the borrower intends a directional bet or not, the structure embeds one. That implicit BTC price exposure over the loan term is the central thing to understand before signing.</p>
+        <p><strong>The structural fact most readers need to understand first:</strong> LMC's BTC-denominated structure removes fiat-denominated margin-call risk by mathematics. That is a real and meaningful advantage. But it does not remove all risk; it transforms it. When a borrower takes LMC and sells the received BTC for fiat, they have <strong>structurally taken a forward-short on BTC</strong>. They owe BTC at term end. Whether the borrower intends a directional bet or not, the structure embeds one. That implicit BTC price exposure over the loan term is the central thing to understand before signing.</p>
       </div>
 
       <p><strong>Structurally:</strong> among reviewed providers, LMC is the BTC-denominated product. You pledge BTC, receive 95% of pledged amount back in BTC, choose what to do with the received BTC (hold, sell for cash, use directly), and at term end deliver the original BTC amount to LMC. Original collateral is released back to you.</p>
@@ -717,7 +717,7 @@
 <strong style="color:var(--primary);">During the term:</strong>
   Borrower can hold the 9.5 BTC, or sell it for fiat, or use it
   Collateral remains locked, on-chain, verifiable
-  No margin calls — BTC price moves don't change the obligation
+  No margin calls, BTC price moves don't change the obligation
 
 <strong style="color:var(--primary);">At maturity (T=12 months, or up to 5 years via rollover):</strong>
   Borrower returns <strong style="color:var(--light);">10 BTC</strong> to LMC
@@ -733,12 +733,12 @@
 
       <h4>Publicly listed terms (as of May 2026)</h4>
       <ul>
-        <li><strong>95% disbursement against pledged BTC</strong> (behaves like 95% LTV in BTC terms — but cannot be compared casually to fiat LTV because there is no USD price-based liquidation trigger)</li>
-        <li><strong>5% fixed upfront fee</strong> deducted from disbursement — no variable interest, no compounding within a period, but <strong>fee compounds across rollover periods</strong></li>
+        <li><strong>95% disbursement against pledged BTC</strong> (behaves like 95% LTV in BTC terms, but cannot be compared casually to fiat LTV because there is no USD price-based liquidation trigger)</li>
+        <li><strong>5% fixed upfront fee</strong> deducted from disbursement, no variable interest, no compounding within a period, but <strong>fee compounds across rollover periods</strong></li>
         <li>12-month base term, <strong>rollable up to 5 years total</strong> (each roll incurs another 5% fee)</li>
         <li>1 BTC minimum</li>
         <li>Custody: TBA's 2-of-3 collaborative multisig (borrower + TBA + independent key agent)</li>
-        <li>No fiat-denominated margin calls — by structure, not policy</li>
+        <li>No fiat-denominated margin calls, by structure, not policy</li>
         <li>No rehypothecation</li>
       </ul>
 
@@ -747,7 +747,7 @@
       <ol>
         <li><strong>Liquidity without selling BTC.</strong> Like every loan in this comparison, LMC lets the borrower access value without triggering a taxable disposition. The difference: LMC denominates in BTC, so the borrower receives BTC and chooses what to do with it. This matters most for borrowers whose current cost basis would create a heavy tax bill on direct sale.</li>
         <li><strong>Liquidity without fiat-denominated margin calls.</strong> Because the obligation is denominated in BTC and the collateral is BTC, the LTV ratio does not move with BTC's USD price. The borrower never faces a Milo-style "BTC dropped 65%, post more collateral or get liquidated" event. <strong>This is the single most important structural advantage over fiat-denominated alternatives.</strong></li>
-        <li><strong>Optional tactical redeployment if BTC falls within the term.</strong> If a borrower has converted the disbursement BTC to fiat and BTC drops during the loan, the borrower can buy back BTC at a lower price than origination and end up with more BTC at term end. This is an optional secondary use that becomes interesting in drawdown scenarios — but it is not the product's primary structural purpose.</li>
+        <li><strong>Optional tactical redeployment if BTC falls within the term.</strong> If a borrower has converted the disbursement BTC to fiat and BTC drops during the loan, the borrower can buy back BTC at a lower price than origination and end up with more BTC at term end. This is an optional secondary use that becomes interesting in drawdown scenarios, but it is not the product's primary structural purpose.</li>
       </ol>
 
       <h4>The BTC price-path risk borrowers must internalize</h4>
@@ -762,7 +762,7 @@
         </tbody>
       </table>
 
-      <p>The asymmetry is genuine, but it's important to read it precisely: <strong>this is not a hedge.</strong> A hedge would have defined max loss and asymmetric payoff. The forward-short structure has unlimited downside in the rally case. The 5-year rollover option helps — borrowers can wait through a BTC rally to a more favorable repurchase moment — but every additional roll costs another 5% in BTC terms.</p>
+      <p>The asymmetry is genuine, but it's important to read it precisely: <strong>this is not a hedge.</strong> A hedge would have defined max loss and asymmetric payoff. The forward-short structure has unlimited downside in the rally case. The 5-year rollover option helps, borrowers can wait through a BTC rally to a more favorable repurchase moment, but every additional roll costs another 5% in BTC terms.</p>
 
       <h4>Cost in BTC terms over multiple rolls</h4>
       <table class="data-table">
@@ -794,21 +794,21 @@
           <ul>
             <li>30-year horizon (compounding 5% rolls become prohibitive)</li>
             <li>Strong conviction BTC will rise meaningfully within the term (the forward-short exposure works against you)</li>
-            <li>New to Bitcoin or risk-averse — the structural implications require sophisticated understanding</li>
-            <li>Wants a hedge against another mortgage's margin-call risk (LMC isn't a hedge — see Part VIII)</li>
+            <li>New to Bitcoin or risk-averse, the structural implications require sophisticated understanding</li>
+            <li>Wants a hedge against another mortgage's margin-call risk (LMC isn't a hedge, see Part VIII)</li>
             <li>High cost basis (tax deferral benefit is small; the fee dominates)</li>
           </ul>
         </div>
       </div>
 
-      <p><strong>Positioning — "Terminal Bitcoin."</strong> TBA explicitly positions LMC for the Terminal Bitcoiner — a holder who has maxed out accumulation through traditional savings, salary, and direct purchase. The framing is honest about the niche: this is not for new Bitcoiners building a position. It is for sophisticated holders past the accumulation phase who want a BTC-denominated capital tool with no fiat margin-call surface.</p>
+      <p><strong>Positioning, "Terminal Bitcoin."</strong> TBA explicitly positions LMC for the Terminal Bitcoiner, a holder who has maxed out accumulation through traditional savings, salary, and direct purchase. The framing is honest about the niche: this is not for new Bitcoiners building a position. It is for sophisticated holders past the accumulation phase who want a BTC-denominated capital tool with no fiat margin-call surface.</p>
 
-      <p><strong>Custody:</strong> 2-of-3 multisig. Borrower holds 1 key. TBA holds 1. Independent key agent holds 1. No single party can move funds. Borrower verifies collateral on-chain in real time — no audit-cycle dependency. TBA's collaborative security model has run since 2016 with no reported losses.</p>
+      <p><strong>Custody:</strong> 2-of-3 multisig. Borrower holds 1 key. TBA holds 1. Independent key agent holds 1. No single party can move funds. Borrower verifies collateral on-chain in real time, no audit-cycle dependency. TBA's collaborative security model has run since 2016 with no reported losses.</p>
     </div>
   </div>
 </section>
 
-<!-- PART V — DENOMINATOR FIRST PRINCIPLES -->
+<!-- PART V, DENOMINATOR FIRST PRINCIPLES -->
 <section class="part" id="denominator">
   <div class="container-narrow">
     <div class="part-label">Part V</div>
@@ -835,18 +835,18 @@
       <li><strong>No price-based liquidation surface. No margin call. By mathematics, not policy.</strong></li>
     </ul>
 
-    <p>This is why LMC's "no margin call" feature isn't generous lender policy — it's the natural consequence of denominating the loan in the same unit as the collateral.</p>
-    <p><strong>The corollary:</strong> any fiat-denominated loan has margin-call risk regardless of how the lender markets the product. "We have no margin calls" claims for fiat-denominated loans should be read with skepticism — the lender is either using a different definition or has hidden the risk somewhere else (e.g., rate adjustments that price the risk into cost rather than triggering a liquidation event).</p>
+    <p>This is why LMC's "no margin call" feature isn't generous lender policy, it's the natural consequence of denominating the loan in the same unit as the collateral.</p>
+    <p><strong>The corollary:</strong> any fiat-denominated loan has margin-call risk regardless of how the lender markets the product. "We have no margin calls" claims for fiat-denominated loans should be read with skepticism: the lender is either using a different definition or has hidden the risk somewhere else (e.g., rate adjustments that price the risk into cost rather than triggering a liquidation event).</p>
     <p>The Peoples Reserve mortgage Model B (covered in the <a href="bitcoin-backed-mortgages.html#models">Mortgages deep dive</a>) uses this trick: rate adjusts as BTC drops, no liquidation triggered, but the borrower pays for the risk through variable monthly payments. The risk is in the cash flow rather than the asset, but it's still there.</p>
   </div>
 </section>
 
-<!-- PART VI — CUSTODY ARCHITECTURES -->
+<!-- PART VI, CUSTODY ARCHITECTURES -->
 <section class="part" id="custody">
   <div class="container-narrow">
     <div class="part-label">Part VI</div>
     <h2>Custody architectures, decoded</h2>
-    <p>The 2022 BTC lender failures weren't credit failures on the BTC-backed loan books — those were over-collateralized. The common pattern across Celsius, BlockFi, Voyager, and Genesis was a <strong>funding-side</strong> set of vulnerabilities: pooled customer deposits, rehypothecation cascades, and counterparty concentration with players like 3AC and FTX. Each failure also had its own specific precipitating events (Three Arrows Capital exposure, FTX/Alameda contagion, depositor-run dynamics, regulatory pressure), so reducing 2022 to a single tidy diagnosis would overstate the analysis. <strong>What the pattern says, more usefully: custody architecture is what protected (or failed to protect) the borrower's collateral from getting pulled into those cascades.</strong> Customers became unsecured creditors in bankruptcy proceedings that are still unwinding four years later.</p>
+    <p>The 2022 BTC lender failures weren't credit failures on the BTC-backed loan books, those were over-collateralized. The common pattern across Celsius, BlockFi, Voyager, and Genesis was a <strong>funding-side</strong> set of vulnerabilities: pooled customer deposits, rehypothecation cascades, and counterparty concentration with players like 3AC and FTX. Each failure also had its own specific precipitating events (Three Arrows Capital exposure, FTX/Alameda contagion, depositor-run dynamics, regulatory pressure), so reducing 2022 to a single tidy diagnosis would overstate the analysis. <strong>What the pattern says, more usefully: custody architecture is what protected (or failed to protect) the borrower's collateral from getting pulled into those cascades.</strong> Customers became unsecured creditors in bankruptcy proceedings that are still unwinding four years later.</p>
     <p>Every Tier 1 provider in this deep dive has moved past that model. But the <em>direction</em> they moved matters for sovereignty-aware borrowers.</p>
 
     <h3>The five custody models, ranked</h3>
@@ -867,27 +867,27 @@
 
     <h3>What collaborative multisig actually delivers (LMC, Unchained)</h3>
     <ol>
-      <li><strong>Borrower-held key is real custody, not nominal.</strong> The borrower doesn't just "see" the BTC — they hold an actual cryptographic signing key. They can refuse to co-sign any movement. This is not theoretical authority; it's mathematical authority.</li>
+      <li><strong>Borrower-held key is real custody, not nominal.</strong> The borrower doesn't just "see" the BTC, they hold an actual cryptographic signing key. They can refuse to co-sign any movement. This is not theoretical authority; it's mathematical authority.</li>
       <li><strong>Recovery without lender cooperation.</strong> If the lender disappeared entirely tomorrow, the borrower and the independent key agent can recover the BTC using their two keys. <strong>Independent counterparties = independent recovery paths.</strong></li>
-      <li><strong>Continuous on-chain proof of funds.</strong> Not "we audit quarterly" — verifiable second-by-second on the public blockchain via any block explorer. Trust requirement collapses to "do I trust math?" rather than "do I trust the lender's audit cycle?"</li>
+      <li><strong>Continuous on-chain proof of funds.</strong> Not "we audit quarterly", verifiable second-by-second on the public blockchain via any block explorer. Trust requirement collapses to "do I trust math?" rather than "do I trust the lender's audit cycle?"</li>
       <li><strong>Operationally proven.</strong> TBA's architecture has run since 2016; Unchained's since 2017. Multisig has been battle-tested across the Bitcoin space for nearly a decade.</li>
     </ol>
 
     <h3>The Lava trade-off worth being honest about</h3>
-    <p>DLC self-custody is <em>more</em> sovereign than multisig — Lava literally never holds keys to your BTC. The borrower retains sole authority through Bitcoin's native scripting.</p>
-    <p>But: if the borrower loses their key, <strong>BTC is permanently lost.</strong> No key agent. No recovery path. Multisig's 2-of-3 (LMC, Unchained) and 3-of-4 (Debifi) trade some sovereignty for recovery — if you lose your key, the other parties can co-sign to restore your access (with appropriate verification). For most borrowers, that's the right trade.</p>
+    <p>DLC self-custody is <em>more</em> sovereign than multisig, Lava literally never holds keys to your BTC. The borrower retains sole authority through Bitcoin's native scripting.</p>
+    <p>But: if the borrower loses their key, <strong>BTC is permanently lost.</strong> No key agent. No recovery path. Multisig's 2-of-3 (LMC, Unchained) and 3-of-4 (Debifi) trade some sovereignty for recovery, if you lose your key, the other parties can co-sign to restore your access (with appropriate verification). For most borrowers, that's the right trade.</p>
 
     <h3>The rehypothecation question for qualified-custodian products</h3>
-    <p>For borrowers using qualified-custodian providers, rehypothecation policy is the most important sovereignty question. <strong>Ledn's current public page states collateral is held with Ledn or trusted partners and "never lent out to earn interest"</strong> — a meaningful change from older third-party characterizations that split Ledn into Custodied/Standard rehypothecation tiers. <strong>Arch also explicitly does not rehypothecate</strong>, with Anchorage Digital custody, segregated wallets, and $100M Lloyd's insurance.</p>
+    <p>For borrowers using qualified-custodian providers, rehypothecation policy is the most important sovereignty question. <strong>Ledn's current public page states collateral is held with Ledn or trusted partners and "never lent out to earn interest"</strong>, a meaningful change from older third-party characterizations that split Ledn into Custodied/Standard rehypothecation tiers. <strong>Arch also explicitly does not rehypothecate</strong>, with Anchorage Digital custody, segregated wallets, and $100M Lloyd's insurance.</p>
     <p><strong>SALT Lending is the notable outlier among the providers reviewed here.</strong> Their loan agreement explicitly permits SALT to "repledge, sell or otherwise transfer or use Stored Coins." Borrowers should understand this is structurally closer to the 2022 cohort's risk profile (though SALT survived 2022). If rehypothecation policy matters to you, read the loan agreement, not the marketing.</p>
-    <p>Regardless of the lender's stated policy, <strong>verify the current public position before signing</strong> — these terms change. A platform that does not rehypothecate today may begin to, or vice versa, and the verification labor falls on the borrower.</p>
+    <p>Regardless of the lender's stated policy, <strong>verify the current public position before signing</strong>, these terms change. A platform that does not rehypothecate today may begin to, or vice versa, and the verification labor falls on the borrower.</p>
 
     <h3>The 2022 lesson, restated</h3>
-    <p>A lender's solvency is your risk surface, not just the price of Bitcoin. The custody architecture is what stands between you and the lender's bankruptcy estate. <strong>Properly structured multisig collateral with a borrower-held key can reduce the risk that pledged Bitcoin is treated like pooled lender property in bankruptcy</strong> — but the legal outcome depends on how the loan agreement, security interest, perfection, jurisdiction, and the specific collateral arrangement are documented. Talk to counsel about the specifics of any structure before relying on its bankruptcy-remoteness claims.</p>
+    <p>A lender's solvency is your risk surface, not just the price of Bitcoin. The custody architecture is what stands between you and the lender's bankruptcy estate. <strong>Properly structured multisig collateral with a borrower-held key can reduce the risk that pledged Bitcoin is treated like pooled lender property in bankruptcy</strong>, but the legal outcome depends on how the loan agreement, security interest, perfection, jurisdiction, and the specific collateral arrangement are documented. Talk to counsel about the specifics of any structure before relying on its bankruptcy-remoteness claims.</p>
   </div>
 </section>
 
-<!-- PART VII — CALCULATOR PLACEHOLDER -->
+<!-- PART VII, CALCULATOR PLACEHOLDER -->
 <section class="part" id="calculator-placeholder">
   <div class="container-narrow">
     <div class="part-label">Part VII</div>
@@ -909,14 +909,14 @@
         <tr><td>SALT</td><td>5.00 BTC</td><td>$59,750 (mid-tier)</td><td>Yes</td><td>Qualified custodian + rehypo</td></tr>
         <tr><td>Ledn</td><td>5.00 BTC</td><td>$54,950 (10.99%, $250K–$500K tier)</td><td>Yes (70% LTV)</td><td>Qualified custodian (no rehypo)</td></tr>
         <tr><td>Arch</td><td>4.17 BTC</td><td>$66,250 (12.5% + origination)</td><td>Yes (80% LTV)</td><td>Anchorage (no rehypo)</td></tr>
-        <tr><td>Debifi</td><td>N/A</td><td>N/A (institutional)</td><td>—</td><td>3-of-4 multisig</td></tr>
+        <tr><td>Debifi</td><td>N/A</td><td>N/A (institutional)</td><td>-</td><td>3-of-4 multisig</td></tr>
       </tbody>
     </table>
-    <p>Direct cost is the wrong frame for this decision. It involves cost, margin-call risk, custody quality, term structure, the BTC exposure LMC embeds, and what you're using the funds for — the calculator weighs all of these dimensions.</p>
+    <p>Direct cost is the wrong frame for this decision. It involves cost, margin-call risk, custody quality, term structure, the BTC exposure LMC embeds, and what you're using the funds for, the calculator weighs all of these dimensions.</p>
   </div>
 </section>
 
-<!-- PART VIII — HEDGE MISCONCEPTION -->
+<!-- PART VIII, HEDGE MISCONCEPTION -->
 <section class="part" id="hedge">
   <div class="container-narrow">
     <div class="part-label">Part VIII</div>
@@ -924,11 +924,11 @@
     <p>A common framing in BTC capital-structure discussions: <em>"Use a BTC-backed loan to hedge against a BTC-backed mortgage's margin-call risk."</em> The argument typically goes: take an LMC loan, sell the received BTC for cash, hold the cash as a margin-call buffer for your Milo mortgage, deploy the cash to buy more BTC if BTC drops.</p>
     <p><strong>This is not a hedge in any structural sense.</strong> Let me walk through the three variations of the structure and why each fails, then show what an actual hedge looks like.</p>
 
-    <h3>Structure 1 — Direct use at the moment of margin call</h3>
+    <h3>Structure 1, Direct use at the moment of margin call</h3>
     <p>You're already in margin call on your Milo Model A mortgage. Can you use LMC to borrow BTC to top up your collateral?</p>
     <p><strong>No.</strong> To borrow BTC from LMC, you need BTC to pledge. If you had spare BTC available to pledge to LMC, you would just send it directly to Milo and skip the 5% fee. LMC adds friction without adding capacity.</p>
 
-    <h3>Structure 2 — Pre-positioned forward short with T-bill buffer</h3>
+    <h3>Structure 2, Pre-positioned forward short with T-bill buffer</h3>
     <p>This is the structurally interesting variation. At origination, pledge BTC to LMC, receive the disbursement BTC, sell it for cash, hold the cash in T-bills. If BTC drops later, deploy the cash to satisfy Milo's margin call.</p>
     <p><strong>Modeled scenario math</strong> (illustrative assumptions, not a forecast):</p>
     <table class="data-table">
@@ -941,11 +941,11 @@
         <tr><td><strong>Moon</strong></td><td>$100K → $200K → $200K</td><td>0.00 BTC</td><td>-$503,385</td><td style="color:var(--red)">Hedge loses big</td></tr>
       </tbody>
     </table>
-    <p><strong>The hedge works in the drop scenario.</strong> The cash buffer can be deployed at the dip — buying more BTC at $35K than the same dollars would have bought at $100K. Combined with the LMC collateral returning at term end, the borrower ends up with <strong>4.52 more BTC</strong> than the no-hedge counterfactual.</p>
-    <p><strong>But the moon scenario is catastrophic.</strong> If BTC rises to $200K, the borrower owes 5 BTC = $1M to LMC at term end. The cash buffer is $485K. <strong>Shortfall: $515K.</strong> Either forfeit the pledged collateral (5 BTC, now worth $1M) or source $515K externally. Forfeiture is also a taxable disposition at FMV — the realized result (gain or loss) depends on the pledged BTC's basis and holding period; in a moon scenario it is typically a large realized gain.</p>
+    <p><strong>The hedge works in the drop scenario.</strong> The cash buffer can be deployed at the dip, buying more BTC at $35K than the same dollars would have bought at $100K. Combined with the LMC collateral returning at term end, the borrower ends up with <strong>4.52 more BTC</strong> than the no-hedge counterfactual.</p>
+    <p><strong>But the moon scenario is catastrophic.</strong> If BTC rises to $200K, the borrower owes 5 BTC = $1M to LMC at term end. The cash buffer is $485K. <strong>Shortfall: $515K.</strong> Either forfeit the pledged collateral (5 BTC, now worth $1M) or source $515K externally. Forfeiture is also a taxable disposition at FMV; the realized result (gain or loss) depends on the pledged BTC's basis and holding period; in a moon scenario it is typically a large realized gain.</p>
     <p>The structure is <strong>a directional bet on BTC volatility, not a hedge.</strong> A real hedge has defined max loss and asymmetric payoff. This has unlimited downside in the rally case.</p>
 
-    <h3>Structure 3 — LMC replaces the mortgage entirely</h3>
+    <h3>Structure 3, LMC replaces the mortgage entirely</h3>
     <p>Instead of a Milo mortgage, take an LMC loan, sell the BTC for cash, buy a house in cash. No mortgage. No margin call surface.</p>
     <p><strong>This works for short horizons.</strong> A 12-month LMC structure replacing a 12-month bridge loan is clean. The 5% fee is the price.</p>
     <p><strong>It fails for long horizons.</strong> A 30-year mortgage replaced by LMC requires 30 annual rolls. (1.05)^30 = <strong>4.32× decay of the pledged stack</strong> over 30 years.</p>
@@ -962,11 +962,11 @@
   </div>
 </section>
 
-<!-- PART IX — OPTIONS STRATEGIES -->
+<!-- PART IX, OPTIONS STRATEGIES -->
 <section class="part" id="options">
   <div class="container-narrow">
     <div class="part-label">Part IX</div>
-    <h2>Options strategies — the actual hedges</h2>
+    <h2>Options strategies, the actual hedges</h2>
     <p>For a Bitcoin holder worried about margin-call risk or forced liquidation, the structurally correct hedge is a long put option (or a put-based spread/collar). Options give defined cost, asymmetric payoff, and upside preservation. None of those properties exist in a loan.</p>
 
     <h3>Five-strategy cost comparison (illustrative, not a quote)</h3>
@@ -982,21 +982,21 @@
         <tr><td>Long put 50% OTM</td><td>$50K</td><td>$25,357</td><td>5.1%</td><td style="color:var(--primary)">Yes</td></tr>
         <tr><td>Put spread 50/25</td><td>$50K long, $25K short</td><td>$22,658</td><td>4.5%</td><td style="color:var(--primary)">Yes</td></tr>
         <tr><td>Collar (50/50)</td><td>$50K put, $150K call</td><td>-$72,950 (premium received)</td><td>-14.6%</td><td style="color:var(--red)">No (capped)</td></tr>
-        <tr><td>LMC forward-short</td><td>—</td><td>$25,000</td><td>5.0%</td><td style="color:var(--red)">No (capped at zero)</td></tr>
+        <tr><td>LMC forward-short</td><td>-</td><td>$25,000</td><td>5.0%</td><td style="color:var(--red)">No (capped at zero)</td></tr>
       </tbody>
     </table>
 
     <h3>Why the 35% OTM put is the headline finding</h3>
-    <p>Using a simplified Black-Scholes-style estimate with 80% implied volatility and a 4.5% risk-free rate, a 12-month put at strike $35K — the level that would trigger a Milo Model A margin call — may cost roughly <strong>1.7% of notional</strong>. For a $500K BTC position, that's approximately $8,500. <strong>If real-world pricing is close to this estimate, that's a surgical hedge for margin-call risk at less than two percent of the position.</strong></p>
-    <p>The structural logic: BTC's implied volatility skew means deep-OTM puts can be surprisingly affordable. The market doesn't fully price 65%+ drawdowns because they're rare in any given 12-month window — but they happen often enough across multi-year horizons to be the central risk for a 30-year mortgage borrower. <strong>Pricing varies; get a live quote before relying on any specific figure.</strong></p>
+    <p>Using a simplified Black-Scholes-style estimate with 80% implied volatility and a 4.5% risk-free rate, a 12-month put at strike $35K, the level that would trigger a Milo Model A margin call, may cost roughly <strong>1.7% of notional</strong>. For a $500K BTC position, that's approximately $8,500. <strong>If real-world pricing is close to this estimate, that's a surgical hedge for margin-call risk at less than two percent of the position.</strong></p>
+    <p>The structural logic: BTC's implied volatility skew means deep-OTM puts can be surprisingly affordable. The market doesn't fully price 65%+ drawdowns because they're rare in any given 12-month window, but they happen often enough across multi-year horizons to be the central risk for a 30-year mortgage borrower. <strong>Pricing varies; get a live quote before relying on any specific figure.</strong></p>
 
     <h3>The verdict on hedging Model A risk</h3>
-    <p>A long put at 35% OTM is the structurally cleanest hedge for margin-call risk. It pays off precisely when the margin call would trigger, and for a naked long put (not financed by selling calls), it preserves all BTC upside. <strong>Anything else — including loan-based "hedges" — trades structure for cost.</strong></p>
+    <p>A long put at 35% OTM is the structurally cleanest hedge for margin-call risk. It pays off precisely when the margin call would trigger, and for a naked long put (not financed by selling calls), it preserves all BTC upside. <strong>Anything else, including loan-based "hedges", trades structure for cost.</strong></p>
     <p style="font-size:0.88rem;color:var(--muted);"><em>Note: "preserves all upside" applies only to a naked long put. Collars and put spreads trade away or cap upside in exchange for lower premium cost.</em></p>
   </div>
 </section>
 
-<!-- PART X — TAX -->
+<!-- PART X, TAX -->
 <section class="part" id="tax">
   <div class="container-narrow">
     <div class="part-label">Part X</div>
@@ -1004,15 +1004,15 @@
     <p>Three things every BTC-backed-loan borrower should understand about US tax treatment.</p>
     <ol>
       <li><strong>Pledging crypto as collateral is generally not a taxable event.</strong> IRS guidance treats it similarly to pledging stock for a loan. You retain beneficial ownership; no realized gain.</li>
-      <li><strong>Forfeiture is a taxable event.</strong> If you fail to repay a BTC-backed loan and the lender liquidates your pledged BTC, that's treated as a disposition at FMV at the moment of forfeiture. The realized result — long-term capital gain, short-term gain, or even a loss — depends on your basis and holding period in the specific BTC that was liquidated. <strong>If it is a realized gain, the tax bill arrives in a year that may also have impaired liquidity.</strong> Plan for this.</li>
+      <li><strong>Forfeiture is a taxable event.</strong> If you fail to repay a BTC-backed loan and the lender liquidates your pledged BTC, that's treated as a disposition at FMV at the moment of forfeiture. The realized result, long-term capital gain, short-term gain, or even a loss, depends on your basis and holding period in the specific BTC that was liquidated. <strong>If it is a realized gain, the tax bill arrives in a year that may also have impaired liquidity.</strong> Plan for this.</li>
       <li><strong>Buying BTC to repay an LMC loan does not trigger gains.</strong> If you used LMC's BTC disbursement for cash purposes and need to buy back BTC at term end, the new BTC has its new cost basis. Acquiring and immediately transferring to LMC doesn't constitute a disposition on your side.</li>
     </ol>
-    <p><strong>State variations matter.</strong> Florida, Texas, Wyoming, Tennessee — no state LTCG. California adds ~13%. New York is similarly hostile.</p>
+    <p><strong>State variations matter.</strong> Florida, Texas, Wyoming, Tennessee, no state LTCG. California adds ~13%. New York is similarly hostile.</p>
     <p style="color:var(--muted);font-size:0.85rem;">This section is not tax advice. Run your specific situation with a CPA who has worked with Bitcoin holders.</p>
   </div>
 </section>
 
-<!-- PART XI — RISK DECOMPOSITION -->
+<!-- PART XI, RISK DECOMPOSITION -->
 <section class="part" id="risk">
   <div class="container-narrow">
     <div class="part-label">Part XI</div>
@@ -1058,7 +1058,7 @@
   </div>
 </section>
 
-<!-- PART XII — DECISION FRAMEWORK -->
+<!-- PART XII, DECISION FRAMEWORK -->
 <section class="part" id="decision">
   <div class="container-narrow">
     <div class="part-label">Part XII</div>
@@ -1096,23 +1096,23 @@
     ├── Want zero margin-call risk → <span class="answer">LMC (BTC-denominated, no margin call by structure)</span>
     ├── Willing to manage margin → <span class="answer">Any fiat-denominated provider + monitoring</span>
     └── Want hedge protection → <span class="answer">Long put at margin threshold (NOT another loan)</span></div>
-    <p><strong>The shortcut:</strong> match the product to the most important constraint for your situation. <strong>Ledn</strong> for regulated mainstream with no rehypothecation — the safe default. <strong>Unchained</strong> for collaborative multisig with fiat liquidity. <strong>Lava</strong> for fast/small/self-custody where you want to retain full key authority. <strong>LMC</strong> as a specialized choice when you have a high-conviction view that BTC will drop within the loan term — recognize this is a directional bet, not a default product.</p>
+    <p><strong>The shortcut:</strong> match the product to the most important constraint for your situation. <strong>Ledn</strong> for regulated mainstream with no rehypothecation, the safe default. <strong>Unchained</strong> for collaborative multisig with fiat liquidity. <strong>Lava</strong> for fast/small/self-custody where you want to retain full key authority. <strong>LMC</strong> as a specialized choice when you have a high-conviction view that BTC will drop within the loan term. Recognize this is a directional bet, not a default product.</p>
   </div>
 </section>
 
-<!-- PART XIII — NON-COLLATERALIZED BRIEF -->
+<!-- PART XIII, NON-COLLATERALIZED BRIEF -->
 <section class="part" id="non-collateralized">
   <div class="container-narrow">
     <div class="part-label">Part XIII</div>
-    <h2>Non-collateralized crypto loans — a brief note</h2>
+    <h2>Non-collateralized crypto loans, a brief note</h2>
     <p>For completeness: not every "crypto loan" is collateralized.</p>
     <p><strong>Flash loans (DeFi)</strong> are zero-collateral loans where the borrowed amount must be repaid in the same transaction block. They exist for arbitrage and atomic-transaction strategies. Not relevant for individual hodlers seeking liquidity.</p>
     <p><strong>Undercollateralized institutional credit</strong> (TrueFi, Maple Finance, Clearpool, Goldfinch) extends credit to professional borrowers based on identity verification and credit underwriting. These are not retail products and require institutional KYC.</p>
-    <p><strong>The honest framing:</strong> if you're an individual Bitcoiner reading this deep dive, you have overcollateralized loans (everything covered in Parts I–XII). Non-collateralized lending is institutional infrastructure, not consumer infrastructure. <strong>If a product promises "Bitcoin loan, no collateral" to a retail borrower, treat it with skepticism</strong> — likely either a hidden fee structure or a scam.</p>
+    <p><strong>The honest framing:</strong> if you're an individual Bitcoiner reading this deep dive, you have overcollateralized loans (everything covered in Parts I–XII). Non-collateralized lending is institutional infrastructure, not consumer infrastructure. <strong>If a product promises "Bitcoin loan, no collateral" to a retail borrower, treat it with skepticism</strong>, likely either a hidden fee structure or a scam.</p>
   </div>
 </section>
 
-<!-- PART XIV — OPEN QUESTIONS -->
+<!-- PART XIV, OPEN QUESTIONS -->
 <section class="part" id="open-questions">
   <div class="container-narrow">
     <div class="part-label">Part XIV</div>
@@ -1144,11 +1144,11 @@
 
     <h3>The structurally distinct case</h3>
     <ul>
-      <li>For a sophisticated Terminal Bitcoiner who wants BTC-denominated liquidity without fiat margin-call exposure → <strong>LMC</strong>. The BTC-denominated structure removes price-based liquidation by mathematics. <strong>But selling the disbursement for fiat creates implicit forward-short BTC exposure</strong> — read Part IV's LMC section carefully to internalize the price-path risk. The 5% per-period fee compounds across rolls (up to 25% of pledged BTC over the 5-year max), so a clear use case for the disbursement liquidity matters more than market-timing assumptions.</li>
+      <li>For a sophisticated Terminal Bitcoiner who wants BTC-denominated liquidity without fiat margin-call exposure → <strong>LMC</strong>. The BTC-denominated structure removes price-based liquidation by mathematics. <strong>But selling the disbursement for fiat creates implicit forward-short BTC exposure</strong>, read Part IV's LMC section carefully to internalize the price-path risk. The 5% per-period fee compounds across rolls (up to 25% of pledged BTC over the 5-year max), so a clear use case for the disbursement liquidity matters more than market-timing assumptions.</li>
     </ul>
 
     <p>The wrong move is to optimize for rate alone. <strong>The 2022 cohort customers did that. They got 8% APR. They lost their BTC.</strong></p>
-    <p>The right move is to match the product to your situation across all three structural axes, verify the lender's actual custody architecture (not their marketing claims), and treat margin-call protection — if you need it — as the job of options, not another loan.</p>
+    <p>The right move is to match the product to your situation across all three structural axes, verify the lender's actual custody architecture (not their marketing claims), and treat margin-call protection, if you need it, as the job of options, not another loan.</p>
   </div>
 </section>
 
@@ -1172,7 +1172,7 @@
           <td><strong>Unchained</strong></td>
           <td><a href="https://www.unchained.com/loans">unchained.com/loans</a></td>
           <td>Nov 2025 (pricing page) / May 2026 (re-verified)</td>
-          <td>Pivoted to commercial (B2B) loans. 14% interest, 16.21% APR, $150K min, 12-payment term. Personal loan product may no longer be available — verify before applying.</td>
+          <td>Pivoted to commercial (B2B) loans. 14% interest, 16.21% APR, $150K min, 12-payment term. Personal loan product may no longer be available, verify before applying.</td>
         </tr>
         <tr>
           <td><strong>Lava</strong></td>
@@ -1220,7 +1220,7 @@
     </table>
 
     <h3>Numerical computations</h3>
-    <p>All cost-comparison and scenario-math figures in this deep dive are reproducible from a Python worksheet at <code>_drafts/loans-math-worksheet.py</code> in the BSA repository, with output captured in <code>data/loans-math-output.json</code>. Worksheet includes: comparative provider costs across multiple loan sizes and horizons, hedge scenario math (drop/flat/moon), Black-Scholes-style options strategy pricing (illustrative only — see Part IX caveat), LMC outperform-BTC scenarios, and break-even analyses.</p>
+    <p>All cost-comparison and scenario-math figures in this deep dive are reproducible from a Python worksheet at <code>_drafts/loans-math-worksheet.py</code> in the BSA repository, with output captured in <code>data/loans-math-output.json</code>. Worksheet includes: comparative provider costs across multiple loan sizes and horizons, hedge scenario math (drop/flat/moon), Black-Scholes-style options strategy pricing (illustrative only, see Part IX caveat), LMC outperform-BTC scenarios, and break-even analyses.</p>
 
     <h3>Options strategy caveats</h3>
     <p>The options pricing figures in Part IX are <strong>illustrative estimates</strong> using simplified Black-Scholes-style math with 80% implied volatility and a 4.5% risk-free rate. Real options pricing varies materially by venue, liquidity, skew, tenor, execution size, and counterparty. <strong>Always get a current quote on a real options venue (Deribit, CME, etc.) before relying on any specific number.</strong></p>

--- a/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
@@ -39,7 +39,6 @@
     --faint: #B3B3B3;
     --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
     --grad-soft: linear-gradient(135deg, rgba(255, 122, 0,0.12), rgba(255,215,0,0.04));
-    --green: #28a745;
     --yellow: #f59e0b;
     --blue: #3b82f6;
     --red: #dc3545;
@@ -286,7 +285,7 @@
   }
   .tag-btc { background: rgba(255, 122, 0,0.15); color: var(--primary); border: 1px solid var(--primary); }
   .tag-fiat { background: rgba(59,130,246,0.15); color: var(--blue); border: 1px solid var(--blue); }
-  .tag-multisig { background: rgba(16,185,129,0.15); color: var(--green); border: 1px solid var(--green); }
+  .tag-multisig { background: rgba(255,122,0,0.12); color: var(--primary); border: 1px solid var(--primary); }
   .tag-custodian { background: rgba(154,164,178,0.15); color: var(--muted); border: 1px solid var(--muted); }
   .tag-selfcustody { background: rgba(255, 122, 0,0.15); color: var(--primary-soft); border: 1px solid var(--primary-soft); }
   .tag-specialized { background: rgba(245,158,11,0.15); color: var(--yellow); border: 1px solid var(--yellow); }
@@ -306,7 +305,7 @@
     padding: 1.25rem;
     border-left: 3px solid var(--border);
   }
-  .fit-card.fit-good { border-left-color: var(--green); }
+  .fit-card.fit-good { border-left-color: var(--primary); }
   .fit-card.fit-bad { border-left-color: var(--red); }
   .fit-card h4 {
     font-size: 0.78rem;
@@ -314,7 +313,7 @@
     margin: 0 0 0.85rem;
     letter-spacing: 0.06em;
   }
-  .fit-card.fit-good h4 { color: var(--green); }
+  .fit-card.fit-good h4 { color: var(--primary); }
   .fit-card.fit-bad h4 { color: var(--red); }
   .fit-card ul {
     margin: 0; padding-left: 1.2rem;
@@ -350,7 +349,7 @@
   .ascii-tree .root, .ascii-tree .start { color: var(--primary); font-weight: 600; }
   .ascii-tree .branch { color: var(--light); font-weight: 600; }
   .ascii-tree .leaf, .ascii-tree .answer { color: var(--muted); }
-  .ascii-tree .yes { color: var(--green); }
+  .ascii-tree .yes { color: var(--primary); }
   .ascii-tree .no { color: var(--red); }
 
   /* FOOTER */
@@ -419,7 +418,7 @@
   </div>
   <div class="eyebrow">A First-Principles Deep Dive</div>
   <h1>A Bitcoin-backed loan is not one product. <span>It's a bundle of trade-offs.</span></h1>
-  <p class="lede">Denomination, custody, rehypothecation, margin risk, tax timing, and human behavior — every BTC-backed loan involves all of them. The loan that looks cheapest can be the most expensive mistake. This deep dive gives you the framework, the verified math, and a decision tree so you can match a product to your situation.</p>
+  <p class="lede">Denomination, custody, rehypothecation, margin risk, tax timing, and human behavior — every BTC-backed loan involves all of them. The loan that looks cheapest can be the most expensive mistake. This deep dive gives you the framework, the modeled math, and a decision tree so you can match a product to your situation.</p>
   <div class="hero-meta">
     <span><strong>~30 min</strong> read</span>
     <span><strong>14 sections</strong></span>
@@ -559,15 +558,15 @@
         <li>24-hour typical funding time after approval</li>
         <li>No credit check, no required monthly payments, no prepayment penalty</li>
         <li>Collateral held in custody with Ledn or trusted partners — <strong>per Ledn's current public policy, never lent out to earn interest</strong></li>
-        <li>Illustrative cost at $250K / 24 months at 11.49% APR: <strong>~$57,450</strong> (interest accrued, payable at maturity or any time)</li>
+        <li>Illustrative cost at $250K / 24 months at 10.99% APR (the $250K–$500K size tier): <strong>~$54,950</strong> (interest accrued, payable at maturity or any time)</li>
       </ul>
 
       <div class="callout">
-        <p><strong>What changed since earlier coverage:</strong> Some prior third-party comparisons split Ledn into "Custodied" (no rehypothecation, ~13.9% APR) and "Standard" (rehypothecation allowed, ~12.4% APR) variants. <strong>Ledn's current public page presents a single product</strong> with tiered rates by loan size and an explicit statement that collateral is "never lent out to earn interest." If you are evaluating an older quote from Ledn that references the two-variant structure, verify the current product structure directly before signing.</p>
+        <p><strong>What changed since earlier coverage:</strong> Some prior third-party comparisons split Ledn into "Custodied" (no rehypothecation, ~13.9% APR) and "Standard" (rehypothecation allowed, ~12.4% APR) variants. <strong>Ledn's current public page presents a single Custodied-model product</strong> with rates tiered by loan size — <strong>11.49% under $250K, 10.99% $250K–$500K, 10.49% $500K–$1M, 9.99% $1M–$2M, 9.25% $2M+</strong> (Ledn, June 2026) — and an explicit statement that collateral is "never lent out to earn interest." If you are evaluating an older quote that references the two-variant structure, verify the current product directly before signing.</p>
       </div>
 
       <div class="callout">
-        <p><strong>The Custodied vs. Standard choice is the most important decision a Ledn borrower makes.</strong> The 1.5% APR delta is the price of sovereignty at Ledn. Most borrowers default into Standard without knowing what they're trading. <strong>Break-even math:</strong> The Custodied premium (≈3% of loan over 2 years) pays off if you believe the rehypothecation counterparty failure probability over 2 years exceeds 6%. Given 2022's cohort failures, that's not a stretch — it's a base rate.</p>
+        <p><strong>With a single no-rehypothecation model, the borrower's real job is verification, not tier-picking.</strong> Ledn states collateral is never lent out — which removes the rehypothecation risk that sank several 2022 lenders, <em>if the statement holds</em>. So the question to ask isn't "Custodied or Standard?" (that choice no longer exists) but "how is the no-rehypothecation claim evidenced?" Ledn provides periodic third-party-audited attestation, not real-time on-chain proof — so the residual single point of failure is BitGo plus Ledn's funding partner. Weigh that against the rate you're quoted, and re-confirm the current product structure directly before signing.</p>
       </div>
 
       <div class="fit-grid">
@@ -585,12 +584,12 @@
           <ul>
             <li>Sovereignty-first priority (use multisig instead)</li>
             <li>Want zero margin-call exposure (use LMC instead)</li>
-            <li>Uncomfortable with rehypothecation but unwilling to pay the Custodied premium</li>
+            <li>Want to hold your own key — Ledn is a qualified-custodian model; the borrower holds no key</li>
           </ul>
         </div>
       </div>
 
-      <p><strong>Custody:</strong> BitGo holds keys (qualified custodian, $250M insurance, audited cold storage). Borrower has no key. Proof-of-funds via periodic third-party-audited attestation, not real-time on-chain. <strong>Single point of failure: BitGo + Ledn's funding partner.</strong> Mitigated by ring-fenced addresses (Custodied) or insurance (always).</p>
+      <p><strong>Custody:</strong> BitGo holds keys (qualified custodian, $250M insurance, audited cold storage). Borrower has no key. Proof-of-funds via periodic third-party-audited attestation, not real-time on-chain. <strong>Single point of failure: BitGo + Ledn's funding partner.</strong> Mitigated by Ledn's stated no-rehypothecation policy and custodial insurance — but evidenced by attestation, not real-time on-chain proof.</p>
     </div>
 
     <!-- UNCHAINED -->
@@ -757,7 +756,7 @@
       <table class="data-table">
         <thead><tr><th>BTC at term end</th><th>Cost in BTC equivalent</th><th>Outcome vs. just holding</th></tr></thead>
         <tbody>
-          <tr><td>Drops to $50K (−50%)</td><td>Repurchase cost: $500K; cash buffer: $992K</td><td style="color:var(--green);">Strategy gains ~9.84 BTC equivalent</td></tr>
+          <tr><td>Drops to $50K (−50%)</td><td>Repurchase cost: $500K; cash buffer: $992K</td><td style="color:var(--primary);">Strategy gains ~9.84 BTC equivalent</td></tr>
           <tr><td>Sideways at $100K</td><td>Repurchase cost: $1M; cash buffer: $992K</td><td style="color:var(--muted);">Strategy ≈ flat (small ~$8K cost from net fee minus T-bill yield)</td></tr>
           <tr><td>Rises to $200K (+100%)</td><td>Repurchase cost: $2M; cash buffer: $992K</td><td style="color:var(--red);">Strategy loses $1M+ (forfeit collateral or source external capital)</td></tr>
         </tbody>
@@ -908,9 +907,8 @@
         <tr><td>Bitfinex</td><td>2.78 BTC</td><td>~$50,000 (10% mid)</td><td>Yes (95%)</td><td>Exchange</td></tr>
         <tr><td>Unchained (Commercial)</td><td>5.00 BTC</td><td>~$80,000 over 24 months (renewal needed; 14% interest + 16.21% APR with origination)</td><td>Yes (200% CTP)</td><td>2-of-3 multisig with Fortis Bank</td></tr>
         <tr><td>SALT</td><td>5.00 BTC</td><td>$59,750 (mid-tier)</td><td>Yes</td><td>Qualified custodian + rehypo</td></tr>
-        <tr><td>Ledn Standard</td><td>5.00 BTC</td><td>$62,000 (12.4%)</td><td>Yes</td><td>Qualified custodian + rehypo</td></tr>
+        <tr><td>Ledn</td><td>5.00 BTC</td><td>$54,950 (10.99%, $250K–$500K tier)</td><td>Yes (70% LTV)</td><td>Qualified custodian (no rehypo)</td></tr>
         <tr><td>Arch</td><td>4.17 BTC</td><td>$66,250 (12.5% + origination)</td><td>Yes (80% LTV)</td><td>Anchorage (no rehypo)</td></tr>
-        <tr><td>Ledn Custodied</td><td>5.00 BTC</td><td>$69,500 (13.9%)</td><td>Yes</td><td>Qualified custodian (no rehypo)</td></tr>
         <tr><td>Debifi</td><td>N/A</td><td>N/A (institutional)</td><td>—</td><td>3-of-4 multisig</td></tr>
       </tbody>
     </table>
@@ -932,13 +930,13 @@
 
     <h3>Structure 2 — Pre-positioned forward short with T-bill buffer</h3>
     <p>This is the structurally interesting variation. At origination, pledge BTC to LMC, receive the disbursement BTC, sell it for cash, hold the cash in T-bills. If BTC drops later, deploy the cash to satisfy Milo's margin call.</p>
-    <p><strong>Verified scenario math:</strong></p>
+    <p><strong>Modeled scenario math</strong> (illustrative assumptions, not a forecast):</p>
     <table class="data-table">
       <thead>
         <tr><th>Scenario</th><th>BTC Path</th><th>Net BTC delta</th><th>Net $ delta</th><th>Winner</th></tr>
       </thead>
       <tbody>
-        <tr><td><strong>V-shaped drop</strong></td><td>$100K → $35K → $100K</td><td>+4.52 BTC</td><td>+$287,101</td><td style="color:var(--green)">Hedge wins</td></tr>
+        <tr><td><strong>V-shaped drop</strong></td><td>$100K → $35K → $100K</td><td>+4.52 BTC</td><td>+$287,101</td><td style="color:var(--primary)">Hedge wins</td></tr>
         <tr><td><strong>Flat</strong></td><td>$100K → $100K → $100K</td><td>0.00 BTC</td><td>-$3,385</td><td style="color:var(--muted)">Roughly neutral</td></tr>
         <tr><td><strong>Moon</strong></td><td>$100K → $200K → $200K</td><td>0.00 BTC</td><td>-$503,385</td><td style="color:var(--red)">Hedge loses big</td></tr>
       </tbody>
@@ -980,9 +978,9 @@
         <tr><th>Strategy</th><th>Strike(s)</th><th>Total Cost</th><th>% of Notional</th><th>Keeps Upside?</th></tr>
       </thead>
       <tbody>
-        <tr><td><strong>Long put 35% OTM</strong></td><td>$35K</td><td><strong>$8,594</strong></td><td><strong>1.7%</strong></td><td style="color:var(--green)">Yes</td></tr>
-        <tr><td>Long put 50% OTM</td><td>$50K</td><td>$25,357</td><td>5.1%</td><td style="color:var(--green)">Yes</td></tr>
-        <tr><td>Put spread 50/25</td><td>$50K long, $25K short</td><td>$22,658</td><td>4.5%</td><td style="color:var(--green)">Yes</td></tr>
+        <tr><td><strong>Long put 35% OTM</strong></td><td>$35K</td><td><strong>$8,594</strong></td><td><strong>1.7%</strong></td><td style="color:var(--primary)">Yes</td></tr>
+        <tr><td>Long put 50% OTM</td><td>$50K</td><td>$25,357</td><td>5.1%</td><td style="color:var(--primary)">Yes</td></tr>
+        <tr><td>Put spread 50/25</td><td>$50K long, $25K short</td><td>$22,658</td><td>4.5%</td><td style="color:var(--primary)">Yes</td></tr>
         <tr><td>Collar (50/50)</td><td>$50K put, $150K call</td><td>-$72,950 (premium received)</td><td>-14.6%</td><td style="color:var(--red)">No (capped)</td></tr>
         <tr><td>LMC forward-short</td><td>—</td><td>$25,000</td><td>5.0%</td><td style="color:var(--red)">No (capped at zero)</td></tr>
       </tbody>
@@ -1083,8 +1081,8 @@
 ├── <span class="branch">WHAT'S YOUR CUSTODY PRIORITY?</span>
 │   ├── Self-custody (you keep all keys) → <span class="answer">Lava</span>
 │   ├── Collaborative multisig (you hold 1 key) → <span class="answer">LMC, Unchained, Debifi</span>
-│   ├── Qualified custodian, no rehypothecation → <span class="answer">Ledn Custodied, Arch</span>
-│   ├── Qualified custodian, rehypothecation OK → <span class="answer">Ledn Standard, SALT</span>
+│   ├── Qualified custodian, no rehypothecation → <span class="answer">Ledn, Arch</span>
+│   ├── Qualified custodian, rehypothecation OK → <span class="answer">SALT</span>
 │   └── Exchange-based → <span class="answer">Bitfinex (2016 hack precedent)</span>
 │
 ├── <span class="branch">WHAT'S YOUR LOAN SIZE?</span>
@@ -1098,7 +1096,7 @@
     ├── Want zero margin-call risk → <span class="answer">LMC (BTC-denominated, no margin call by structure)</span>
     ├── Willing to manage margin → <span class="answer">Any fiat-denominated provider + monitoring</span>
     └── Want hedge protection → <span class="answer">Long put at margin threshold (NOT another loan)</span></div>
-    <p><strong>The shortcut:</strong> match the product to the most important constraint for your situation. <strong>Ledn Custodied</strong> for regulated mainstream with no rehypothecation — the safe default. <strong>Unchained</strong> for collaborative multisig with fiat liquidity. <strong>Lava</strong> for fast/small/self-custody where you want to retain full key authority. <strong>LMC</strong> as a specialized choice when you have a high-conviction view that BTC will drop within the loan term — recognize this is a directional bet, not a default product.</p>
+    <p><strong>The shortcut:</strong> match the product to the most important constraint for your situation. <strong>Ledn</strong> for regulated mainstream with no rehypothecation — the safe default. <strong>Unchained</strong> for collaborative multisig with fiat liquidity. <strong>Lava</strong> for fast/small/self-custody where you want to retain full key authority. <strong>LMC</strong> as a specialized choice when you have a high-conviction view that BTC will drop within the loan term — recognize this is a directional bet, not a default product.</p>
   </div>
 </section>
 
@@ -1138,7 +1136,7 @@
 
     <h3>The default-fit decision tree</h3>
     <ul>
-      <li>For a regulated mainstream borrower wanting USD with no margin-call panic → <strong>Ledn Custodied</strong></li>
+      <li>For a regulated mainstream borrower wanting USD with no margin-call panic → <strong>Ledn</strong></li>
       <li>For a sovereignty-first borrower wanting USD with personal key authority → <strong>Unchained</strong></li>
       <li>For the maximalist who wants to never let go of their keys → <strong>Lava</strong></li>
       <li>For an institutional borrower wanting the most redundant custody → <strong>Debifi</strong></li>
@@ -1167,8 +1165,8 @@
         <tr>
           <td><strong>Ledn</strong></td>
           <td><a href="https://www.ledn.io/bitcoin-backed-loans">ledn.io/bitcoin-backed-loans</a></td>
-          <td>May 2026</td>
-          <td>Headline rates start at 11.49% APR, scale to 9.99% at $1M+. Custodied vs Standard tier spread varies — get a current quote.</td>
+          <td>June 2026</td>
+          <td>Single Custodied model (no rehypothecation). Size-tiered APR: 11.49% under $250K, 10.99% $250K–$500K, 10.49% $500K–$1M, 9.99% $1M–$2M, 9.25% $2M+. 50% LTV at origination, 70% margin call, 80% liquidation. The prior Custodied-vs-Standard split is retired.</td>
         </tr>
         <tr>
           <td><strong>Unchained</strong></td>
@@ -1242,6 +1240,7 @@
 <footer>
   <p style="margin-bottom:1rem;"><a href="/deep-dives/bitcoin-capital/#start-here" style="color:var(--primary);text-decoration:none;font-weight:600;">← Back to Bitcoin Capital Start Here</a></p>
   <p><a href="/">Bitcoin Sovereign Academy</a> · <a href="/deep-dives/">Deep Dives</a> · <a href="/deep-dives/bitcoin-capital/">Bitcoin Capital</a></p>
+  <p style="margin-top:0.85rem;">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
   <p class="footer-meta">v1.0 (prose) · Calculator coming in Phase 3 · Published May 2026 · Last updated <span id="today"></span></p>
 </footer>
 

--- a/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
@@ -179,8 +179,8 @@
   }
   .part p { color: var(--dim); margin-bottom: 1.1rem; max-width: 70ch; }
   .part p strong { color: var(--light); font-weight: 600; }
-  .part ul, .part ol { color: var(--dim); margin-left: 1.5rem; margin-bottom: 1.25rem; max-width: 68ch; }
-  .part ul li, .part ol li { margin-bottom: 0.5rem; }
+  .part ul .part ol { color: var(--dim); margin-left: 1.5rem; margin-bottom: 1.25rem; max-width: 68ch; }
+  .part ul li .part ol li { margin-bottom: 0.5rem; }
   .part code {
     font-family: var(--mono);
     font-size: 0.86em;
@@ -200,7 +200,7 @@
     overflow: hidden;
     font-size: 0.88rem;
   }
-  .taxonomy-table th, .taxonomy-table td {
+  .taxonomy-table th .taxonomy-table td {
     padding: 0.7rem 0.9rem;
     border-bottom: 1px solid var(--border);
     text-align: left;
@@ -226,7 +226,7 @@
     font-variant-numeric: tabular-nums;
     font-size: 0.9rem;
   }
-  .stat-table th, .stat-table td {
+  .stat-table th .stat-table td {
     padding: 0.65rem 0.8rem;
     border-bottom: 1px solid var(--border);
   }
@@ -596,7 +596,7 @@
   @media (max-width: 768px) {
     .header-inner { padding: 0.85rem 1rem; }
     .header-nav { display: none; }
-    .container, .container-narrow { padding: 0 1rem; }
+    .container .container-narrow { padding: 0 1rem; }
     .hero { padding: 3rem 1rem 2rem; }
     section.part { padding: 3rem 0; }
     .calc-grid { padding: 0 1rem; }
@@ -641,7 +641,7 @@
 <section class="hero">
   <div class="eyebrow">A First-Principles Deep Dive</div>
   <h1>Should you pledge or sell your Bitcoin <span>to buy a home?</span></h1>
-  <p class="lede">Bitcoin-backed mortgages are no longer experimental — Milo has originated $100M+, and Better and Coinbase launched a Fannie Mae-backed conforming product in March 2026. Roughly one in six US adults report having used digital assets at some point (Pew Research, 2024). But the product trades one set of risks for another. This deep dive builds the category from primitives, runs the math, and gives you an interactive calculator to find out where you actually stand.</p>
+  <p class="lede">Bitcoin-backed mortgages are no longer experimental, Milo has originated $100M+, and Better and Coinbase launched a Fannie Mae-backed conforming product in March 2026. Roughly one in six US adults report having used digital assets at some point (Pew Research, 2024). But the product trades one set of risks for another. This deep dive builds the category from primitives, runs the math, and gives you an interactive calculator to find out where you actually stand.</p>
   <div class="hero-meta">
     <span>📐 <strong>10 sections</strong> · ~25 min read</span>
     <span>🧮 <strong>Live calculator</strong> · 4 scenarios</span>
@@ -649,11 +649,11 @@
   </div>
 </section>
 
-<!-- PART I — ONTOLOGY -->
+<!-- PART I, ONTOLOGY -->
 <section class="part" id="ontology">
   <div class="container-narrow">
     <div class="part-label">Part I</div>
-    <h2>The ontology — what these things actually are</h2>
+    <h2>The ontology, what these things actually are</h2>
     <p>Most writing on this product starts with the marketing label ("Bitcoin mortgage") and works outward. That is backwards. The label encodes assumptions you should derive, not import. Start from primitives.</p>
 
     <h3>What Bitcoin is, structurally</h3>
@@ -661,14 +661,14 @@
     <p>Two of these dominate the mortgage product: <strong>bearer</strong> makes custody the central design question, and <strong>volatile</strong> makes the loan structure exotic.</p>
 
     <h3>What a mortgage is, structurally</h3>
-    <p>A mortgage is a long-duration secured loan with four essential properties: long-duration (15–30 years), secured by specific collateral, amortizing on a schedule, and recorded with a public lien registry. Its native collateral — real estate — is <strong>illiquid</strong>, <strong>slow-moving</strong>, has recorded title, and is use-coupled (the borrower lives in it).</p>
+    <p>A mortgage is a long-duration secured loan with four essential properties: long-duration (15–30 years), secured by specific collateral, amortizing on a schedule, and recorded with a public lien registry. Its native collateral, real estate, is <strong>illiquid</strong>, <strong>slow-moving</strong>, has recorded title, and is use-coupled (the borrower lives in it).</p>
 
     <h3>What a Bitcoin-backed mortgage is, derived</h3>
-    <p>Combining the primitives: a Bitcoin-backed mortgage is a long-duration amortizing loan with <strong>security interests in two collateral pools with maximally different liquidity and volatility profiles</strong>. The lender takes a recorded lien on the property (slow-moving, illiquid) and a security interest in pledged Bitcoin under a custody arrangement (fast-moving, liquid). The borrower retains beneficial ownership of both; the lender's claim is conditional on default events defined in the loan agreement. No traditional secured loan structure pairs collateral with such different time constants. That dual-collateral structure is the thing to understand — everything else is downstream.</p>
+    <p>Combining the primitives: a Bitcoin-backed mortgage is a long-duration amortizing loan with <strong>security interests in two collateral pools with maximally different liquidity and volatility profiles</strong>. The lender takes a recorded lien on the property (slow-moving, illiquid) and a security interest in pledged Bitcoin under a custody arrangement (fast-moving, liquid). The borrower retains beneficial ownership of both; the lender's claim is conditional on default events defined in the loan agreement. No traditional secured loan structure pairs collateral with such different time constants. That dual-collateral structure is the thing to understand, everything else is downstream.</p>
   </div>
 </section>
 
-<!-- PART II — TAXONOMY -->
+<!-- PART II, TAXONOMY -->
 <section class="part" id="taxonomy">
   <div class="container-narrow">
     <div class="part-label">Part II</div>
@@ -695,43 +695,43 @@
         <tr><td>Price-based margin call risk</td><td class="pill-no">No</td><td class="pill-yes">Yes</td><td>Product-specific: Yes (Milo); No (Better+Coinbase, Peoples Reserve)</td></tr>
       </tbody>
     </table>
-    <p style="font-size:0.88rem;color:var(--muted);"><em>Note:</em> the BTC-backed mortgage row collapses three distinct concepts that the deep dive disentangles in the structural-models section below: (1) the percentage of the home's value financed, (2) the ratio of BTC pledged vs. the loan principal, and (3) the per-dollar BTC collateral requirement on a down-payment loan. Different lenders use different combinations of these — always compare specific product disclosures, not just "LTV."</p>
+    <p style="font-size:0.88rem;color:var(--muted);"><em>Note:</em> the BTC-backed mortgage row collapses three distinct concepts that the deep dive disentangles in the structural-models section below: (1) the percentage of the home's value financed, (2) the ratio of BTC pledged vs. the loan principal, and (3) the per-dollar BTC collateral requirement on a down-payment loan. Different lenders use different combinations of these. Always compare specific product disclosures, not just "LTV."</p>
 
-    <p>Only the third column — <strong>Bitcoin-Backed Mortgage</strong> — is the subject of this deep dive. The other two are useful reference points for the trade-offs.</p>
+    <p>Only the third column, <strong>Bitcoin-Backed Mortgage</strong>, is the subject of this deep dive. The other two are useful reference points for the trade-offs.</p>
   </div>
 </section>
 
-<!-- PART II½ — THREE STRUCTURAL MODELS -->
+<!-- PART II½, THREE STRUCTURAL MODELS -->
 <section class="part" id="models">
   <div class="container-narrow">
     <div class="part-label">Part II½</div>
     <h2>Within BTC-backed mortgages, three structural models</h2>
-    <p>Not every Bitcoin-backed mortgage uses the same risk-transfer mechanism. As of 2026 there are <strong>three distinct structural models</strong> in market, distinguished by what triggers a liquidation event — price moves, rate adjustments, or only payment delinquency. The choice between them is one of the most important decisions a borrower makes.</p>
+    <p>Not every Bitcoin-backed mortgage uses the same risk-transfer mechanism. As of 2026 there are <strong>three distinct structural models</strong> in market, distinguished by what triggers a liquidation event, price moves, rate adjustments, or only payment delinquency. The choice between them is one of the most important decisions a borrower makes.</p>
 
-    <h3>Model A — Price-based margin call (Milo)</h3>
+    <h3>Model A, Price-based margin call (Milo)</h3>
     <p>The mortgage rate is <strong>fixed</strong>. The lender monitors the BTC collateral's value. If Bitcoin's price drops far enough from origination (Milo's published threshold: a 65% drawdown), the lender issues a margin call. The borrower can add collateral, pay down principal, or accept forced liquidation of pledged BTC.</p>
     <p>Milo originated $100M+ on this model. Notable operational detail: <strong>Milo has publicly stated it has issued zero margin calls to date</strong>, which suggests real-world behavior involves communication and borrower-managed paydowns more than mechanical liquidation at threshold. The structural risk is still real, but the worst case is rarer than the threshold framing alone would suggest.</p>
 
-    <h3>Model B — Dynamic-rate adjustment (Peoples Reserve)</h3>
-    <p>The mortgage rate is <strong>variable</strong>, tied to the collateral ratio and Bitcoin's price. If Bitcoin appreciates, the rate falls. If Bitcoin drops, the rate rises — compensating the lender for the added risk. There is <strong>no price-triggered margin call</strong>. Liquidation occurs only if the borrower defaults on payments.</p>
-    <p>Peoples Reserve's <strong>Bitcoin Powered Mortgage (BPM)</strong> is the leading public example. Per company materials (June 2026), BPM uses a tiered-rate ladder — Basic 10.5% APR, Silver 9.5%, Gold 8.5%, Diamond 7.5% — falling as low as <strong>3.5% APR</strong> for Diamond borrowers who over-collateralize toward the 200% maximum; the rate re-prices as Bitcoin moves (roughly each 10% price move, within a 30-day window, based on LTV). Collateral is 1:1 Bitcoin, custody can be multisignature with no rehypothecation, and there is no price-triggered liquidation. <em>Tiers and rates are company-quoted — verify directly with Peoples Reserve before relying on them.</em></p>
-    <p>Peoples Reserve also markets adjacent products (HEBLOC, a Bitcoin-powered Treasury bond) — those are separate structures and out of scope for this deep dive.</p>
+    <h3>Model B, Dynamic-rate adjustment (Peoples Reserve)</h3>
+    <p>The mortgage rate is <strong>variable</strong>, tied to the collateral ratio and Bitcoin's price. If Bitcoin appreciates, the rate falls. If Bitcoin drops, the rate rises, compensating the lender for the added risk. There is <strong>no price-triggered margin call</strong>. Liquidation occurs only if the borrower defaults on payments.</p>
+    <p>Peoples Reserve's <strong>Bitcoin Powered Mortgage (BPM)</strong> is the leading public example. Per company materials (June 2026), BPM uses a tiered-rate ladder, Basic 10.5% APR, Silver 9.5%, Gold 8.5%, Diamond 7.5%, falling as low as <strong>3.5% APR</strong> for Diamond borrowers who over-collateralize toward the 200% maximum; the rate re-prices as Bitcoin moves (roughly each 10% price move, within a 30-day window, based on LTV). Collateral is 1:1 Bitcoin, custody can be multisignature with no rehypothecation, and there is no price-triggered liquidation. <em>Tiers and rates are company-quoted, verify directly with Peoples Reserve before relying on them.</em></p>
+    <p>Peoples Reserve also markets adjacent products (HEBLOC, a Bitcoin-powered Treasury bond), those are separate structures and out of scope for this deep dive.</p>
 
-    <h3>Model C — Delinquency-only liquidation (Better + Coinbase, Fannie Mae conforming)</h3>
-    <p>Unveiled March 2026; first loan funded June 2026 (an Ann Arbor, Michigan couple), with a nationwide rollout planned for summer 2026. The mortgage rate is <strong>fixed</strong> (15- or 30-year), the loan is a <strong>Fannie Mae-backed conforming mortgage</strong>, and — structurally distinct from Models A and B — there are <strong>no price-based margin calls and no top-up requirements regardless of how far BTC drops</strong>. Per Better's published product description, liquidation risk applies <strong>only in the event of a 60-day payment delinquency, the same standard that applies to any conforming mortgage</strong>.</p>
+    <h3>Model C, Delinquency-only liquidation (Better + Coinbase, Fannie Mae conforming)</h3>
+    <p>Unveiled March 2026; first loan funded June 2026 (an Ann Arbor, Michigan couple), with a nationwide rollout planned for summer 2026. The mortgage rate is <strong>fixed</strong> (15- or 30-year), the loan is a <strong>Fannie Mae-backed conforming mortgage</strong>, and, structurally distinct from Models A and B, there are <strong>no price-based margin calls and no top-up requirements regardless of how far BTC drops</strong>. Per Better's published product description, liquidation risk applies <strong>only in the event of a 60-day payment delinquency, the same standard that applies to any conforming mortgage</strong>.</p>
     <p>Collateralization is set up-front: pledge $2.50 of Bitcoin (or $1.25 of USDC) for every $1 of down payment financed. The crypto sits in Coinbase Prime custody for the life of the down-payment loan. BTC price moves do not affect the borrower's monthly obligation, do not trigger margin calls, and do not put the collateral at price-driven liquidation risk.</p>
     <p>Structurally this is the closest product to a traditional conforming mortgage. The crypto serves as up-front collateral for the down-payment loan, not as a continuously monitored LTV variable. <strong>If you pay your monthly mortgage on time, the crypto stays where it is, regardless of BTC's price path.</strong></p>
 
-    <h3>The structural comparison — three models</h3>
+    <h3>The structural comparison, three models</h3>
     <p>All three address the same problem (BTC holder wants real estate without selling BTC) but transfer risk through different mechanisms:</p>
 
     <table class="taxonomy-table">
       <thead>
         <tr>
           <th>Property</th>
-          <th>Model A — Price margin call</th>
-          <th>Model B — Dynamic rate</th>
-          <th>Model C — Delinquency-only</th>
+          <th>Model A, Price margin call</th>
+          <th>Model B, Dynamic rate</th>
+          <th>Model C, Delinquency-only</th>
         </tr>
       </thead>
       <tbody>
@@ -748,15 +748,15 @@
       </tbody>
     </table>
 
-    <p>Model A's risk lives in the asset (forced sale on price). Model B's risk lives in the cash flow (variable payment). Model C's risk lives in the borrower's payment discipline — structurally the closest thing to a traditional mortgage with extra collateral up front.</p>
+    <p>Model A's risk lives in the asset (forced sale on price). Model B's risk lives in the cash flow (variable payment). Model C's risk lives in the borrower's payment discipline, structurally the closest thing to a traditional mortgage with extra collateral up front.</p>
 
-    <p>None is universally better. A borrower with stable income and a strong view that BTC will compound steadily may prefer <strong>Model C</strong> — the conforming structure with no active price-monitoring threshold. A borrower with stable income and a willingness to absorb price-path-dependent payment variability may prefer <strong>Model B</strong>. A borrower with fixed income, lower BTC conviction, and tolerance for the tail-risk of a forced sale event may accept <strong>Model A</strong> (often at the lowest headline rate).</p>
+    <p>None is universally better. A borrower with stable income and a strong view that BTC will compound steadily may prefer <strong>Model C</strong>, the conforming structure with no active price-monitoring threshold. A borrower with stable income and a willingness to absorb price-path-dependent payment variability may prefer <strong>Model B</strong>. A borrower with fixed income, lower BTC conviction, and tolerance for the tail-risk of a forced sale event may accept <strong>Model A</strong> (often at the lowest headline rate).</p>
 
-    <p>The remainder of this deep dive — including the formal mechanics in Part III and the interactive calculator in Part V — primarily models <strong>Model A</strong>, because its price-triggered dynamics produce the cleanest closed-form math and are the most informative for risk-decomposition purposes. <strong>Model C borrowers face no price-based liquidation surface</strong>, so the LTV-evolution math in Part III does not apply to them in the same way. Model B requires a stochastic interest-rate model dependent on BTC's path and is best evaluated case-by-case with the originating lender.</p>
+    <p>The remainder of this deep dive, including the formal mechanics in Part III and the interactive calculator in Part V, primarily models <strong>Model A</strong>, because its price-triggered dynamics produce the cleanest closed-form math and are the most informative for risk-decomposition purposes. <strong>Model C borrowers face no price-based liquidation surface</strong>, so the LTV-evolution math in Part III does not apply to them in the same way. Model B requires a stochastic interest-rate model dependent on BTC's path and is best evaluated case-by-case with the originating lender.</p>
   </div>
 </section>
 
-<!-- PART III — MECHANICS -->
+<!-- PART III, MECHANICS -->
 <section class="part" id="mechanics">
   <div class="container-narrow">
     <div class="part-label">Part III</div>
@@ -764,16 +764,16 @@
     <p>The product can be described by a small set of state variables. Stating them formally clarifies what is and is not at risk.</p>
 
     <ul>
-      <li><code>P(t)</code> — price of Bitcoin at time t (USD per BTC)</li>
-      <li><code>Q</code> — quantity of BTC pledged (fixed at origination)</li>
-      <li><code>L(t)</code> — outstanding loan balance at time t (decreases via amortization)</li>
-      <li><code>LTV(t) = L(t) / (P(t) × Q)</code> — current loan-to-value</li>
-      <li><code>M</code> — the lender's margin-call threshold, expressed as either an LTV ratio or a percentage drop in <code>P(t)</code> from origination</li>
+      <li><code>P(t)</code>, price of Bitcoin at time t (USD per BTC)</li>
+      <li><code>Q</code>, quantity of BTC pledged (fixed at origination)</li>
+      <li><code>L(t)</code>, outstanding loan balance at time t (decreases via amortization)</li>
+      <li><code>LTV(t) = L(t) / (P(t) × Q)</code>, current loan-to-value</li>
+      <li><code>M</code>, the lender's margin-call threshold, expressed as either an LTV ratio or a percentage drop in <code>P(t)</code> from origination</li>
     </ul>
 
-    <p><strong>Important caveat about the threshold:</strong> The mapping between "BTC price drop from origination" and "LTV ratio at which margin call triggers" depends on the initial collateralization. Milo publishes a 65% price-drop threshold for a product structured with ~1:1 BTC-value to loan-principal at origination, which translates to LTV ≈ 2.86 at trigger. Products structured with different initial collateralization ratios (e.g., Better/Coinbase's 2.5:1 BTC-to-loan ratio for the down-payment loan) map a 65% price drop to a very different effective LTV — and Better/Coinbase doesn't use a price-based trigger at all (Model C above). <strong>The threshold logic in this section formalizes Model A (price-based margin call) at the initial-collateralization point Milo uses; it is not a universal rule.</strong></p>
+    <p><strong>Important caveat about the threshold:</strong> The mapping between "BTC price drop from origination" and "LTV ratio at which margin call triggers" depends on the initial collateralization. Milo publishes a 65% price-drop threshold for a product structured with ~1:1 BTC-value to loan-principal at origination, which translates to LTV ≈ 2.86 at trigger. Products structured with different initial collateralization ratios (e.g., Better/Coinbase's 2.5:1 BTC-to-loan ratio for the down-payment loan) map a 65% price drop to a very different effective LTV, and Better/Coinbase doesn't use a price-based trigger at all (Model C above). <strong>The threshold logic in this section formalizes Model A (price-based margin call) at the initial-collateralization point Milo uses; it is not a universal rule.</strong></p>
 
-    <p>For a borrower in a Model A product: good standing as long as <code>LTV(t) &lt; M</code>. When <code>LTV(t) ≥ M</code>, the lender issues a margin call. The borrower can add to <code>Q</code>, reduce <code>L(t)</code>, or do both — or the lender liquidates pledged BTC to restore the LTV.</p>
+    <p>For a borrower in a Model A product: good standing as long as <code>LTV(t) &lt; M</code>. When <code>LTV(t) ≥ M</code>, the lender issues a margin call. The borrower can add to <code>Q</code>, reduce <code>L(t)</code>, or do both, or the lender liquidates pledged BTC to restore the LTV.</p>
 
     <p>Three observations from the dynamics:</p>
     <ul>
@@ -784,11 +784,11 @@
   </div>
 </section>
 
-<!-- PART IV — STATISTICS -->
+<!-- PART IV, STATISTICS -->
 <section class="part" id="statistics">
   <div class="container-narrow">
     <div class="part-label">Part IV</div>
-    <h2>Statistics — Bitcoin's drawdown history</h2>
+    <h2>Statistics, Bitcoin's drawdown history</h2>
     <p>The 65% margin threshold sounds far away. Bitcoin's history says it has happened every cycle.</p>
 
     <table class="stat-table">
@@ -800,7 +800,7 @@
         <tr><td>2013–15</td><td>~$1,150</td><td>~$170</td><td>−85%</td><td>~36 mo</td></tr>
         <tr><td>2017–18</td><td>~$19,800</td><td>~$3,200</td><td>−84%</td><td>~36 mo</td></tr>
         <tr><td>2021–22</td><td>~$69,000</td><td>~$15,500</td><td>−77%</td><td>~24 mo</td></tr>
-        <tr class="median-row"><td>Median</td><td>—</td><td>—</td><td>−85%</td><td>~30 mo</td></tr>
+        <tr class="median-row"><td>Median</td><td>-</td><td>-</td><td>−85%</td><td>~30 mo</td></tr>
       </tbody>
     </table>
 
@@ -830,7 +830,7 @@
       </div>
     </div>
 
-    <p>Past recovery windows have spanned 22–36 months. The structural lesson: <strong>historically, major BTC drawdowns have often reversed over multi-year periods, which means an early forced liquidation can convert a temporary impairment into a permanent loss</strong>. Whether any specific borrower experiences a margin event depends on entry timing, initial collateralization, principal amortization, prepayment behavior, and the lender's specific liquidation logic — so "plan around the assumption that one will occur" is one defensible framing, but is not a mechanical rule. A borrower originating mid-cycle with conservative collateralization and steady prepayments faces materially different risk than one originating at peak with maximum leverage.</p>
+    <p>Past recovery windows have spanned 22–36 months. The structural lesson: <strong>historically, major BTC drawdowns have often reversed over multi-year periods, which means an early forced liquidation can convert a temporary impairment into a permanent loss</strong>. Whether any specific borrower experiences a margin event depends on entry timing, initial collateralization, principal amortization, prepayment behavior, and the lender's specific liquidation logic, so "plan around the assumption that one will occur" is one defensible framing, but is not a mechanical rule. A borrower originating mid-cycle with conservative collateralization and steady prepayments faces materially different risk than one originating at peak with maximum leverage.</p>
 
     <p>The strongest defense is mechanical: <strong>front-loaded principal paydown</strong>. Extra payments in years 1–5 are functionally identical to buying margin-call insurance.</p>
   </div>
@@ -841,9 +841,9 @@
   <div class="calc-header">
     <div class="part-label">Part V · Interactive</div>
     <h2>Run the math on your <span>actual situation</span></h2>
-    <p>Adjust the inputs to your stack, the property, and the lender's terms. The model projects 30 years of LTV evolution, net worth under each scenario, and tax efficiency — and tells you the break-even BTC return.</p>
+    <p>Adjust the inputs to your stack, the property, and the lender's terms. The model projects 30 years of LTV evolution, net worth under each scenario, and tax efficiency, and tells you the break-even BTC return.</p>
     <p style="margin-top:1rem;font-size:0.85rem;color:var(--muted);max-width:64ch;margin-left:auto;margin-right:auto;border:1px dashed rgba(255, 122, 0,0.3);padding:0.75rem 1rem;border-radius:8px;">
-      <strong style="color:var(--primary);">What this calculator models — and what it doesn't.</strong> This projects <strong>Model A</strong> (price-based margin call, Milo-style — fixed rate, margin call at BTC drawdown threshold). It uses <em>smooth annual compounding</em> for BTC price paths, which is a path-independent simplification. <strong>Real BTC price paths are highly path-dependent</strong> — a 60% drawdown in year 2 followed by a recovery to the same end-of-term price produces very different margin-call outcomes than a smooth path with the same CAGR. The calculator's "margin call" output should be read as "did the path ever cross the threshold," not as "did the smooth CAGR end below the threshold." For <strong>Model B</strong> (dynamic-rate, Peoples Reserve-style) and <strong>Model C</strong> (delinquency-only, Better+Coinbase), this projection does not apply — see the Models section above and run the comparison with the originating lender.
+      <strong style="color:var(--primary);">What this calculator models, and what it doesn't.</strong> This projects <strong>Model A</strong> (price-based margin call, Milo-style, fixed rate, margin call at BTC drawdown threshold). It uses <em>smooth annual compounding</em> for BTC price paths, which is a path-independent simplification. <strong>Real BTC price paths are highly path-dependent</strong>, a 60% drawdown in year 2 followed by a recovery to the same end-of-term price produces very different margin-call outcomes than a smooth path with the same CAGR. The calculator's "margin call" output should be read as "did the path ever cross the threshold," not as "did the smooth CAGR end below the threshold." For <strong>Model B</strong> (dynamic-rate, Peoples Reserve-style) and <strong>Model C</strong> (delinquency-only, Better+Coinbase), this projection does not apply, see the Models section above and run the comparison with the originating lender.
     </p>
   </div>
 
@@ -894,7 +894,7 @@
       <div class="input-row">
         <label>Margin call threshold (% BTC drop) <span class="val" id="lbl-margin">65%</span></label>
         <input type="range" id="margin" min="30" max="80" step="5" value="65">
-        <div class="input-help">Milo publishes a 65% drawdown threshold; non-mortgage BTC-collateralized loan products (e.g., Ledn) typically operate at tighter margin thresholds because their LTVs are lower at origination. Verify the specific threshold with the originating lender — this is one of the most product-specific parameters in the category.</div>
+        <div class="input-help">Milo publishes a 65% drawdown threshold; non-mortgage BTC-collateralized loan products (e.g., Ledn) typically operate at tighter margin thresholds because their LTVs are lower at origination. Verify the specific threshold with the originating lender, this is one of the most product-specific parameters in the category.</div>
       </div>
 
       <h3>BTC price scenario</h3>
@@ -913,12 +913,12 @@
       <!-- Headline cards -->
       <div class="headline-cards">
         <div class="headline-card" id="card-pledge">
-          <div class="label">Pledge — net worth at term</div>
+          <div class="label">Pledge, net worth at term</div>
           <div class="value" id="val-pledge">$0</div>
           <div class="sub">Keep BTC. Pay mortgage. Subject to margin call.</div>
         </div>
         <div class="headline-card" id="card-sell">
-          <div class="label">Sell — net worth at term</div>
+          <div class="label">Sell, net worth at term</div>
           <div class="value" id="val-sell">$0</div>
           <div class="sub">Liquidate BTC. Pay tax. Buy home. No BTC exposure.</div>
         </div>
@@ -980,7 +980,7 @@
   </div>
 </section>
 
-<!-- PART VI — RISK SURFACE -->
+<!-- PART VI, RISK SURFACE -->
 <section class="part" id="risk">
   <div class="container-narrow">
     <div class="part-label">Part VI</div>
@@ -1023,13 +1023,13 @@
     <p>The risks are correlated. A BTC drawdown that triggers a margin call typically arrives in the same macro environment as job-loss risk and lender-stress risk. Diversifying across them is harder than it sounds.</p>
 
     <h3>Counterparty risk is the deepest cut</h3>
-    <p>Market risk is publicly observable. You can model it, hedge it, watch it. Counterparty risk hides until it ruptures, and then ruptures fully. The 2022 cohort failures (Celsius, Voyager, BlockFi, Genesis) shared a common pattern across multiple distinct precipitating events: <strong>maturity mismatch, rehypothecation, counterparty concentration, and pooled non-segregated custody</strong>. Each failure also had its own specific triggers — 3AC exposure, FTX/Alameda contagion, run dynamics on yield deposits, regulatory pressure — so reducing 2022 to a single tidy diagnosis would overstate the analysis. The structural pattern across them is more usefully read as a <em>recurring set of vulnerabilities</em> than as a single cause. Ledn and Milo, by contrast, ran with term-matched books, no or limited rehypothecation, counterparty diversification, and bankruptcy-remote custody — and survived the same macro environment.</p>
+    <p>Market risk is publicly observable. You can model it, hedge it, watch it. Counterparty risk hides until it ruptures, and then ruptures fully. The 2022 cohort failures (Celsius, Voyager, BlockFi, Genesis) shared a common pattern across multiple distinct precipitating events: <strong>maturity mismatch, rehypothecation, counterparty concentration, and pooled non-segregated custody</strong>. Each failure also had its own specific triggers, 3AC exposure, FTX/Alameda contagion, run dynamics on yield deposits, regulatory pressure, so reducing 2022 to a single tidy diagnosis would overstate the analysis. The structural pattern across them is more usefully read as a <em>recurring set of vulnerabilities</em> than as a single cause. Ledn and Milo, by contrast, ran with term-matched books, no or limited rehypothecation, counterparty diversification, and bankruptcy-remote custody, and survived the same macro environment.</p>
 
     <p>The lesson for lender evaluation today: <strong>structural questions, not promotional claims</strong>. Marketing about "safety" is noise. What matters is the legal structure of custody, the disclosure of rehypothecation, and the published bankruptcy-remoteness arrangements.</p>
   </div>
 </section>
 
-<!-- PART VII — DECISION -->
+<!-- PART VII, DECISION -->
 <section class="part" id="decision">
   <div class="container-narrow">
     <div class="part-label">Part VII</div>
@@ -1051,14 +1051,14 @@
       <li>Your income is variable or BTC-correlated (working in the industry, BTC-denominated revenue).</li>
       <li>The lender's custody arrangement is opaque or pooled.</li>
       <li>You would be financially fragile if forced to liquidate at the bottom of a cycle.</li>
-      <li>Your cost basis is close to current price — small unrealized gain, small tax-deferral benefit, same downside.</li>
+      <li>Your cost basis is close to current price, small unrealized gain, small tax-deferral benefit, same downside.</li>
     </ul>
 
     <p>The strongest version of the trade is for a holder who is <strong>already past the wealth-building phase</strong> with respect to Bitcoin, has multiple stacks across different storage arrangements, has stable income from non-Bitcoin sources, and is using the mortgage to deploy a small slice of their stack into housing without disturbing the rest.</p>
   </div>
 </section>
 
-<!-- APPENDIX — SOURCES & VERIFICATION -->
+<!-- APPENDIX, SOURCES & VERIFICATION -->
 <section class="part" id="sources">
   <div class="container-narrow">
     <div class="part-label">Appendix · Sources &amp; Verification</div>
@@ -1078,7 +1078,7 @@
           <td><strong>Peoples Reserve</strong> (Model B)</td>
           <td><a href="https://www.peoplesreserve.com/personal-borrow">peoplesreserve.com/personal-borrow</a></td>
           <td>June 2026</td>
-          <td>Bitcoin Powered Mortgage (BPM): tiered APR ladder — Basic 10.5%, Silver 9.5%, Gold 8.5%, Diamond 7.5% — as low as 3.5% for Diamond borrowers at ~200% over-collateralization. Rate re-prices ~each 10% BTC move (30-day window) by LTV. 1:1 BTC collateral, optional multisig, no rehypothecation, no price-triggered liquidation. Tiers are company-quoted — confirm directly.</td>
+          <td>Bitcoin Powered Mortgage (BPM): tiered APR ladder, Basic 10.5%, Silver 9.5%, Gold 8.5%, Diamond 7.5%, as low as 3.5% for Diamond borrowers at ~200% over-collateralization. Rate re-prices ~each 10% BTC move (30-day window) by LTV. 1:1 BTC collateral, optional multisig, no rehypothecation, no price-triggered liquidation. Tiers are company-quoted, confirm directly.</td>
         </tr>
         <tr>
           <td><strong>Better + Coinbase</strong> (Model C)</td>
@@ -1090,7 +1090,7 @@
     </table>
 
     <h3>Numerical computations</h3>
-    <p>The figures in Part V are produced by the on-page interactive calculator, which uses simplified smooth-CAGR compounding across the four scenarios (Bear −5%, Base +5%, Bull +12%, Super +20%). It does <strong>not</strong> model intra-year volatility or stochastic margin-call timing — it formalizes <strong>Model A</strong> (price-based margin call) at Milo's initial-collateralization point and is illustrative, not a forecast. Model B's path-dependent rate and Model C's delinquency-only structure are described qualitatively rather than modeled.</p>
+    <p>The figures in Part V are produced by the on-page interactive calculator, which uses simplified smooth-CAGR compounding across the four scenarios (Bear −5%, Base +5%, Bull +12%, Super +20%). It does <strong>not</strong> model intra-year volatility or stochastic margin-call timing; it formalizes <strong>Model A</strong> (price-based margin call) at Milo's initial-collateralization point and is illustrative, not a forecast. Model B's path-dependent rate and Model C's delinquency-only structure are described qualitatively rather than modeled.</p>
 
     <h3>What we do when sources are unclear</h3>
     <p>Where a product is newly launched or only company-quoted (currently: Peoples Reserve's rate tiers; Better + Coinbase's pre-nationwide-launch terms), we date the figure and label it company-quoted rather than presenting it as independently audited. When a lender's structure changes materially, we note the change explicitly and re-date the entry.</p>
@@ -1109,9 +1109,9 @@
 
 <!-- DISCLAIMER -->
 <div class="disclaimer">
-  <h4>Educational only — not advice</h4>
+  <h4>Educational only, not advice</h4>
   <p>This calculator and accompanying piece are educational. They do not constitute legal, tax, or financial advice. Specific decisions require a CPA, attorney, or financial professional with Bitcoin experience.</p>
-  <p>Projections are scenario analyses, not predictions. Bitcoin's future return distribution is unknown. The calculator uses simplified compounding (smooth CAGR) and does not model intra-year volatility or stochastic margin call events. Real lender terms — rates, margin thresholds, custody structure — vary; verify with the originating lender before relying on any figure.</p>
+  <p>Projections are scenario analyses, not predictions. Bitcoin's future return distribution is unknown. The calculator uses simplified compounding (smooth CAGR) and does not model intra-year volatility or stochastic margin call events. Real lender terms (rates, margin thresholds, custody structure) vary; verify with the originating lender before relying on any figure.</p>
 </div>
 
 <footer>
@@ -1418,7 +1418,7 @@ function update() {
       ? `Pledging wins under ${sel.label} scenario at year ${state.term}.`
       : `Selling wins under ${sel.label} scenario at year ${state.term}.`;
 
-  // LTV chart — show bear, base, bull
+  // LTV chart, show bear, base, bull
   const ltvScenarios = ['bear', 'base', 'bull'];
   ltvChart.data.labels = selProj.path.map(p => 'Y' + p.year);
   ltvChart.data.datasets = ltvScenarios.map(k => {
@@ -1434,7 +1434,7 @@ function update() {
       fill: false
     };
   });
-  // Margin threshold line — LTV at the moment of margin call
+  // Margin threshold line, LTV at the moment of margin call
   // Convert: if BTC drops X%, value is (1-X)*P0*Q. Initial LTV0 = L0/(P0*Q). At drop X, LTV = L/( (1-X)*P0*Q ) = LTV_at_t / (1-X).
   // Margin trigger: when BTC drops by margin%, the "threshold LTV" rises to LTV_at_origination / (1 - margin%).
   const ltvAtOrigination = state.loan / (state.btcQty * state.btcPrice);
@@ -1451,18 +1451,18 @@ function update() {
   ltvChart.options.scales.y.max = Math.max(marginLTV * 1.4, 3);
   ltvChart.update();
 
-  // Net worth chart — selected scenario, pledge vs sell
+  // Net worth chart, selected scenario, pledge vs sell
   nwChart.data.labels = selProj.path.map(p => 'Y' + p.year);
   nwChart.data.datasets = [
     {
-      label: 'Pledge — net worth',
+      label: 'Pledge, net worth',
       data: selProj.path.map(p => p.pledgeNW),
       borderColor: '#FF7A00',
       backgroundColor: 'rgba(255, 122, 0,0.1)',
       borderWidth: 2.5, pointRadius: 0, tension: 0.25, fill: true
     },
     {
-      label: 'Sell — net worth',
+      label: 'Sell, net worth',
       data: selProj.path.map(p => p.sellNW),
       borderColor: '#2A2A2A',
       backgroundColor: 'rgba(154,164,178,0.06)',
@@ -1492,7 +1492,7 @@ function update() {
   ];
   scenarioChart.update();
 
-  // Cost decomposition — cumulative interest vs avoided tax (constant line)
+  // Cost decomposition, cumulative interest vs avoided tax (constant line)
   costsChart.data.labels = selProj.path.map(p => 'Y' + p.year);
   costsChart.data.datasets = [
     {
@@ -1548,12 +1548,12 @@ function update() {
   const breakevenCagr = computeBreakEven();
 
   let txt = `<strong>Pledging beats selling by ${fmt$(Math.abs(delta))}</strong> at year ${state.term} under the ${sel.label} scenario `;
-  txt += delta >= 0 ? '— a clear win for pledging. ' : '— but selling is better here. ';
+  txt += delta >= 0 ? ', a clear win for pledging. ' : ', but selling is better here. ';
 
   txt += `Selling now would create a <strong>${fmt$(taxOwed)}</strong> taxable disposition at the assumed LTCG rate, locking in that tax cost (your actual liability depends on basis, holding period, and applicable rate). Pledging avoids the sale but pays <strong>${fmt$(cumInt30)}</strong> in cumulative mortgage interest over the full ${state.term}-year term.`;
 
   if (mcLines.length > 0) {
-    txt += `<br><br><strong style="color:var(--red);">Margin call risk in scenarios:</strong> ${mcLines.join('; ')}. In a real margin call (Model A only), the lender liquidates pledged BTC at the worst price — and the forced sale is a taxable disposition, which may realize gains or losses depending on your basis and holding period.`;
+    txt += `<br><br><strong style="color:var(--red);">Margin call risk in scenarios:</strong> ${mcLines.join('; ')}. In a real margin call (Model A only), the lender liquidates pledged BTC at the worst price, and the forced sale is a taxable disposition, which may realize gains or losses depending on your basis and holding period.`;
   } else {
     txt += `<br><br><strong style="color:var(--primary);">No margin call</strong> is triggered in any of the four scenarios at the current ${state.margin}% drop threshold. Your collateral has structural buffer.`;
   }
@@ -1630,7 +1630,7 @@ document.querySelectorAll('.scenario-tab').forEach(tab => {
 document.getElementById('today').textContent = new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 
 // =============================================================
-// Init — defensive, with Chart.js wait + visible error reporting
+// Init, defensive, with Chart.js wait + visible error reporting
 // =============================================================
 function showCalcError(msg) {
   const wraps = document.querySelectorAll('.chart-wrap');
@@ -1658,7 +1658,7 @@ function waitForChart() {
   } else if (chartWait++ < 60) {  // ~6 seconds max
     setTimeout(waitForChart, 100);
   } else {
-    showCalcError('Chart.js could not load after 6 seconds. Check the browser console (F12) and your network — an ad blocker or corporate proxy may be blocking cdn.jsdelivr.net and unpkg.com.');
+    showCalcError('Chart.js could not load after 6 seconds. Check the browser console (F12) and your network, an ad blocker or corporate proxy may be blocking cdn.jsdelivr.net and unpkg.com.');
   }
 }
 

--- a/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
@@ -42,8 +42,6 @@
     --faint: #B3B3B3;
     --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
     --grad-soft: linear-gradient(135deg, rgba(255, 122, 0,0.15), rgba(255,215,0,0.05));
-    --green: #28a745;
-    --green-soft: rgba(16,185,129,0.15);
     --red: #dc3545;
     --red-soft: rgba(239,68,68,0.12);
     --yellow: #f59e0b;
@@ -218,7 +216,7 @@
   .taxonomy-table tbody td:first-child { color: var(--dim); font-weight: 500; }
   .taxonomy-table tbody td:not(:first-child) { color: var(--muted); text-align: center; }
   .taxonomy-table tbody tr:hover { background: rgba(255, 122, 0,0.03); }
-  .pill-yes { color: var(--green); font-weight: 600; }
+  .pill-yes { color: var(--primary); font-weight: 600; }
   .pill-no  { color: var(--red); font-weight: 600; }
 
   /* ------- Drawdown table ------- */
@@ -392,7 +390,7 @@
     position: relative;
     overflow: hidden;
   }
-  .headline-card.winner { border-color: var(--green); background: linear-gradient(180deg, rgba(16,185,129,0.06), var(--dark2)); }
+  .headline-card.winner { border-color: var(--primary); background: linear-gradient(180deg, rgba(255,122,0,0.06), var(--dark2)); }
   .headline-card.loser { border-color: var(--red); background: linear-gradient(180deg, rgba(239,68,68,0.05), var(--dark2)); }
   .headline-card .label {
     color: var(--faint);
@@ -411,7 +409,7 @@
     line-height: 1.1;
     margin-bottom: 0.4rem;
   }
-  .headline-card .value.pos { color: var(--green); }
+  .headline-card .value.pos { color: var(--primary); }
   .headline-card .value.neg { color: var(--red); }
   .headline-card .sub {
     font-size: 0.78rem;
@@ -420,9 +418,9 @@
   }
   .headline-card .badge {
     position: absolute; top: 0.85rem; right: 0.85rem;
-    background: rgba(40,167,69,0.15);
-    color: var(--green);
-    border: 1px solid var(--green);
+    background: rgba(255,122,0,0.12);
+    color: var(--primary);
+    border: 1px solid var(--primary);
     font-size: 0.65rem;
     padding: 0.15rem 0.5rem;
     border-radius: 4px;
@@ -716,11 +714,11 @@
 
     <h3>Model B — Dynamic-rate adjustment (Peoples Reserve)</h3>
     <p>The mortgage rate is <strong>variable</strong>, tied to the collateral ratio and Bitcoin's price. If Bitcoin appreciates, the rate falls. If Bitcoin drops, the rate rises — compensating the lender for the added risk. There is <strong>no price-triggered margin call</strong>. Liquidation occurs only if the borrower defaults on payments.</p>
-    <p>Peoples Reserve's <strong>Bitcoin Powered Mortgage (BPM)</strong> is the leading public example. Per company materials and media coverage, rates start around prime + 1 with discounts available for higher collateralization (reportedly reaching low single-digit APRs at substantial over-collateralization); custody uses multisignature wallets with no rehypothecation. <em>Specific rate figures are based on company-quoted terms — verify directly with Peoples Reserve before relying on them.</em></p>
+    <p>Peoples Reserve's <strong>Bitcoin Powered Mortgage (BPM)</strong> is the leading public example. Per company materials (June 2026), BPM uses a tiered-rate ladder — Basic 10.5% APR, Silver 9.5%, Gold 8.5%, Diamond 7.5% — falling as low as <strong>3.5% APR</strong> for Diamond borrowers who over-collateralize toward the 200% maximum; the rate re-prices as Bitcoin moves (roughly each 10% price move, within a 30-day window, based on LTV). Collateral is 1:1 Bitcoin, custody can be multisignature with no rehypothecation, and there is no price-triggered liquidation. <em>Tiers and rates are company-quoted — verify directly with Peoples Reserve before relying on them.</em></p>
     <p>Peoples Reserve also markets adjacent products (HEBLOC, a Bitcoin-powered Treasury bond) — those are separate structures and out of scope for this deep dive.</p>
 
     <h3>Model C — Delinquency-only liquidation (Better + Coinbase, Fannie Mae conforming)</h3>
-    <p>Launched March 2026. The mortgage rate is <strong>fixed</strong>, the loan is a <strong>Fannie Mae-backed conforming mortgage</strong>, and — structurally distinct from Models A and B — there are <strong>no price-based margin calls and no top-up requirements regardless of how far BTC drops</strong>. Per Better's published product description, liquidation risk applies <strong>only in the event of a 60-day payment delinquency, the same standard that applies to any conforming mortgage</strong>.</p>
+    <p>Unveiled March 2026; first loan funded June 2026 (an Ann Arbor, Michigan couple), with a nationwide rollout planned for summer 2026. The mortgage rate is <strong>fixed</strong> (15- or 30-year), the loan is a <strong>Fannie Mae-backed conforming mortgage</strong>, and — structurally distinct from Models A and B — there are <strong>no price-based margin calls and no top-up requirements regardless of how far BTC drops</strong>. Per Better's published product description, liquidation risk applies <strong>only in the event of a 60-day payment delinquency, the same standard that applies to any conforming mortgage</strong>.</p>
     <p>Collateralization is set up-front: pledge $2.50 of Bitcoin (or $1.25 of USDC) for every $1 of down payment financed. The crypto sits in Coinbase Prime custody for the life of the down-payment loan. BTC price moves do not affect the borrower's monthly obligation, do not trigger margin calls, and do not put the collateral at price-driven liquidation risk.</p>
     <p>Structurally this is the closest product to a traditional conforming mortgage. The crypto serves as up-front collateral for the down-payment loan, not as a continuously monitored LTV variable. <strong>If you pay your monthly mortgage on time, the crypto stays where it is, regardless of BTC's price path.</strong></p>
 
@@ -1060,6 +1058,47 @@
   </div>
 </section>
 
+<!-- APPENDIX — SOURCES & VERIFICATION -->
+<section class="part" id="sources">
+  <div class="container-narrow">
+    <div class="part-label">Appendix · Sources &amp; Verification</div>
+    <h2>Where the numbers come from</h2>
+    <p>Every lender figure in this deep dive is publicly stated product information as of the dates below. Bitcoin-backed mortgages are a fast-moving, newly-forming category; rates, thresholds, and product structures change. <strong>Always verify directly with the originating lender before relying on any figure.</strong></p>
+
+    <table class="taxonomy-table">
+      <thead><tr><th>Lender</th><th>Source</th><th>Verified</th><th>Verification note</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><strong>Milo</strong> (Model A)</td>
+          <td><a href="https://www.milo.io/">milo.io</a></td>
+          <td>June 2026</td>
+          <td>Fixed-rate; 65% BTC-drawdown margin-call threshold; at threshold Milo reduces LTV rather than force-liquidating. Company publicly states <strong>zero margin calls and zero liquidations to date</strong>. $100M+ originated, largest single deal $12M (Feb 2026). Confirmed via company site + CoinDesk (Feb 2026).</td>
+        </tr>
+        <tr>
+          <td><strong>Peoples Reserve</strong> (Model B)</td>
+          <td><a href="https://www.peoplesreserve.com/personal-borrow">peoplesreserve.com/personal-borrow</a></td>
+          <td>June 2026</td>
+          <td>Bitcoin Powered Mortgage (BPM): tiered APR ladder — Basic 10.5%, Silver 9.5%, Gold 8.5%, Diamond 7.5% — as low as 3.5% for Diamond borrowers at ~200% over-collateralization. Rate re-prices ~each 10% BTC move (30-day window) by LTV. 1:1 BTC collateral, optional multisig, no rehypothecation, no price-triggered liquidation. Tiers are company-quoted — confirm directly.</td>
+        </tr>
+        <tr>
+          <td><strong>Better + Coinbase</strong> (Model C)</td>
+          <td><a href="https://www.coinbase.com/blog/coinbase-powers-the-first-crypto-backed-conforming-mortgages-by-better">coinbase.com/blog</a></td>
+          <td>June 2026</td>
+          <td>Fannie Mae conforming mortgage plus a separate crypto-collateralized down-payment loan: pledge 2.5× in BTC (or 1.25× in USDC) per $1 of down payment financed; 15- or 30-year fixed; Coinbase Prime custody; liquidation only on payment delinquency (no price-based margin call). Unveiled March 2026, first loan funded June 2026, nationwide rollout planned summer 2026. Per Coinbase/Better announcements + coverage (The Block, HousingWire, Cryptopolitan, June 2026).</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Numerical computations</h3>
+    <p>The figures in Part V are produced by the on-page interactive calculator, which uses simplified smooth-CAGR compounding across the four scenarios (Bear −5%, Base +5%, Bull +12%, Super +20%). It does <strong>not</strong> model intra-year volatility or stochastic margin-call timing — it formalizes <strong>Model A</strong> (price-based margin call) at Milo's initial-collateralization point and is illustrative, not a forecast. Model B's path-dependent rate and Model C's delinquency-only structure are described qualitatively rather than modeled.</p>
+
+    <h3>What we do when sources are unclear</h3>
+    <p>Where a product is newly launched or only company-quoted (currently: Peoples Reserve's rate tiers; Better + Coinbase's pre-nationwide-launch terms), we date the figure and label it company-quoted rather than presenting it as independently audited. When a lender's structure changes materially, we note the change explicitly and re-date the entry.</p>
+
+    <p style="margin-top:1.5rem;font-size:0.88rem;color:var(--muted);">If you spot an error or a figure that has shifted, email <a href="mailto:thesovereign.academy@proton.me">thesovereign.academy@proton.me</a>. Corrections are logged with attribution and dated. See also the educational-only disclaimer below.</p>
+  </div>
+</section>
+
 <!-- CTA -->
 <div class="cta-block">
   <h3>Want the full written deep dive?</h3>
@@ -1078,6 +1117,7 @@
 <footer>
   <p style="margin-bottom:1rem;"><a href="/deep-dives/bitcoin-capital/#start-here" style="color:var(--primary);text-decoration:none;font-weight:600;">← Back to Bitcoin Capital Start Here</a></p>
   <p><a href="/" style="color:var(--primary);text-decoration:none;">Bitcoin Sovereign Academy</a> · <a href="/deep-dives/" style="color:var(--primary);text-decoration:none;">Deep Dives</a> · <a href="/deep-dives/bitcoin-capital/" style="color:var(--primary);text-decoration:none;">Bitcoin Capital</a></p>
+  <p style="margin-top:0.85rem;">Created by Dalia · <a href="https://bitcoinsovereign.academy" style="color:var(--primary);text-decoration:none;">bitcoinsovereign.academy</a></p>
   <p class="footer-meta">v1.0 · Published May 2026 · Last updated <span id="today"></span></p>
 </footer>
 
@@ -1102,7 +1142,7 @@ const state = {
 const SCENARIOS = [
   { key: 'bear',  label: 'Bear',  cagr: -5,  color: '#dc3545' },
   { key: 'base',  label: 'Base',  cagr:  5,  color: '#f59e0b' },
-  { key: 'bull',  label: 'Bull',  cagr: 12,  color: '#28a745' },
+  { key: 'bull',  label: 'Bull',  cagr: 12,  color: '#FFD400' },
   { key: 'super', label: 'Super', cagr: 20,  color: '#3b82f6' }
 ];
 
@@ -1465,7 +1505,7 @@ function update() {
     {
       label: 'Tax saved by not selling (one-time, locked in)',
       data: selProj.path.map(_ => selProj.taxOwed),
-      borderColor: '#28a745',
+      borderColor: '#FF7A00',
       borderDash: [6, 4],
       borderWidth: 2.5, pointRadius: 0, fill: false
     }
@@ -1515,7 +1555,7 @@ function update() {
   if (mcLines.length > 0) {
     txt += `<br><br><strong style="color:var(--red);">Margin call risk in scenarios:</strong> ${mcLines.join('; ')}. In a real margin call (Model A only), the lender liquidates pledged BTC at the worst price — and the forced sale is a taxable disposition, which may realize gains or losses depending on your basis and holding period.`;
   } else {
-    txt += `<br><br><strong style="color:var(--green);">No margin call</strong> is triggered in any of the four scenarios at the current ${state.margin}% drop threshold. Your collateral has structural buffer.`;
+    txt += `<br><br><strong style="color:var(--primary);">No margin call</strong> is triggered in any of the four scenarios at the current ${state.margin}% drop threshold. Your collateral has structural buffer.`;
   }
 
   if (breakevenCagr !== null) {

--- a/deep-dives/bitcoin-capital/index.html
+++ b/deep-dives/bitcoin-capital/index.html
@@ -30,8 +30,6 @@
     --faint: #B3B3B3;
     --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
     --grad-soft: linear-gradient(135deg, rgba(255, 122, 0,0.12), rgba(255,215,0,0.04));
-    --green: #28a745;
-    --green-soft: rgba(16,185,129,0.12);
     --yellow: #f59e0b;
     --yellow-soft: rgba(245,158,11,0.12);
     --blue: #3b82f6;
@@ -534,7 +532,7 @@
     font-weight: 700;
     white-space: nowrap;
   }
-  .pill-shipped { background: var(--green-soft); color: var(--green); border: 1px solid var(--green); }
+  .pill-shipped { background: rgba(255,122,0,0.12); color: var(--primary); border: 1px solid var(--primary); }
   .pill-drafting { background: var(--yellow-soft); color: var(--yellow); border: 1px solid var(--yellow); }
   .pill-researching { background: var(--blue-soft); color: var(--blue); border: 1px solid var(--blue); }
   .pill-planned { background: var(--gray-pill); color: var(--muted); border: 1px solid var(--muted); }
@@ -855,6 +853,7 @@
 
   <footer>
     <p><a href="/">Bitcoin Sovereign Academy</a> · <a href="/deep-dives/">Deep Dives</a> · Bitcoin Capital Series</p>
+    <p style="margin-top:0.85rem;">Created by Dalia · <a href="https://bitcoinsovereign.academy">bitcoinsovereign.academy</a></p>
     <p class="footer-meta">Truthfulness is the first principle · Last updated <span id="today"></span></p>
   </footer>
 

--- a/deep-dives/bitcoin-capital/index.html
+++ b/deep-dives/bitcoin-capital/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Bitcoin Capital — Deep Dive Series | Bitcoin Sovereign Academy</title>
-<meta name="description" content="A multi-piece deep-dive resource on Bitcoin as capital — mortgages, loans, treasury structure, inheritance. First-principles analysis with interactive calculators, comparative provider matrices, and honest trade-off framing.">
+<title>Bitcoin Capital, Deep Dive Series | Bitcoin Sovereign Academy</title>
+<meta name="description" content="A multi-piece deep-dive resource on Bitcoin as capital, mortgages, loans, treasury structure, inheritance. First-principles analysis with interactive calculators, comparative provider matrices, and honest trade-off framing.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/bitcoin-capital/">
-<meta property="og:title" content="Bitcoin Capital — Deep Dive Series">
+<meta property="og:title" content="Bitcoin Capital, Deep Dive Series">
 <meta property="og:description" content="First-principles deep dives on Bitcoin as capital. Real numbers. Honest trade-offs.">
 <meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/bitcoin-capital/">
 <meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg">
@@ -515,7 +515,7 @@
     color: var(--yellow);
     font-weight: 600;
   }
-  .matrix tr.planned td:first-child,
+  .matrix tr.planned td:first-child
   .matrix tr.researching td:first-child {
     color: var(--muted);
     font-weight: 600;
@@ -646,7 +646,7 @@
     <div class="disclosure-inner">
       <span class="disclosure-icon">ⓘ</span>
       <div class="disclosure-text">
-        <strong>Heads-up before you read.</strong> BSA's founder Dalia advises at The Bitcoin Adviser (TBA), the company behind <strong>Loan My Coins</strong> — one of the providers covered in the Loans deep dive in this series. We've made a deliberate choice to scrutinize TBA's products the same way we scrutinize every other provider, including pointing out where they aren't the right fit. The math is the math regardless of who built the product.
+        <strong>Heads-up before you read.</strong> BSA's founder Dalia advises at The Bitcoin Adviser (TBA), the company behind <strong>Loan My Coins</strong>, one of the providers covered in the Loans deep dive in this series. We've made a deliberate choice to scrutinize TBA's products the same way we scrutinize every other provider, including pointing out where they aren't the right fit. The math is the math regardless of who built the product.
       </div>
       <button class="disclosure-dismiss" id="disclosure-dismiss" aria-label="Dismiss disclosure banner">Dismiss ×</button>
     </div>
@@ -661,7 +661,7 @@
       </div>
       <div class="eyebrow">Deep Dive Series</div>
       <h1>First principles. Real numbers. <span>Honest trade-offs.</span></h1>
-      <p class="lede">A multi-piece resource on Bitcoin as capital — mortgages, loans, treasury structure, inheritance. Each deep dive builds its subject from primitives, runs the math, and ships interactive calculators where the math is worth playing with. Truthfulness over tone.</p>
+      <p class="lede">A multi-piece resource on Bitcoin as capital, mortgages, loans, treasury structure, inheritance. Each deep dive builds its subject from primitives, runs the math, and ships interactive calculators where the math is worth playing with. Truthfulness over tone.</p>
     </section>
 
     <!-- ============ START HERE FLOWCHART ============ -->
@@ -683,21 +683,21 @@
           <a href="bitcoin-backed-mortgages.html#models" class="flow-card coming">
             <span class="flow-icon">💰</span>
             <h3>Get cash from my BTC without selling</h3>
-            <p>Liquidity for any purpose — defined-period loan where BTC is collateral, USD or BTC is disbursed. Covers Ledn, Unchained, Lava, LMC, plus Tier 2 providers. Comparative calculator with options-hedge overlay.</p>
+            <p>Liquidity for any purpose, defined-period loan where BTC is collateral, USD or BTC is disbursed. Covers Ledn, Unchained, Lava, LMC, plus Tier 2 providers. Comparative calculator with options-hedge overlay.</p>
             <span class="flow-route">Bitcoin-Backed Loans (drafting) <span class="arrow">→</span></span>
           </a>
 
           <a href="bitcoin-backed-mortgages.html#models" class="flow-card coming">
             <span class="flow-icon">📈</span>
             <h3>Accumulate more BTC strategically</h3>
-            <p>Use existing BTC as a base to acquire more through structural leverage — the "Terminal Bitcoin" strategy. Covered as a specific section of the Loans deep dive.</p>
+            <p>Use existing BTC as a base to acquire more through structural leverage, the "Terminal Bitcoin" strategy. Covered as a specific section of the Loans deep dive.</p>
             <span class="flow-route">Bitcoin-Backed Loans (drafting) <span class="arrow">→</span></span>
           </a>
 
           <a href="#coming-next" class="flow-card coming">
             <span class="flow-icon">🛡️</span>
             <h3>Plan for family / legacy / inheritance</h3>
-            <p>Structures for holding BTC across generations — multisig custody, inheritance planning, family-office collateral positions. Future deep dive in this series.</p>
+            <p>Structures for holding BTC across generations, multisig custody, inheritance planning, family-office collateral positions. Future deep dive in this series.</p>
             <span class="flow-route">Inheritance Planning (planned) <span class="arrow">→</span></span>
           </a>
 
@@ -718,7 +718,7 @@
             <div class="featured-icon">🏠</div>
             <div class="topic">Capital Structure · Real Estate</div>
             <h2>Bitcoin-Backed Mortgages</h2>
-            <p class="summary">Should you pledge or sell your Bitcoin to buy a home? An ontological breakdown of the product, full statistics on BTC's drawdown history, an interactive calculator projecting 30 years of LTV evolution and net-worth comparison, structural risk decomposition, and the 2022 lender autopsy. Covers Model A (price-based margin call — Milo, Better+Coinbase) and Model B (dynamic-rate — Peoples Reserve).</p>
+            <p class="summary">Should you pledge or sell your Bitcoin to buy a home? An ontological breakdown of the product, full statistics on BTC's drawdown history, an interactive calculator projecting 30 years of LTV evolution and net-worth comparison, structural risk decomposition, and the 2022 lender autopsy. Covers Model A (price-based margin call, Milo, Better+Coinbase) and Model B (dynamic-rate, Peoples Reserve).</p>
             <div class="meta">
               <span><strong>25 min</strong> read</span>
               <span><strong>4 charts</strong></span>
@@ -739,7 +739,7 @@
               <span><strong>Comparative calculator</strong></span>
               <span><strong>13 sections</strong></span>
             </div>
-            <span class="open-cta">In active drafting — ETA 4-6 weeks <span class="arrow">→</span></span>
+            <span class="open-cta">In active drafting, ETA 4-6 weeks <span class="arrow">→</span></span>
           </a>
 
         </div>
@@ -769,14 +769,14 @@
                 <td><a href="bitcoin-backed-mortgages.html">Bitcoin-Backed Mortgages</a></td>
                 <td>30-year housing finance with BTC pledged</td>
                 <td>25 min</td>
-                <td>Yes — Model A projection, 4 charts</td>
+                <td>Yes, Model A projection, 4 charts</td>
                 <td><span class="status-pill pill-shipped">Shipped</span></td>
               </tr>
               <tr class="drafting">
                 <td>Bitcoin-Backed Loans</td>
                 <td>1–5 year liquidity from BTC; provider selection</td>
                 <td>~30 min</td>
-                <td>Yes — 9-provider comparison + options overlay</td>
+                <td>Yes, 9-provider comparison + options overlay</td>
                 <td><span class="status-pill pill-drafting">Drafting</span></td>
               </tr>
               <tr class="researching">
@@ -810,7 +810,7 @@
     <section class="major" id="about">
       <div class="container">
         <div class="section-label">About This Resource</div>
-        <h2 class="section-title">How we work — and why you can trust the numbers</h2>
+        <h2 class="section-title">How we work, and why you can trust the numbers</h2>
         <p class="section-sub">Six things that make this resource different from the typical BTC-lending listicle.</p>
 
         <div class="about-grid">
@@ -822,7 +822,7 @@
 
           <div class="about-card">
             <h3>Scope</h3>
-            <p>Centralized BTC-only lending platforms. Bitcoin-backed mortgages. Honest hedge analysis. Multi-asset crypto lenders, DeFi (Sovryn Zero, flash loans), and institutional undercollateralized credit (Maple, TrueFi) are deliberately out of scope — they'd dilute the Bitcoin focus.</p>
+            <p>Centralized BTC-only lending platforms. Bitcoin-backed mortgages. Honest hedge analysis. Multi-asset crypto lenders, DeFi (Sovryn Zero, flash loans), and institutional undercollateralized credit (Maple, TrueFi) are deliberately out of scope, they'd dilute the Bitcoin focus.</p>
           </div>
 
           <div class="about-card">
@@ -832,7 +832,7 @@
 
           <div class="about-card">
             <h3>Disclosures</h3>
-            <p>BSA's founder Dalia advises at The Bitcoin Adviser (TBA), parent of Loan My Coins (LMC). LMC is covered alongside independent competitors, evaluated against the same structural framework. The hedge analysis deliberately corrects misconceptions that benefit all lenders — including LMC — to clarify.</p>
+            <p>BSA's founder Dalia advises at The Bitcoin Adviser (TBA), parent of Loan My Coins (LMC). LMC is covered alongside independent competitors, evaluated against the same structural framework. The hedge analysis deliberately corrects misconceptions that benefit all lenders, including LMC, to clarify.</p>
           </div>
 
           <div class="about-card">


### PR DESCRIPTION
Completes the deferred bitcoin-capital cleanups (the cluster excluded from #124). Off `origin/main`; **no shared-tree disruption**. All 3 pages validate clean (no new html-validate errors).

## Ledn — verified live (ledn.io, June 2026)
The loans page described a **Custodied-vs-Standard split Ledn has retired**, contradicting its own "single product now" callout. Reconciled the whole section to reality:
- **Single Custodied model**, never rehypothecated. Size-tiered APR: 11.49% (<$250K) · 10.99% ($250K–500K) · 10.49% ($500K–1M) · 9.99% ($1M–2M) · 9.25% ($2M+). 50% LTV / 70% margin call / 80% liquidation.
- **Cost table:** two deprecated rows ($62,000/12.4% + $69,500/13.9%) → one current row **$54,950 / 10.99%** ($250K/24mo at the $250K–$500K tier).
- Decision tree, two shortcuts, fit-list, custody line, and the Sources-appendix row all reconciled.

## Mortgages — new verified Sources & Verification appendix
Built the appendix (mirrors loans'), with **live-verified June 2026** rows:
- **Milo** — claims accurate (65% threshold, zero margin calls, $100M+; [CoinDesk Feb 2026](https://www.coindesk.com/business/2026/02/18/crypto-mortgage-specialist-milo-crosses-usd100m-home-loan-milestone-including-record-usd12m-transaction)).
- **Peoples Reserve** — corrected vague "prime+1" → real tier ladder (10.5/9.5/8.5/7.5%, **3.5%** at ~200% over-collateralization).
- **Better + Coinbase** — corrected "Launched March 2026" → unveiled March / first loan June / nationwide summer 2026. The 2.5:1 BTC and 1.25:1 USDC ratios confirmed accurate.
- Did **not** fabricate a math-worksheet path (none exists for mortgages, unlike loans) — described the calculator method honestly instead.

## Brand / voice (all 3)
- **De-green:** removed all `#28a745`/emerald tokens → brand orange (red kept for loss). Mortgages scenario chart bull line → brand yellow `#FFD400` (distinct from amber base).
- **"Verified scenario math" → "Modeled scenario math (illustrative assumptions, not a forecast)."**
- **Locked footer** added to all three.
- **Brand fade already present** (pages already define canonical `--grad #FF7A00→#FFD400`); section-heading h2 fade left off per owner call.

## Out of scope (flagged separately)
These 3 pages have **no `/api/track` analytics or reflect-widget** — the money pages are invisible in the funnel. Spun into its own follow-up task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)