### PR TITLE
demos(safety): warn that browser-generated keys/addresses aren't for real funds

### DIFF
--- a/interactive-demos/bitcoin-key-generator-visual/index.html
+++ b/interactive-demos/bitcoin-key-generator-visual/index.html
@@ -127,6 +127,9 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 .info ul{margin-left:1.2rem}
 .warn{background:rgba(234,84,85,.08);border-left:3px solid var(--red);border-radius:4px;padding:.75rem 1rem;margin:.6rem 0;font-size:.85rem}
 .warn h4{color:var(--red);margin-bottom:.3rem}
+.danger-banner{background:rgba(234,84,85,.14);border:2px solid var(--red);border-radius:8px;padding:1rem 1.2rem;margin:1rem 0 1.4rem;color:var(--text)}
+.danger-banner strong{color:var(--red);display:block;font-size:.95rem;margin-bottom:.35rem}
+.danger-banner p{font-size:.85rem;line-height:1.5;margin:0}
 
 /* ── buttons ── */
 .btn{background:var(--orange);color:#fff;padding:.65rem 1.4rem;border:none;border-radius:8px;font-weight:700;cursor:pointer;transition:all .2s;font-size:.9rem;margin:.25rem}
@@ -167,6 +170,12 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 <div class="hdr">
     <h1>🔑 Bitcoin Key Generator</h1>
     <p>Real cryptography, live and reactive — change one bit, watch everything cascade</p>
+</div>
+
+<!-- ── SAFETY BANNER ── -->
+<div class="danger-banner" role="alert">
+    <strong>⚠️ Educational only. Never send real Bitcoin to any key or address shown here.</strong>
+    <p>These are genuine, valid Bitcoin keys, but they are generated and displayed inside your web browser, where other software, extensions, or anyone watching your screen could capture them. A key that has touched a browser is never safe to hold real funds. To hold real Bitcoin, generate your keys offline on a hardware wallet and never type or paste a real seed into any website.</p>
 </div>
 
 <!-- ── ERROR BAR ── -->

--- a/interactive-demos/wallet-security-workshop/index.html
+++ b/interactive-demos/wallet-security-workshop/index.html
@@ -884,12 +884,13 @@
                         <div class="derivation-path">
                             Path: <span id="derivationPath"></span>
                         </div>
+                        <p style="margin-top:.6rem;font-size:.8rem;color:var(--red,#ea5455);font-weight:600;">⚠️ Demo address, illustrative only. Never send real Bitcoin to this address.</p>
                     </div>
 
                     <div id="qrContainer" class="qr-container" style="display: none;">
                         <h3>QR Code</h3>
                         <canvas id="qrCode" class="qr-code"></canvas>
-                        <p><small>Scan to share address</small></p>
+                        <p><small>Demo QR for this illustrative address, not for receiving real funds.</small></p>
                     </div>
 
                     <div id="multipleAddresses" style="display: none;">


### PR DESCRIPTION
## Why
Read-only audit of the interactive-demos group surfaced a real money-loss risk:

- **`bitcoin-key-generator-visual`** generates **genuine, spendable mainnet keys and addresses in the browser** (confirmed real secp256k1 + `base58Check(0x00…)` → `1…` + `bech32('bc'…)` → `bc1q…` in `bitcoin-crypto.js`), with copy buttons and only generic "keep your seed secret" notes. Nothing told the learner that a key shown in a browser must never hold real funds.
- **`wallet-security-workshop`** shows a *fake* (`simpleHash`) address with a QR captioned **"Scan to share address"** and no demo label — someone could fund a junk address.

## What
- Persistent red danger banner on the key generator: educational only, generated in-browser where other software can capture them, never fund, use a hardware wallet offline for real keys.
- "Demo address, illustrative only. Never send real Bitcoin" note under the workshop address + relabel the QR caption.

Additive only; no logic touched. No em dashes (house rule). Verified rendering in a worktree static server.

This is **PR-A (safety)**, the first of a batched demos-audit cleanup (brand/font sweep, mechanical-truth fixes, and per-demo rewrites follow as separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)