### PR TITLE
Austrian economics deep-dives: rebuild as two-sided research labs

### DIFF
--- a/deep-dives/austrian-economics/economic-calculation-problem.html
+++ b/deep-dives/austrian-economics/economic-calculation-problem.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Economic Calculation Problem: The Case for Decentralization | Bitcoin Sovereign Academy</title>
-    <meta name="description" content="Discover Hayek's economic calculation problem - why central planning fails and markets coordinate without rulers. Learn why Bitcoin's decentralized design outperforms central control.">
+    <title>The Economic Calculation Problem: Can an Economy Run Without Prices? | Bitcoin Sovereign Academy</title>
+    <meta name="description" content="A research lab on Mises's calculation problem and Hayek's knowledge problem: try to plan without prices, see why coordination is hard, and weigh whether modern computing changes the answer. Inform, not convince.">
 
     <style>
         :root {
@@ -17,336 +17,139 @@
             --warning-orange: #FF7A00;
             --error-red: #dc3545;
         }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background: var(--primary-dark); color: var(--text-light); line-height: 1.6; padding: 2rem 1rem; }
+        .container { max-width: 1000px; margin: 0 auto; }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        .module-header { text-align: center; margin-bottom: 3rem; padding: 3rem 2rem; background: #101010; border-radius: 16px; border: 3px solid var(--accent-bronze); }
+        .module-icon { font-size: 5rem; margin-bottom: 1rem; animation: pulse 3s ease-in-out infinite; }
+        @keyframes pulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.05); } }
+        @media (prefers-reduced-motion: reduce) { .module-icon { animation: none; } }
+        h1 { font-size: 2.8rem; color: var(--accent-bronze); margin-bottom: 1rem; font-weight: 800; }
+        .module-subtitle { font-size: 1.25rem; color: var(--text-dim); max-width: 820px; margin: 0 auto 1.5rem; line-height: 1.8; }
+        .breadcrumb { text-align: center; margin-top: 1.5rem; font-size: 0.9rem; color: var(--text-dim); }
+        .breadcrumb a { color: var(--accent-bronze); text-decoration: none; transition: color 0.3s; }
+        .breadcrumb a:hover { color: var(--accent-gold); }
 
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: var(--primary-dark);
-            color: var(--text-light);
-            line-height: 1.6;
-            padding: 2rem 1rem;
-        }
+        .research-question { background: #101010; border: 2px solid var(--accent-bronze); border-radius: 12px; padding: 1.75rem 2rem; margin: 0 auto 2.5rem; max-width: 1000px; }
+        .research-question .label { font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent-bronze); font-weight: 700; }
+        .research-question p { font-size: 1.25rem; line-height: 1.6; margin-top: 0.5rem; color: var(--text-light); }
 
-        .container {
-            max-width: 1000px;
-            margin: 0 auto;
-        }
+        .content-section { background: var(--secondary-dark); border-radius: 16px; padding: 3rem; margin-bottom: 2.5rem; border: 2px solid rgba(139, 111, 71, 0.3); }
+        .content-section h2 { color: var(--accent-bronze); font-size: 2rem; margin-bottom: 1.5rem; font-weight: 700; }
+        .content-section h3 { color: var(--accent-bronze-light); font-size: 1.4rem; margin: 2rem 0 1rem; font-weight: 600; }
+        .content-section p { color: var(--text-light); margin-bottom: 1.5rem; line-height: 1.9; font-size: 1.05rem; }
+        .content-section strong { color: var(--accent-gold); font-weight: 600; }
+        .content-section ul { list-style: none; padding-left: 0; margin: 1.5rem 0; }
+        .content-section li { padding: 0.85rem 0 0.85rem 1.5rem; position: relative; color: var(--text-light); line-height: 1.8; border-bottom: 1px solid rgba(139, 111, 71, 0.1); }
+        .content-section li:last-child { border-bottom: none; }
+        .content-section li:before { content: "›"; position: absolute; left: 0; color: var(--accent-bronze); font-weight: 700; }
 
-        /* Header */
-        .module-header {
-            text-align: center;
-            margin-bottom: 3rem;
-            padding: 3rem 2rem;
-            background: #101010;
-            border-radius: 16px;
-            border: 3px solid var(--accent-bronze);
-        }
+        .highlight-box { background: #101010; border-left: 5px solid var(--accent-gold); padding: 2rem; margin: 2rem 0; border-radius: 8px; }
+        .highlight-box h4 { color: var(--accent-gold); margin-bottom: 1rem; font-size: 1.25rem; }
+        .highlight-box p { margin-bottom: 1rem; }
+        .highlight-box p:last-child { margin-bottom: 0; }
 
-        .module-icon {
-            font-size: 5rem;
-            margin-bottom: 1rem;
-            animation: pulse 3s ease-in-out infinite;
-        }
+        .steelman-box { background: #101010; border: 2px solid #5a78a0; border-radius: 12px; padding: 2rem; margin: 2rem 0; }
+        .steelman-box h4 { color: #9db8da; font-size: 1.2rem; margin-bottom: 1rem; }
+        .steelman-box .response { margin-top: 1.25rem; padding-top: 1.25rem; border-top: 1px solid rgba(255,255,255,0.12); }
+        .steelman-box .response strong { color: var(--accent-gold); }
 
-        @keyframes pulse {
-            0%, 100% { transform: scale(1); }
-            50% { transform: scale(1.05); }
-        }
+        .myth { background: rgba(0,0,0,0.3); border-radius: 10px; padding: 1.5rem; margin: 1.25rem 0; border-left: 4px solid #2A2A2A; }
+        .myth .myth-label { color: var(--text-dim); font-weight: 700; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .myth .reality-label { color: var(--accent-bronze); font-weight: 700; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .myth p { margin: 0.35rem 0 1rem; }
+        .myth p:last-child { margin-bottom: 0; }
 
-        h1 {
-            font-size: 2.8rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-gold));
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            margin-bottom: 1rem;
-            font-weight: 800;
-        }
+        .data-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
+        table.compare { width: 100%; border-collapse: collapse; font-size: 0.95rem; min-width: 640px; }
+        table.compare th, table.compare td { padding: 0.75rem 0.85rem; text-align: left; border-bottom: 1px solid rgba(255,255,255,0.1); vertical-align: top; }
+        table.compare thead th { color: var(--accent-bronze); border-bottom: 2px solid rgba(255,122,0,0.4); font-weight: 700; }
+        table.compare td:first-child, table.compare th:first-child { font-weight: 600; }
+        table.compare caption { caption-side: bottom; color: var(--text-dim); font-size: 0.82rem; padding-top: 0.75rem; text-align: left; }
 
-        .module-subtitle {
-            font-size: 1.3rem;
-            color: var(--text-dim);
-            max-width: 800px;
-            margin: 0 auto 1.5rem;
-            line-height: 1.8;
-        }
+        .interactive { background: #101010; border: 2px solid var(--accent-bronze); border-radius: 12px; padding: 2rem; margin: 2rem 0; }
+        .interactive h4 { color: var(--accent-bronze); font-size: 1.2rem; margin-bottom: 0.5rem; }
+        .interactive .hint { color: var(--text-dim); font-size: 0.9rem; margin-bottom: 1.25rem; }
+        .interactive label { display: block; margin: 0.75rem 0 0.35rem; font-weight: 600; }
+        .interactive input[type="range"] { width: 100%; accent-color: var(--accent-bronze); }
+        .interactive button { background: var(--accent-bronze); color: #101010; border: none; border-radius: 8px; padding: 0.65rem 1.4rem; font-weight: 700; font-size: 0.95rem; cursor: pointer; margin: 1rem 0.5rem 0 0; }
+        .interactive button:hover { background: var(--accent-gold); }
+        .interactive button.secondary { background: transparent; color: var(--accent-bronze); border: 1px solid var(--accent-bronze); }
+        .interactive .readout { font-size: 1.05rem; font-weight: 700; color: var(--accent-bronze); }
+        .choice-btn { display: block; width: 100%; text-align: left; background: var(--secondary-dark); color: var(--text-light); border: 1px solid rgba(255,255,255,0.2); border-radius: 8px; padding: 0.75rem 1rem; margin: 0.5rem 0; cursor: pointer; font-size: 0.98rem; }
+        .choice-btn:hover { border-color: var(--accent-bronze); }
+        .reveal { margin-top: 1.25rem; padding-top: 1.25rem; border-top: 1px solid rgba(255,255,255,0.12); }
+        .reveal[hidden] { display: none; }
+        .barline { display: grid; grid-template-columns: 130px 1fr; align-items: center; gap: 0.75rem; margin: 0.4rem 0; }
+        .barline .name { color: var(--text-dim); font-size: 0.88rem; }
+        .barline .bar-track { background: rgba(255,255,255,0.06); border-radius: 4px; overflow: hidden; height: 1.4rem; }
+        .barline .bar-fill { background: var(--accent-bronze); height: 1.4rem; border-radius: 4px; }
 
-        .breadcrumb {
-            text-align: center;
-            margin-top: 1.5rem;
-            font-size: 0.9rem;
-            color: var(--text-dim);
-        }
+        .socratic-section { background: #101010; border-radius: 16px; padding: 3rem; margin-bottom: 2.5rem; border: 2px solid #2A2A2A; }
+        .socratic-section h3 { color: #FF7A00; margin-bottom: 2rem; font-size: 1.8rem; }
+        .question { background: rgba(0, 0, 0, 0.3); padding: 1.5rem; border-radius: 8px; margin-bottom: 1.5rem; border-left: 4px solid #FF7A00; }
+        .question-number { color: #FF7A00; font-weight: 700; font-size: 1.2rem; margin-right: 0.5rem; }
 
-        .breadcrumb a {
-            color: var(--accent-bronze);
-            text-decoration: none;
-            transition: color 0.3s;
-        }
+        .sources-section { background: var(--secondary-dark); border-radius: 16px; padding: 2.5rem 3rem; margin-bottom: 2.5rem; border: 2px solid rgba(139,111,71,0.3); }
+        .sources-section h2 { color: var(--accent-bronze); font-size: 1.6rem; margin-bottom: 0.5rem; }
+        .sources-section .asof { color: var(--text-dim); font-size: 0.85rem; margin-bottom: 1.5rem; }
+        .sources-section ol { padding-left: 1.25rem; }
+        .sources-section li { padding: 0.5rem 0; color: var(--text-dim); font-size: 0.92rem; line-height: 1.6; }
+        .sources-section a { color: var(--accent-bronze); text-decoration: none; }
+        .sources-section a:hover { text-decoration: underline; }
 
-        .breadcrumb a:hover {
-            color: var(--accent-gold);
-        }
+        .nav-buttons { display: flex; gap: 1.5rem; justify-content: space-between; margin: 3rem 0; flex-wrap: wrap; }
+        .nav-btn { display: inline-block; padding: 1rem 2rem; background: var(--secondary-dark); color: var(--text-light); text-decoration: none; border-radius: 12px; border: 2px solid var(--accent-bronze); font-weight: 600; transition: all 0.3s ease; text-align: center; flex: 1; min-width: 200px; }
+        .nav-btn:hover { background: var(--accent-bronze); transform: translateY(-2px); }
+        .nav-btn.primary { background: var(--accent-bronze); color: white; }
+        .nav-btn.primary:hover { background: var(--accent-gold); }
 
-        /* Content Sections */
-        .content-section {
-            background: var(--secondary-dark);
-            border-radius: 16px;
-            padding: 3rem;
-            margin-bottom: 2.5rem;
-            border: 2px solid rgba(139, 111, 71, 0.3);
-            transition: all 0.3s ease;
-        }
-
-        .content-section:hover {
-            border-color: var(--accent-bronze);
-            box-shadow: 0 8px 24px rgba(139, 111, 71, 0.2);
-        }
-
-        .content-section h2 {
-            color: var(--accent-bronze);
-            font-size: 2rem;
-            margin-bottom: 1.5rem;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-        }
-
-        .content-section h3 {
-            color: var(--accent-bronze-light);
-            font-size: 1.5rem;
-            margin: 2rem 0 1rem;
-            font-weight: 600;
-        }
-
-        .content-section p {
-            color: var(--text-light);
-            margin-bottom: 1.5rem;
-            line-height: 1.9;
-            font-size: 1.05rem;
-        }
-
-        .content-section strong {
-            color: var(--accent-gold);
-            font-weight: 600;
-        }
-
-        .content-section ul {
-            list-style: none;
-            padding-left: 0;
-            margin: 1.5rem 0;
-        }
-
-        .content-section li {
-            padding: 1rem 0 1rem 2.5rem;
-            position: relative;
-            color: var(--text-light);
-            line-height: 1.8;
-            border-bottom: 1px solid rgba(139, 111, 71, 0.1);
-        }
-
-        .content-section li:last-child {
-            border-bottom: none;
-        }
-
-        .content-section li:before {
-            content: "📊";
-            position: absolute;
-            left: 0;
-            font-size: 1.2rem;
-        }
-
-        /* Highlight Boxes */
-        .highlight-box {
-            background: #101010;
-            border-left: 5px solid var(--accent-gold);
-            padding: 2rem;
-            margin: 2rem 0;
-            border-radius: 8px;
-        }
-
-        .highlight-box h4 {
-            color: var(--accent-gold);
-            margin-bottom: 1rem;
-            font-size: 1.3rem;
-        }
-
-        .highlight-box p {
-            margin-bottom: 1rem;
-        }
-
-        /* Comparison Grid */
-        .comparison-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 2rem;
-            margin: 2rem 0;
-        }
-
-        .comparison-card {
-            background: rgba(0, 0, 0, 0.3);
-            padding: 2rem;
-            border-radius: 12px;
-            transition: all 0.3s ease;
-        }
-
-        .comparison-card.good {
-            border: 2px solid #2A2A2A;
-        }
-
-        .comparison-card.bad {
-            border: 2px solid var(--error-red);
-        }
-
-        .comparison-card h4 {
-            font-size: 1.2rem;
-            margin-bottom: 1rem;
-        }
-
-        .comparison-card.good h4 {
-            color: #F7F7F2;
-        }
-
-        .comparison-card.bad h4 {
-            color: var(--error-red);
-        }
-
-        /* Socratic Section */
-        .socratic-section {
-            background: #101010;
-            border-radius: 16px;
-            padding: 3rem;
-            margin-bottom: 2.5rem;
-            border: 2px solid #2A2A2A;
-        }
-
-        .socratic-section h3 {
-            color: #FF7A00;
-            margin-bottom: 2rem;
-            font-size: 1.8rem;
-        }
-
-        .question {
-            background: rgba(0, 0, 0, 0.3);
-            padding: 1.5rem;
-            border-radius: 8px;
-            margin-bottom: 1.5rem;
-            border-left: 4px solid #FF7A00;
-        }
-
-        .question-number {
-            color: #FF7A00;
-            font-weight: 700;
-            font-size: 1.2rem;
-            margin-right: 0.5rem;
-        }
-
-        /* Navigation */
-        .nav-buttons {
-            display: flex;
-            gap: 1.5rem;
-            justify-content: space-between;
-            margin: 3rem 0;
-            flex-wrap: wrap;
-        }
-
-        .nav-btn {
-            display: inline-block;
-            padding: 1rem 2rem;
-            background: var(--secondary-dark);
-            color: var(--text-light);
-            text-decoration: none;
-            border-radius: 12px;
-            border: 2px solid var(--accent-bronze);
-            font-weight: 600;
-            transition: all 0.3s ease;
-            text-align: center;
-            flex: 1;
-            min-width: 200px;
-        }
-
-        .nav-btn:hover {
-            background: var(--accent-bronze);
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(139, 111, 71, 0.3);
-        }
-
-        .nav-btn.primary {
-            background: var(--accent-bronze);
-            color: white;
-        }
-
-        .nav-btn.primary:hover {
-            background: var(--accent-gold);
-        }
-
-        /* Responsive */
         @media (max-width: 768px) {
-            .module-header {
-                padding: 2rem 1rem;
-            }
-
-            h1 {
-                font-size: 2rem;
-            }
-
-            .module-subtitle {
-                font-size: 1.1rem;
-            }
-
-            .content-section {
-                padding: 2rem 1.5rem;
-            }
-
-            .comparison-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .nav-buttons {
-                flex-direction: column;
-            }
+            .module-header { padding: 2rem 1rem; }
+            h1 { font-size: 2rem; }
+            .module-subtitle { font-size: 1.1rem; }
+            .content-section { padding: 2rem 1.5rem; }
+            .nav-buttons { flex-direction: column; }
         }
     </style>
     <link rel="stylesheet" href="/css/icons.css">
-<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/economic-calculation-problem"><meta property="og:title" content="Economic Calculation Problem - Bitcoin Sovereign Academy"><meta property="og:description" content="Learn about economic calculation problem at Bitcoin Sovereign Academy. Interactive Bitcoin education with hands-on exercises and expert guidance."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/economic-calculation-problem"><meta property="og:type" content="website"><script type="application/ld+json">{
+<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/economic-calculation-problem"><meta property="og:title" content="The Economic Calculation Problem: Can an Economy Run Without Prices?"><meta property="og:description" content="Try to plan an economy without prices, then see why Mises and Hayek argued it cannot be done well, and whether modern computing changes the answer."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/economic-calculation-problem"><meta property="og:type" content="article"><script type="application/ld+json">{
   "@context": "https://schema.org",
-  "@type": "EducationalOrganization",
-  "name": "Bitcoin Sovereign Academy",
-  "description": "Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here.",
-  "url": "https://bitcoinsovereign.academy",
-  "logo": "https://bitcoinsovereign.academy/assets/og-image.jpg",
-  "sameAs": [
-    "https://github.com/Sovereigndwp/bitcoin-sovereign-academy"
-  ],
-  "educationalLevel": "Beginner to Advanced",
+  "@type": "LearningResource",
+  "name": "The Economic Calculation Problem: Can an Economy Run Without Prices?",
+  "learningResourceType": "Deep dive",
+  "educationalLevel": "Intermediate to Advanced",
+  "isAccessibleForFree": true,
   "teaches": [
-    "Bitcoin Fundamentals",
-    "Cryptocurrency Technology",
-    "Financial Sovereignty",
-    "Digital Asset Security"
+    "Mises's calculation problem and Hayek's knowledge problem",
+    "How prices carry dispersed information",
+    "Why central coordination of an economy is hard",
+    "Whether modern computing changes the argument",
+    "How Bitcoin coordinates by rule without a central planner"
   ],
-  "audience": {
-    "@type": "Audience",
-    "audienceType": "Students interested in Bitcoin and cryptocurrency"
-  }
+  "publisher": { "@type": "EducationalOrganization", "name": "Bitcoin Sovereign Academy", "url": "https://bitcoinsovereign.academy" }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
+
+<!-- content-graph edges (BSA ontology)
+content_type: deep_dive
+strategic_role: economics_first_principles
+teaches: [calculation_problem, knowledge_problem, price_signals, spontaneous_order, rule_based_coordination]
+repairs: [misconception_bitcoin_solved_the_calculation_problem, misconception_central_planning_just_needs_better_tech, misconception_prices_are_arbitrary]
+supports_decision: [why_decentralized_coordination_can_outperform_central_control]
+bridges_to: [/deep-dives/austrian-economics/sound-money-theory.html, /interactive-demos/consensus-game/, /deep-dives/austrian-economics/time-preference-fundamentals.html]
+blocked_by_boundary: [no_direct_tba_funnel]
+-->
 </head>
 <body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
-        <!-- Header -->
         <header class="module-header">
             <div class="module-icon">📊</div>
             <h1>The Economic Calculation Problem</h1>
             <p class="module-subtitle">
-                How do millions of people coordinate without a central planner? Discover Hayek's insights on knowledge, prices, and why Bitcoin's decentralized design outperforms central control.
+                A research lab on a deceptively simple question: can anyone, or any computer, coordinate an economy without market prices? Try it yourself, see why Mises and Hayek argued it cannot be done well, and weigh whether modern computing changes the answer.
             </p>
             <div class="breadcrumb">
                 <a href="/">Home</a> →
@@ -356,444 +159,163 @@
             </div>
         </header>
 
-        <!-- Introduction -->
+        <div class="research-question">
+            <span class="label">The question we are investigating</span>
+            <p>A pencil has no single maker. If no one person knows how to produce even a pencil, how does an economy of billions of goods coordinate itself? And could a central planner do it instead?</p>
+        </div>
+
         <section class="content-section">
-            <h2><span data-icon="brain"></span> The Central Question</h2>
-            
+            <h2>Why this matters</h2>
             <p>
-                In 1920, Austrian economist <strong>Ludwig von Mises</strong> posed a devastating challenge to socialism:
+                This is not an abstract debate. The same question sits underneath central planning, central banking, central bank digital currencies, and the design of Bitcoin. Each is an answer to "who decides, and on what information?" Getting the question right is the difference between understanding those systems and just having opinions about them.
             </p>
-
-            <div class="highlight-box">
-                <h4>❓ The Mises Challenge</h4>
-                <p style="font-size: 1.1rem;">
-                    <strong>"How can a central planner possibly know what to produce, how much to produce, and how to allocate resources efficiently — without market prices to signal scarcity and demand?"</strong>
-                </p>
-            </div>
-
             <p>
-                This became known as the <strong>economic calculation problem</strong>. It's not a political argument. It's a <strong>knowledge problem</strong>.
-            </p>
-
-            <p>
-                Mises proved that <strong>without private property and market prices, rational economic calculation is impossible</strong>. Central planners can't calculate because they lack the information that only markets provide.
-            </p>
-
-            <p>
-                Decades later, <strong>Friedrich Hayek</strong> extended this insight in his landmark 1945 essay <em>"The Use of Knowledge in Society"</em> — showing that the key economic problem isn't how to allocate <em>known</em> resources, but <strong>how to discover and use knowledge scattered across millions of minds</strong>.
-            </p>
-
-            <p>
-                This same logic explains why <strong>Bitcoin's decentralized architecture beats centralized alternatives</strong>. It's not just about philosophy — it's about information, calculation, and survival.
+                In 1920 Ludwig von Mises argued that a fully planned economy cannot calculate rationally, because without market prices for capital goods, planners have no way to compare the countless possible uses of resources. In 1945 Friedrich Hayek sharpened the point: the knowledge an economy needs is dispersed across millions of people and is often tacit, local, and changing. No central body can gather it in time. We will test that claim, not just assert it.
             </p>
         </section>
 
-        <!-- The Knowledge Problem -->
         <section class="content-section">
-            <h2>🧠 Hayek's Knowledge Problem</h2>
-
-            <h3>The Central Planner's Impossible Task</h3>
+            <h2>Try it: plan without prices</h2>
             <p>
-                Imagine you're a central planner tasked with running an economy. Your job:
-            </p>
-            <ul>
-                <li>Decide how many shoes to produce this year</li>
-                <li>Determine optimal steel allocation between cars, buildings, and bridges</li>
-                <li>Set wages for every profession</li>
-                <li>Price every good and service</li>
-                <li>Coordinate millions of workers and resources</li>
-            </ul>
-
-            <p>
-                <strong>Question:</strong> How would you get the information to make these decisions?
+                You are the planner. You have 100 workers to assign across three goods. People need all three, but you cannot see how much they need, because there is no market and no prices telling you. Make your best guess, then see how close you came.
             </p>
 
-            <h3>Knowledge Is Dispersed</h3>
-            <p>
-                Hayek's insight: <strong>The knowledge necessary for economic coordination doesn't exist in any single mind or institution</strong>.
-            </p>
-
-            <div class="highlight-box">
-                <h4>💡 Hayek's Core Insight</h4>
-                <p>
-                    <strong>"The peculiar character of the problem of a rational economic order is determined precisely by the fact that the knowledge of the circumstances of which we must make use never exists in concentrated or integrated form but solely as the dispersed bits of incomplete and frequently contradictory knowledge which all the separate individuals possess."</strong>
-                </p>
-                <p style="margin: 0; font-size: 0.95rem; font-style: italic;">
-                    — Friedrich Hayek, "The Use of Knowledge in Society" (1945)
-                </p>
+            <div class="interactive" id="plan-tool">
+                <h4>Allocate 100 workers</h4>
+                <p class="hint">Move the sliders. They do not have to sum to 100; the tool scales your mix to 100 workers when you run the plan. Then reveal what the people actually needed.</p>
+                <label for="a-bread">Bread: <span class="readout" id="a-bread-v">33</span></label>
+                <input type="range" id="a-bread" min="0" max="100" value="33">
+                <label for="a-house">Housing: <span class="readout" id="a-house-v">33</span></label>
+                <input type="range" id="a-house" min="0" max="100" value="33">
+                <label for="a-phone">Phones: <span class="readout" id="a-phone-v">33</span></label>
+                <input type="range" id="a-phone" min="0" max="100" value="33">
+                <button id="plan-run" type="button">Run the plan</button>
+                <button id="plan-reveal" class="secondary" type="button">Reveal what prices would have shown</button>
+                <div class="reveal" id="plan-result" hidden></div>
             </div>
-
             <p>
-                Knowledge is <strong>local, tacit, and constantly changing</strong>:
-            </p>
-            <ul>
-                <li><strong>Local:</strong> The farmer knows his soil. The factory worker knows his machine. The consumer knows her preferences</li>
-                <li><strong>Tacit:</strong> Much knowledge can't be written down or transmitted — it's "know-how" gained through experience</li>
-                <li><strong>Dynamic:</strong> Conditions change every second. Yesterday's optimal plan is today's waste</li>
-            </ul>
-
-            <p>
-                No planner can know:
-            </p>
-            <ul>
-                <li>Which mechanic is most skilled at fixing a specific engine</li>
-                <li>That a drought is forming in a distant region</li>
-                <li>That consumer tastes are shifting from product A to product B</li>
-                <li>That a new technology makes process X obsolete</li>
-            </ul>
-
-            <p>
-                <strong>Central planning fails not because planners are stupid, but because the knowledge problem is unsolvable.</strong>
+                However you did, notice the core difficulty: you were guessing. A market does not guess. When bread runs short its price rises, which pulls workers toward baking and signals shoppers to economize, all without anyone issuing an order. The price is not arbitrary; it is compressed information about a scarcity only the buyers and sellers could know.
             </p>
         </section>
 
-        <!-- Prices as Information -->
         <section class="content-section">
-            <h2>💰 Prices: The Distributed Information System</h2>
-
+            <h2>Prices as a signal: predict the shock</h2>
             <p>
-                Hayek's solution: <strong>We don't need a central planner. We have prices.</strong>
+                Hayek's claim was that prices move knowledge no planner could collect. Test your intuition on a concrete shock before reading the answer.
             </p>
-
-            <h3>How Prices Communicate Knowledge</h3>
-            <p>
-                Prices are not just numbers. <strong>They are signals that carry knowledge</strong> about:
-            </p>
-            <ul>
-                <li><strong>Scarcity:</strong> High prices signal "this resource is scarce"</li>
-                <li><strong>Demand:</strong> Rising prices signal "more people want this"</li>
-                <li><strong>Opportunity cost:</strong> Prices reveal what must be sacrificed to get something</li>
-                <li><strong>Profit opportunities:</strong> Price gaps signal where resources should flow</li>
-            </ul>
-
-            <h3>The Miracle of Market Coordination</h3>
-            <p>
-                Consider a simple example: <strong>A hurricane destroys oil refineries in the Gulf of Mexico</strong>.
-            </p>
-
-            <p>
-                <strong>Without central planning, the market responds instantly:</strong>
-            </p>
-            <ul>
-                <li>Oil prices spike → signals scarcity</li>
-                <li>Drivers reduce consumption → conservation without mandate</li>
-                <li>Producers increase output → incentive to drill more</li>
-                <li>Investors fund alternatives → capital flows to opportunity</li>
-                <li>Entrepreneurs innovate → seek efficiency gains</li>
-            </ul>
-
-            <p>
-                Nobody gave orders. Nobody wrote a plan. <strong>Millions of people coordinated through price signals</strong>.
-            </p>
-
-            <div class="highlight-box">
-                <h4>🎯 The Price System as a Computer</h4>
-                <p>
-                    The price system is a <strong>distributed computation network</strong>. Every transaction inputs new data. Every price adjustment outputs a signal. The system "computes" optimal resource allocation without a central processor.
-                </p>
-                <p style="margin: 0;">
-                    <strong>No planner could match this speed, scale, or accuracy.</strong>
-                </p>
-            </div>
-
-            <h3>What Happens When Prices Are Suppressed?</h3>
-            <p>
-                When governments fix prices or ban markets, they destroy the information system.
-            </p>
-
-            <div class="comparison-grid">
-                <div class="comparison-card good">
-                    <h4>✅ Free Prices</h4>
-                    <ul style="list-style: disc; padding-left: 1.5rem;">
-                        <li>Scarcity signals reach everyone</li>
-                        <li>Resources flow to highest value use</li>
-                        <li>Waste is punished by losses</li>
-                        <li>Innovation is rewarded by profits</li>
-                        <li>Coordination is automatic</li>
-                    </ul>
+            <div class="interactive" id="signal-tool">
+                <h4>A drought cuts the wheat harvest in half. In an unhampered market, what happens first, and why is it useful?</h4>
+                <div id="signal-choices">
+                    <button class="choice-btn" data-correct="false" type="button">Nothing changes until a regulator notices and issues new guidance.</button>
+                    <button class="choice-btn" data-correct="true" type="button">The price of wheat rises, and that single number tells millions of strangers to use less and produce more, with no central order.</button>
+                    <button class="choice-btn" data-correct="false" type="button">Bakers keep buying the same amount because they did not hear about the drought.</button>
                 </div>
-                <div class="comparison-card bad">
-                    <h4>❌ Price Controls</h4>
-                    <ul style="list-style: disc; padding-left: 1.5rem;">
-                        <li>Shortages and surpluses</li>
-                        <li>Black markets emerge</li>
-                        <li>Quality deteriorates</li>
-                        <li>Malinvestment proliferates</li>
-                        <li>Chaos and corruption</li>
-                    </ul>
-                </div>
+                <div class="reveal" id="signal-result" hidden></div>
             </div>
-
-            <p>
-                <strong>Examples from history:</strong>
-            </p>
-            <ul>
-                <li><strong>Soviet Union:</strong> Chronic shortages despite abundant resources. No price signals = no calculation</li>
-                <li><strong>Venezuela:</strong> Price controls on food → empty shelves, starvation</li>
-                <li><strong>Rent control:</strong> Housing shortages in every city that tries it</li>
-            </ul>
-
-            <p>
-                The pattern is universal: <strong>Suppress prices, destroy coordination. Free prices, enable prosperity.</strong>
-            </p>
         </section>
 
-        <!-- Bitcoin and Economic Calculation -->
         <section class="content-section">
-            <h2>₿ Bitcoin: Economic Calculation for Money</h2>
-
+            <h2>How different systems answer the question</h2>
             <p>
-                Bitcoin applies the <strong>same Austrian principles</strong> that explain why markets beat central planning.
+                "Who sets prices, and where does the information come from?" separates these systems more cleanly than slogans do. The table is descriptive; each row has real tradeoffs.
             </p>
-
-            <h3>The Monetary Calculation Problem</h3>
-            <p>
-                Central banks face an impossible calculation problem:
-            </p>
-            <ul>
-                <li><strong>How much money should exist?</strong> Too much = inflation. Too little = deflation</li>
-                <li><strong>What should interest rates be?</strong> Too low = bubbles. Too high = recession</li>
-                <li><strong>Who should get newly created money first?</strong> Banks? Government? The market?</li>
-            </ul>
-
-            <p>
-                Just like Soviet planners couldn't price shoes, <strong>central bankers can't "price" money correctly</strong>. They lack the dispersed knowledge that only a market could provide.
-            </p>
-
-            <h3>Bitcoin's Decentralized Solution</h3>
-            <p>
-                Bitcoin solves the monetary calculation problem by <strong>removing the planner entirely</strong>.
-            </p>
-
-            <ul>
-                <li><strong>Fixed supply:</strong> 21 million BTC. No calculation needed — scarcity is absolute</li>
-                <li><strong>Decentralized issuance:</strong> Miners compete for block rewards. No favoritism, no Cantillon effect</li>
-                <li><strong>Market-set fees:</strong> Transaction fees determined by supply/demand, not a committee</li>
-                <li><strong>Permissionless innovation:</strong> Developers and users coordinate via prices (fees), not bureaucracy</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>🔑 Why Bitcoin Works</h4>
-                <p>
-                    Bitcoin doesn't need a central planner because <strong>the protocol embeds the rules that allow decentralized coordination</strong>:
-                </p>
-                <ul style="margin: 1rem 0;">
-                    <li><strong>Supply schedule:</strong> Predetermined, predictable, transparent</li>
-                    <li><strong>Fee market:</strong> Prices signal congestion and priority</li>
-                    <li><strong>Proof-of-work:</strong> Energy expenditure proves commitment (skin in the game)</li>
-                    <li><strong>Open verification:</strong> Every node checks every rule (distributed calculation)</li>
-                </ul>
-                <p style="margin: 0;">
-                    Bitcoin is <strong>Hayek's knowledge problem, solved with math</strong>.
-                </p>
+            <div class="data-table-wrap">
+                <table class="compare">
+                    <thead><tr><th>System</th><th>Who sets key prices?</th><th>Information source</th><th>Characteristic failure mode</th></tr></thead>
+                    <tbody>
+                        <tr><td>Soviet central planning</td><td>Central planning board</td><td>Production targets and quotas</td><td>Chronic shortages and surpluses; no way to compare uses (see Kornai)</td></tr>
+                        <tr><td>Modern central banking</td><td>Committee sets one key interest rate</td><td>Models and aggregate data</td><td>One rate cannot fit dispersed local conditions; boom and bust risk</td></tr>
+                        <tr><td>CBDC</td><td>Central bank, programmable</td><td>State ledger</td><td>Control and surveillance by design; same calculation limits as planning</td></tr>
+                        <tr><td>Bitcoin protocol</td><td>No one; issuance is a fixed rule, fees set by an open market</td><td>Open auction for block space</td><td>Volatile fees; coordinates money issuance only, not the wider economy</td></tr>
+                    </tbody>
+                    <caption>Bitcoin is included as a contrast in coordination design, not as a solution to the socialist calculation problem. See the misconception note below.</caption>
+                </table>
             </div>
-
-            <h3>Why Central Bank Digital Currencies (CBDCs) Fail</h3>
-            <p>
-                CBDCs replicate the same calculation problem that doomed the Soviet Union:
-            </p>
-            <ul>
-                <li><strong>Supply still controlled by committee:</strong> Same knowledge problem as fiat</li>
-                <li><strong>Transaction approval:</strong> Who decides which payments are allowed? Censorship becomes possible by design</li>
-                <li><strong>Privacy eliminated:</strong> Every transaction monitored. Panopticon money</li>
-                <li><strong>Innovation blocked:</strong> Permission required to build. Stifles experimentation</li>
-            </ul>
-
-            <p>
-                <strong>CBDCs hand central planners far more visibility and control over individual transactions</strong> — which deepens the calculation problem rather than solving it.
-            </p>
-
-            <p>
-                Bitcoin does the opposite: <strong>It removes control and enables calculation through decentralized coordination</strong>.
-            </p>
         </section>
 
-        <!-- Spontaneous Order -->
         <section class="content-section">
-            <h2>🌀 Spontaneous Order: Rules Without Rulers</h2>
-
+            <h2>The strongest objection: can computers plan now?</h2>
             <p>
-                Hayek introduced the concept of <strong>spontaneous order</strong> — complex, functional systems that emerge <em>without</em> central design.
+                The most serious challenge to Mises and Hayek is not that they were wrong in 1920, but that technology has changed since. This deserves its full strength.
             </p>
-
-            <h3>Examples of Spontaneous Order</h3>
-            <ul>
-                <li><strong>Language:</strong> Nobody designed English. It evolved through use</li>
-                <li><strong>Common law:</strong> Legal principles emerged from case-by-case judgment, not top-down legislation</li>
-                <li><strong>Market prices:</strong> Emerge from millions of voluntary trades, not government decree</li>
-                <li><strong>The internet:</strong> Protocols like TCP/IP enable coordination without a CEO</li>
-            </ul>
-
-            <p>
-                <strong>Bitcoin is spontaneous order at its purest.</strong>
-            </p>
-
-            <h3>Bitcoin's Spontaneous Order</h3>
-            <ul>
-                <li><strong>No CEO:</strong> Nobody is in charge. Satoshi disappeared</li>
-                <li><strong>No headquarters:</strong> Nodes run everywhere. Unstoppable</li>
-                <li><strong>No board of directors:</strong> Changes require overwhelming consensus</li>
-                <li><strong>Rules, not rulers:</strong> The protocol governs, not people</li>
-            </ul>
-
-            <p>
-                Yet Bitcoin <strong>coordinates global economic activity</strong> — settling trillions of dollars in value, securing the network, processing transactions, all without a single boss.
-            </p>
-
-            <div class="highlight-box">
-                <h4>🏛️ The Austrian Vision</h4>
+            <div class="steelman-box">
+                <h4>The case that modern computing solves it</h4>
                 <p>
-                    Austrian economists showed that <strong>the most sophisticated systems arise not from planning, but from freedom under rules</strong>.
+                    The economist Oskar Lange argued in the 1930s that planners could simulate a market by adjusting prices until shortages cleared (market socialism). Today the case is stronger: firms like Walmart and Amazon plan vast internal supply chains with enormous data and optimization, arguably out-planning small economies. Chile's Cybersyn project in the 1970s tried real-time economic coordination by computer. With modern machine learning and sensors, why could a planner not gather the dispersed knowledge Hayek described and compute the answer?
                 </p>
-                <p>
-                    Bitcoin is the ultimate proof. It's <strong>Hayek's dream realized in code</strong> — a system where:
-                </p>
-                <ul style="margin: 1rem 0;">
-                    <li>Prices (fees) coordinate participants</li>
-                    <li>Decentralized knowledge (nodes) validates truth</li>
-                    <li>Proof-of-work signals commitment</li>
-                    <li>Consensus emerges without coercion</li>
-                </ul>
-                <p style="margin: 0;">
-                    <strong>Rules without rulers. Order without planning. Prosperity without permission.</strong>
+                <p class="response">
+                    <strong>The response, and where it lands:</strong> three gaps remain. First, much knowledge is <em>tacit</em> and never written down, so it cannot be uploaded. Second, preferences are subjective and constantly changing, so the target moves faster than any model. Third, and most telling, large firms plan internally precisely because they buy their inputs at <em>market prices</em> set outside the firm; they ride on the very signal a whole-economy planner would have abolished. Walmart knows what a truck costs because there is a trucking market. Remove all external prices and the optimizer has no values to optimize against. That is the part computing has not closed. It is a real and live debate, not a settled rout in either direction.
                 </p>
             </div>
         </section>
 
-        <!-- Why This Matters -->
         <section class="content-section">
-            <h2>🌍 Why the Economic Calculation Problem Matters Today</h2>
-
-            <h3>Central Banking Is Central Planning</h3>
+            <h2>Dispersed knowledge, from pencils to Bitcoin</h2>
             <p>
-                The Federal Reserve, ECB, and other central banks are <strong>central planners of money</strong>. They face the exact same knowledge problem Mises and Hayek identified.
+                Leonard Read's essay "I, Pencil" (1958) makes the point vividly: no single person knows how to make a pencil from raw materials, yet pencils are abundant and cheap. Graphite miners, cedar growers, machinists, shippers, and retailers coordinate through prices without any of them grasping the whole. The knowledge is in the system, not in any head.
             </p>
-            <ul>
-                <li><strong>FOMC meetings:</strong> 12 people decide interest rates for 330 million Americans</li>
-                <li><strong>Quantitative easing:</strong> Committee decides how many trillions to print</li>
-                <li><strong>Forward guidance:</strong> Central bankers claim to predict the future (they can't)</li>
-            </ul>
-
             <p>
-                Austrian economists warned: <strong>This will end in crisis</strong>. And it does — every 7–10 years like clockwork.
-            </p>
-
-            <h3>The Boom-Bust Cycle</h3>
-            <p>
-                When central banks manipulate interest rates, they create <strong>malinvestment</strong>:
-            </p>
-            <ul>
-                <li><strong>Artificially low rates:</strong> Signal "capital is abundant" when it's not</li>
-                <li><strong>Entrepreneurs overbuild:</strong> Housing bubbles, dot-com bubbles, everything bubbles</li>
-                <li><strong>Reality catches up:</strong> Resources were misallocated. Bust follows boom</li>
-            </ul>
-
-            <p>
-                <strong>Examples:</strong>
-            </p>
-            <ul>
-                <li><strong>2008 Financial Crisis:</strong> Fed held rates too low → housing bubble → collapse</li>
-                <li><strong>2020–2022 Everything Bubble:</strong> Fed printed $5 trillion → inflation, asset bubbles</li>
-                <li><strong>Mounting pressure:</strong> a national debt above $30 trillion and growing (US Treasury) raises hard questions about how it gets resolved — through default, inflation, or austerity</li>
-            </ul>
-
-            <p>
-                The pattern repeats because <strong>the calculation problem is unsolvable</strong>. No human or committee can "manage" a monetary system. Austrian economics explains why.
+                Bitcoin is a smaller example of the same shape: coordination without a coordinator. Miners, node operators, wallet developers, exchanges, and self-custodians each act on local information and incentives, and the network holds together with no one in charge. Notice this is a claim about <strong>coordination design</strong>, not a claim that Bitcoin runs an economy. It coordinates one thing, the issuance and settlement of a money, by rule.
             </p>
         </section>
 
-        <!-- Socratic Reflection -->
+        <section class="content-section">
+            <h2>Claims to handle with care</h2>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Bitcoin solved the economic calculation problem."</p>
+                <span class="reality-label">Reality</span>
+                <p>The calculation problem is about allocating an entire economy's resources without market prices. Bitcoin does not do that; it coordinates the issuance and settlement of money by a fixed rule. It is an example of decentralized coordination, not a solution to socialist planning. Conflating the two overstates the case.</p>
+            </div>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Central planning just needs smarter people and better technology."</p>
+                <span class="reality-label">Reality</span>
+                <p>This is the strongest objection, and it has a real answer (above): the binding constraints are tacit knowledge, changing subjective preferences, and the fact that internal planning still depends on external market prices. Better tools help within those limits; they have not removed them.</p>
+            </div>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Prices are arbitrary numbers set by sellers."</p>
+                <span class="reality-label">Reality</span>
+                <p>In a competitive market a price is the meeting point of countless buyers' and sellers' local knowledge and willingness. It is closer to a measurement than a decree, which is exactly why suppressing it (price controls) destroys information and tends to produce shortages.</p>
+            </div>
+        </section>
+
         <section class="socratic-section">
-            <h3>💭 Socratic Reflection Questions</h3>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">1.</span> If no single person knows how to make a pencil (wood, graphite, rubber, metal, machines, logistics), how can a central planner possibly coordinate an entire economy?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">2.</span> When gasoline prices spike, people drive less even though nobody ordered them to. How does this happen? What role do prices play?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">3.</span> The Soviet Union had brilliant scientists, abundant resources, and total control. Why did it collapse while decentralized market economies thrived?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">4.</span> The Federal Reserve has PhDs, supercomputers, and unlimited data. Why can't they prevent boom-bust cycles?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">5.</span> Bitcoin has no CEO yet processes billions of dollars daily. CBDCs have entire governments backing them. Which system will win long-term? Why?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">6.</span> "We just need smarter central planners with better technology." Do you agree or disagree? What does Austrian economics say?
-                </p>
-            </div>
+            <h3>💭 Reflection questions</h3>
+            <p style="color:var(--text-dim);margin-bottom:1.5rem;">No answer key. Argue them in both directions.</p>
+            <div class="question"><p><span class="question-number">1.</span> In the planning tool, what information would have made your allocation better? Where in a real economy does that information live, and who has it?</p></div>
+            <div class="question"><p><span class="question-number">2.</span> Make the strongest case that Walmart's internal planning disproves Hayek. Then explain why Walmart still needs outside markets to do it.</p></div>
+            <div class="question"><p><span class="question-number">3.</span> If a price is information, what exactly is lost when a government fixes a price by law? Can you name a case where the loss might be worth it?</p></div>
+            <div class="question"><p><span class="question-number">4.</span> A central bank sets one interest rate for a whole country. In what sense is that a smaller version of the calculation problem? In what sense is it different?</p></div>
+            <div class="question"><p><span class="question-number">5.</span> Bitcoin coordinates money issuance without a planner. What does it deliberately <em>not</em> try to coordinate, and why might that limit be a feature?</p></div>
+            <div class="question"><p><span class="question-number">6.</span> What experiment, even a thought experiment, would convince you that a computer could plan a whole economy as well as markets do?</p></div>
         </section>
 
-        <!-- Key Takeaways -->
-        <section class="content-section">
-            <h2>🎯 Key Takeaways</h2>
-
-            <ul>
-                <li><strong>Economic calculation problem:</strong> Central planners lack the dispersed knowledge needed to allocate resources efficiently</li>
-                <li><strong>Knowledge is scattered:</strong> No person or committee can know what millions of individuals know</li>
-                <li><strong>Prices communicate knowledge:</strong> They signal scarcity, demand, and opportunity without requiring a planner</li>
-                <li><strong>Central planning always fails:</strong> Not because planners are stupid, but because the problem is unsolvable</li>
-                <li><strong>Markets coordinate spontaneously:</strong> Millions of people work together through voluntary exchange, not top-down control</li>
-                <li><strong>Bitcoin applies this logic to money:</strong> Decentralized, rule-based system beats central bank planning</li>
-                <li><strong>CBDCs replicate Soviet failures:</strong> Central control amplifies the calculation problem</li>
-                <li><strong>Spontaneous order:</strong> Complex systems emerge from simple rules, not blueprints</li>
-                <li><strong>Boom-bust cycles</strong> result from central banks distorting price signals (interest rates)</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>🌟 The Big Picture</h4>
-                <p>
-                    The economic calculation problem is <strong>the most important insight in 20th-century economics</strong>. It explains why:
-                </p>
-                <ul style="margin: 1rem 0;">
-                    <li>Socialism collapsed</li>
-                    <li>Central banking causes crises</li>
-                    <li>Bitcoin's decentralization isn't a bug — it's a feature</li>
-                    <li>Freedom outperforms control</li>
-                </ul>
-                <p>
-                    <strong>Bitcoin is the answer to a question Hayek posed 80 years ago:</strong> How can a society coordinate without coercion?
-                </p>
-                <p style="margin: 0;">
-                    Rules in code. Prices in sats. Consensus without kings. <strong>This is the alternative Bitcoin offers.</strong>
-                </p>
-            </div>
+        <section class="sources-section">
+            <h2>Sources and claim ledger</h2>
+            <p class="asof">Last reviewed June 17, 2026.</p>
+            <ol>
+                <li>The calculation problem: Ludwig von Mises, "Economic Calculation in the Socialist Commonwealth" (1920).</li>
+                <li>The knowledge problem: F. A. Hayek, "The Use of Knowledge in Society," <em>American Economic Review</em> (1945).</li>
+                <li>Market socialism (the planning-can-simulate-markets case): Oskar Lange, "On the Economic Theory of Socialism" (1936 to 1937).</li>
+                <li>Shortage as a systemic feature of planned economies: János Kornai, <em>Economics of Shortage</em> (1980).</li>
+                <li>Dispersed knowledge in production: Leonard Read, "I, Pencil" (1958).</li>
+                <li>Real-time computer coordination attempt: Project Cybersyn, Chile (1971 to 1973), historical record.</li>
+                <li>Price controls and shortages (illustrative modern evidence): Rebecca Diamond et al. on rent control, <em>American Economic Review</em> (2019).</li>
+                <li>Bitcoin coordination by rule (issuance, fee market): Bitcoin protocol and Bitcoin white paper (2008).</li>
+            </ol>
         </section>
 
-        <!-- Navigation -->
         <div class="nav-buttons">
-            <a href="/deep-dives/austrian-economics/" class="nav-btn">
-                ← Back to Austrian Economics
-            </a>
-            <a href="/interactive-demos/consensus-game/" class="nav-btn primary">
-                Play the Consensus Game →
-            </a>
+            <a href="/deep-dives/austrian-economics/" class="nav-btn">← Back to Austrian Economics</a>
+            <a href="/interactive-demos/consensus-game/" class="nav-btn primary">Try the Consensus demo →</a>
         </div>
     </main>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>
     <script>
-        // Inject icons after DOM loads
         document.addEventListener('DOMContentLoaded', function() {
             if (window.IconLibrary) {
                 document.querySelectorAll('[data-icon]').forEach(function(element) {
@@ -813,15 +335,93 @@
         });
     </script>
 
+    <!-- Deep-dive interactives (vanilla JS, no external data) -->
+    <script>
+    (function () {
+        // Hidden "true need" the planner cannot see (fixed, deterministic)
+        var NEED = { bread: 50, house: 35, phone: 15 };
+        var sBread = document.getElementById('a-bread');
+        var sHouse = document.getElementById('a-house');
+        var sPhone = document.getElementById('a-phone');
+        var vBread = document.getElementById('a-bread-v');
+        var vHouse = document.getElementById('a-house-v');
+        var vPhone = document.getElementById('a-phone-v');
+        function syncLabels(){ vBread.textContent = sBread.value; vHouse.textContent = sHouse.value; vPhone.textContent = sPhone.value; }
+        [sBread,sHouse,sPhone].forEach(function(s){ s.addEventListener('input', syncLabels); });
+        syncLabels();
+
+        function scaled(){
+            var b = +sBread.value, h = +sHouse.value, p = +sPhone.value;
+            var tot = b + h + p;
+            if (tot === 0) return { bread: 0, house: 0, phone: 0 };
+            return { bread: Math.round(b/tot*100), house: Math.round(h/tot*100), phone: Math.round(p/tot*100) };
+        }
+        function bar(label, val, max){
+            var pct = Math.max(2, Math.round(val/max*100));
+            var wrap = document.createElement('div'); wrap.className = 'barline';
+            var nm = document.createElement('span'); nm.className = 'name'; nm.textContent = label + ' (' + val + ')';
+            var track = document.createElement('div'); track.className = 'bar-track';
+            var fill = document.createElement('div'); fill.className = 'bar-fill'; fill.style.width = pct + '%';
+            track.appendChild(fill); wrap.appendChild(nm); wrap.appendChild(track);
+            return wrap;
+        }
+        var planResult = document.getElementById('plan-result');
+        function runPlan(){
+            var a = scaled();
+            var waste = Math.abs(a.bread-NEED.bread) + Math.abs(a.house-NEED.house) + Math.abs(a.phone-NEED.phone);
+            var score = Math.max(0, 100 - waste); // 100 = perfect match
+            planResult.hidden = false;
+            planResult.textContent = '';
+            var p = document.createElement('p');
+            p.innerHTML = 'Coordination score: <span class="readout">' + score + ' / 100</span>. ' +
+                (score >= 90 ? 'Close, but you were guessing, and the need can shift tomorrow.' :
+                 score >= 60 ? 'A real mismatch: some goods are short, others wasted.' :
+                 'Large shortages and surpluses, the signature of planning without prices.');
+            planResult.appendChild(p);
+            var head = document.createElement('p'); head.style.color = '#b3b3b3'; head.style.fontSize = '0.9rem'; head.textContent = 'Your mix vs what people needed:';
+            planResult.appendChild(head);
+            planResult.appendChild(bar('You: Bread', a.bread, 100));
+            planResult.appendChild(bar('Need: Bread', NEED.bread, 100));
+            planResult.appendChild(bar('You: Housing', a.house, 100));
+            planResult.appendChild(bar('Need: Housing', NEED.house, 100));
+            planResult.appendChild(bar('You: Phones', a.phone, 100));
+            planResult.appendChild(bar('Need: Phones', NEED.phone, 100));
+        }
+        function revealPlan(){
+            runPlan();
+            var note = document.createElement('p');
+            note.style.marginTop = '1rem';
+            note.innerHTML = 'In a market you would never have to guess this. Prices would rise on whatever is short and fall on whatever is over-produced, steering workers automatically. The hidden need above is exactly the information a price system makes public, one number at a time.';
+            planResult.appendChild(note);
+        }
+        document.getElementById('plan-run').addEventListener('click', runPlan);
+        document.getElementById('plan-reveal').addEventListener('click', revealPlan);
+
+        // Price-signal predictor
+        var signalResult = document.getElementById('signal-result');
+        document.querySelectorAll('#signal-choices .choice-btn').forEach(function(btn){
+            btn.addEventListener('click', function(){
+                var correct = btn.getAttribute('data-correct') === 'true';
+                signalResult.hidden = false;
+                signalResult.textContent = '';
+                var p = document.createElement('p');
+                p.innerHTML = correct
+                    ? '<span class="readout">That is Hayek’s point.</span> The rising price is a message no one had to write. It reaches people who have never heard of the drought and changes their behavior anyway. The price carries the knowledge; the planner would still be collecting reports.'
+                    : 'Not quite. Watch what an unhampered price does: it rises immediately on the shortage, and that single number tells millions of strangers to economize and to produce more, with no central order. That is the coordination Hayek argued a planner cannot match.';
+                signalResult.appendChild(p);
+            });
+        });
+    })();
+    </script>
 
     <!-- Navigation Context (return-to-path functionality) -->
     <script src="/js/navigation-context.js"></script>
     <!-- Reflect: Socratic questions after activity -->
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
-             data-topic="money"
+             data-topic="economic-calculation"
              data-path="principled"
-             data-title="Reflect: How do markets calculate without a central planner?">
+             data-title="Reflect: How do markets coordinate without a planner?">
         </div>
     </div>
     <script src="/js/reflect-widget.js"></script>

--- a/deep-dives/austrian-economics/index.html
+++ b/deep-dives/austrian-economics/index.html
@@ -2,7 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Austrian Economics &amp; Bitcoin | Bitcoin Sovereign Academy</title>
-    <meta name="description" content="Explore how Austrian School economics explains why Bitcoin matters. Learn about time preference, sound money, praxeology, and economic calculation.">
+    <meta name="description" content="Four first-principles research labs on Austrian economics and Bitcoin: time preference, sound money, the economic calculation problem, and praxeology. Inform, not convince.">
     <link rel="stylesheet" href="/css/global.css">
     <style>
         .hero {
@@ -113,16 +113,16 @@
         <div class="hero">
             <h1>🏛️ Austrian Economics &amp; Bitcoin</h1>
             <p style="font-size: 1.2rem; color: var(--text-dim); max-width: 800px; margin: 0 auto;">
-                Discover how the Austrian School of Economics explains why Bitcoin matters. From time preference to sound money theory, explore the economic foundations of the Bitcoin revolution.
+                Four research labs on the economic ideas people use to argue about Bitcoin. Each investigates a hard question from first principles, compares systems, weighs the strongest objections, and lets you test the claims yourself. The goal is to inform, not to convince.
             </p>
         </div>
 
         <div class="modules-grid">
             <div class="module-card">
                 <span class="status available">Available Now</span>
-                <h3>⏳ Time Preference Fundamentals</h3>
+                <h3>⏳ Time Preference</h3>
                 <p>
-                    The most important economic concept for understanding Bitcoin. Learn how time preference shapes civilizations and why sound money rewards delayed gratification.
+                    What is a future dollar worth to you today? Measure your own time preference, read what the savings and inflation data actually show, and weigh whether patience is really a virtue.
                 </p>
                 <a href="/deep-dives/austrian-economics/time-preference-fundamentals.html" class="cta-btn">
                     Start Learning →
@@ -133,7 +133,7 @@
                 <span class="status available">Available Now</span>
                 <h3>💰 Sound Money Theory</h3>
                 <p>
-                    What makes money "sound"? Explore the properties of good money and why Bitcoin represents the hardest money ever created.
+                    Does any money hold its value across decades? Compare gold, fiat, and Bitcoin on eight properties, check the data yourself, and weigh the mainstream case against hard money.
                 </p>
                 <a href="/deep-dives/austrian-economics/sound-money-theory.html" class="cta-btn">
                     Start Learning →
@@ -144,7 +144,7 @@
                 <span class="status available">Available Now</span>
                 <h3>📊 Economic Calculation Problem</h3>
                 <p>
-                    How do markets coordinate without central planning? Understand Hayek's insights and why decentralized systems outperform central control.
+                    Can anyone, or any computer, run an economy without prices? Try to plan one yourself, then weigh whether modern computing changes Mises and Hayek's answer.
                 </p>
                 <a href="/deep-dives/austrian-economics/economic-calculation-problem.html" class="cta-btn">
                     Start Learning →
@@ -155,12 +155,19 @@
                 <span class="status available">Available Now</span>
                 <h3>🎯 Praxeology &amp; Human Action</h3>
                 <p>
-                    Mises' science of human action. Learn how Austrian economics differs from mainstream approaches and why it matters for Bitcoin.
+                    Can you reason out economics from a single axiom? Classify human action yourself, compare Austrian and mainstream method fairly, and weigh the objection that the method cannot be falsified.
                 </p>
                 <a href="/deep-dives/austrian-economics/praxeology-human-action.html" class="cta-btn">
                     Start Learning →
                 </a>
             </div>
+        </div>
+
+        <div style="max-width: 800px; margin: 1rem auto 3rem; padding: 1.75rem 2rem; background: #101010; border: 1px solid #2A2A2A; border-radius: 12px;">
+            <h3 style="color: #FF7A00; font-size: 1.1rem; margin-bottom: 0.75rem;">What these deep dives are, and are not</h3>
+            <p style="color: var(--text-dim); margin: 0; line-height: 1.7;">
+                They are research labs, not a sales pitch. Each one states a hard claim, shows the evidence, gives the strongest objection a fair hearing, and leaves the conclusion to you. They are not a promise about returns, a manifesto, or a single-cause story that blames every problem on the money. Where Austrians disagree among themselves, we say so.
+            </p>
         </div>
 
         <div style="text-align: center; margin: 3rem 0;">
@@ -176,7 +183,7 @@
     <!-- Reflect: Socratic questions after activity -->
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
-             data-topic="money"
+             data-topic="austrian-economics"
              data-path="principled"
              data-title="Reflect: What is Austrian economics?">
         </div>

--- a/deep-dives/austrian-economics/praxeology-human-action.html
+++ b/deep-dives/austrian-economics/praxeology-human-action.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Praxeology &amp; Human Action: The Science of Choice | Bitcoin Sovereign Academy</title>
-    <meta name="description" content="Discover Mises' praxeology - the science of human action. Learn how Austrian economics differs from mainstream approaches and why this framework explains Bitcoin's success.">
+    <title>Praxeology: Can You Reason About the Economy From One Axiom? | Bitcoin Sovereign Academy</title>
+    <meta name="description" content="A research lab on Mises's praxeology and the action axiom: classify human action yourself, see what the method claims, and weigh the serious objection that it cannot be falsified. Inform, not convince.">
 
     <style>
         :root {
@@ -17,337 +17,140 @@
             --warning-orange: #FF7A00;
             --error-red: #dc3545;
         }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background: var(--primary-dark); color: var(--text-light); line-height: 1.6; padding: 2rem 1rem; }
+        .container { max-width: 1000px; margin: 0 auto; }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        .module-header { text-align: center; margin-bottom: 3rem; padding: 3rem 2rem; background: #101010; border-radius: 16px; border: 3px solid var(--accent-bronze); }
+        .module-icon { font-size: 5rem; margin-bottom: 1rem; animation: pulse 3s ease-in-out infinite; }
+        @keyframes pulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.05); } }
+        @media (prefers-reduced-motion: reduce) { .module-icon { animation: none; } }
+        h1 { font-size: 2.8rem; color: var(--accent-bronze); margin-bottom: 1rem; font-weight: 800; }
+        .module-subtitle { font-size: 1.25rem; color: var(--text-dim); max-width: 820px; margin: 0 auto 1.5rem; line-height: 1.8; }
+        .breadcrumb { text-align: center; margin-top: 1.5rem; font-size: 0.9rem; color: var(--text-dim); }
+        .breadcrumb a { color: var(--accent-bronze); text-decoration: none; transition: color 0.3s; }
+        .breadcrumb a:hover { color: var(--accent-gold); }
 
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            background: var(--primary-dark);
-            color: var(--text-light);
-            line-height: 1.6;
-            padding: 2rem 1rem;
-        }
+        .research-question { background: #101010; border: 2px solid var(--accent-bronze); border-radius: 12px; padding: 1.75rem 2rem; margin: 0 auto 2.5rem; max-width: 1000px; }
+        .research-question .label { font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent-bronze); font-weight: 700; }
+        .research-question p { font-size: 1.25rem; line-height: 1.6; margin-top: 0.5rem; color: var(--text-light); }
 
-        .container {
-            max-width: 1000px;
-            margin: 0 auto;
-        }
+        .content-section { background: var(--secondary-dark); border-radius: 16px; padding: 3rem; margin-bottom: 2.5rem; border: 2px solid rgba(139, 111, 71, 0.3); }
+        .content-section h2 { color: var(--accent-bronze); font-size: 2rem; margin-bottom: 1.5rem; font-weight: 700; }
+        .content-section h3 { color: var(--accent-bronze-light); font-size: 1.4rem; margin: 2rem 0 1rem; font-weight: 600; }
+        .content-section p { color: var(--text-light); margin-bottom: 1.5rem; line-height: 1.9; font-size: 1.05rem; }
+        .content-section strong { color: var(--accent-gold); font-weight: 600; }
+        .content-section ul { list-style: none; padding-left: 0; margin: 1.5rem 0; }
+        .content-section li { padding: 0.85rem 0 0.85rem 1.5rem; position: relative; color: var(--text-light); line-height: 1.8; border-bottom: 1px solid rgba(139, 111, 71, 0.1); }
+        .content-section li:last-child { border-bottom: none; }
+        .content-section li:before { content: "›"; position: absolute; left: 0; color: var(--accent-bronze); font-weight: 700; }
 
-        /* Header */
-        .module-header {
-            text-align: center;
-            margin-bottom: 3rem;
-            padding: 3rem 2rem;
-            background: #101010;
-            border-radius: 16px;
-            border: 3px solid var(--accent-bronze);
-        }
+        .highlight-box { background: #101010; border-left: 5px solid var(--accent-gold); padding: 2rem; margin: 2rem 0; border-radius: 8px; }
+        .highlight-box h4 { color: var(--accent-gold); margin-bottom: 1rem; font-size: 1.25rem; }
+        .highlight-box p { margin-bottom: 1rem; }
+        .highlight-box p:last-child { margin-bottom: 0; }
 
-        .module-icon {
-            font-size: 5rem;
-            margin-bottom: 1rem;
-            animation: pulse 3s ease-in-out infinite;
-        }
+        .steelman-box { background: #101010; border: 2px solid #5a78a0; border-radius: 12px; padding: 2rem; margin: 2rem 0; }
+        .steelman-box h4 { color: #9db8da; font-size: 1.2rem; margin-bottom: 1rem; }
+        .steelman-box .response { margin-top: 1.25rem; padding-top: 1.25rem; border-top: 1px solid rgba(255,255,255,0.12); }
+        .steelman-box .response strong { color: var(--accent-gold); }
 
-        @keyframes pulse {
-            0%, 100% { transform: scale(1); }
-            50% { transform: scale(1.05); }
-        }
+        .myth { background: rgba(0,0,0,0.3); border-radius: 10px; padding: 1.5rem; margin: 1.25rem 0; border-left: 4px solid #2A2A2A; }
+        .myth .myth-label { color: var(--text-dim); font-weight: 700; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .myth .reality-label { color: var(--accent-bronze); font-weight: 700; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .myth p { margin: 0.35rem 0 1rem; }
+        .myth p:last-child { margin-bottom: 0; }
 
-        h1 {
-            font-size: 2.8rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-gold));
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            margin-bottom: 1rem;
-            font-weight: 800;
-        }
+        .data-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
+        table.compare { width: 100%; border-collapse: collapse; font-size: 0.95rem; min-width: 560px; }
+        table.compare th, table.compare td { padding: 0.75rem 0.85rem; text-align: left; border-bottom: 1px solid rgba(255,255,255,0.1); vertical-align: top; }
+        table.compare thead th { color: var(--accent-bronze); border-bottom: 2px solid rgba(255,122,0,0.4); font-weight: 700; }
+        table.compare td:first-child, table.compare th:first-child { font-weight: 600; }
+        table.compare caption { caption-side: bottom; color: var(--text-dim); font-size: 0.82rem; padding-top: 0.75rem; text-align: left; }
 
-        .module-subtitle {
-            font-size: 1.3rem;
-            color: var(--text-dim);
-            max-width: 800px;
-            margin: 0 auto 1.5rem;
-            line-height: 1.8;
-        }
+        .interactive { background: #101010; border: 2px solid var(--accent-bronze); border-radius: 12px; padding: 2rem; margin: 2rem 0; }
+        .interactive h4 { color: var(--accent-bronze); font-size: 1.2rem; margin-bottom: 0.5rem; }
+        .interactive .hint { color: var(--text-dim); font-size: 0.9rem; margin-bottom: 1.25rem; }
+        .interactive .readout { font-size: 1.05rem; font-weight: 700; color: var(--accent-bronze); }
+        .interactive button { background: var(--accent-bronze); color: #101010; border: none; border-radius: 8px; padding: 0.5rem 1.1rem; font-weight: 700; font-size: 0.9rem; cursor: pointer; }
+        .interactive button:hover { background: var(--accent-gold); }
+        .interactive button.secondary { background: transparent; color: var(--accent-bronze); border: 1px solid var(--accent-bronze); }
+        .scenario { padding: 1rem 0; border-bottom: 1px solid rgba(255,255,255,0.08); }
+        .scenario:last-of-type { border-bottom: none; }
+        .scenario .stext { display: block; margin-bottom: 0.6rem; }
+        .scenario .btns { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+        .scenario .verdict { margin-top: 0.6rem; font-size: 0.92rem; color: var(--text-dim); }
+        .scenario .verdict[hidden] { display: none; }
+        .scenario .verdict .tag { font-weight: 700; }
+        .choice-btn { display: block; width: 100%; text-align: left; background: var(--secondary-dark); color: var(--text-light); border: 1px solid rgba(255,255,255,0.2); border-radius: 8px; padding: 0.75rem 1rem; margin: 0.5rem 0; cursor: pointer; font-size: 0.98rem; }
+        .choice-btn:hover { border-color: var(--accent-bronze); }
+        .reveal { margin-top: 1.25rem; padding-top: 1.25rem; border-top: 1px solid rgba(255,255,255,0.12); }
+        .reveal[hidden] { display: none; }
 
-        .breadcrumb {
-            text-align: center;
-            margin-top: 1.5rem;
-            font-size: 0.9rem;
-            color: var(--text-dim);
-        }
+        .socratic-section { background: #101010; border-radius: 16px; padding: 3rem; margin-bottom: 2.5rem; border: 2px solid #2A2A2A; }
+        .socratic-section h3 { color: #FF7A00; margin-bottom: 2rem; font-size: 1.8rem; }
+        .question { background: rgba(0, 0, 0, 0.3); padding: 1.5rem; border-radius: 8px; margin-bottom: 1.5rem; border-left: 4px solid #FF7A00; }
+        .question-number { color: #FF7A00; font-weight: 700; font-size: 1.2rem; margin-right: 0.5rem; }
 
-        .breadcrumb a {
-            color: var(--accent-bronze);
-            text-decoration: none;
-            transition: color 0.3s;
-        }
+        .sources-section { background: var(--secondary-dark); border-radius: 16px; padding: 2.5rem 3rem; margin-bottom: 2.5rem; border: 2px solid rgba(139,111,71,0.3); }
+        .sources-section h2 { color: var(--accent-bronze); font-size: 1.6rem; margin-bottom: 0.5rem; }
+        .sources-section .asof { color: var(--text-dim); font-size: 0.85rem; margin-bottom: 1.5rem; }
+        .sources-section ol { padding-left: 1.25rem; }
+        .sources-section li { padding: 0.5rem 0; color: var(--text-dim); font-size: 0.92rem; line-height: 1.6; }
+        .sources-section a { color: var(--accent-bronze); text-decoration: none; }
+        .sources-section a:hover { text-decoration: underline; }
 
-        .breadcrumb a:hover {
-            color: var(--accent-gold);
-        }
+        .nav-buttons { display: flex; gap: 1.5rem; justify-content: space-between; margin: 3rem 0; flex-wrap: wrap; }
+        .nav-btn { display: inline-block; padding: 1rem 2rem; background: var(--secondary-dark); color: var(--text-light); text-decoration: none; border-radius: 12px; border: 2px solid var(--accent-bronze); font-weight: 600; transition: all 0.3s ease; text-align: center; flex: 1; min-width: 200px; }
+        .nav-btn:hover { background: var(--accent-bronze); transform: translateY(-2px); }
+        .nav-btn.primary { background: var(--accent-bronze); color: white; }
+        .nav-btn.primary:hover { background: var(--accent-gold); }
 
-        /* Content Sections */
-        .content-section {
-            background: var(--secondary-dark);
-            border-radius: 16px;
-            padding: 3rem;
-            margin-bottom: 2.5rem;
-            border: 2px solid rgba(139, 111, 71, 0.3);
-            transition: all 0.3s ease;
-        }
-
-        .content-section:hover {
-            border-color: var(--accent-bronze);
-            box-shadow: 0 8px 24px rgba(139, 111, 71, 0.2);
-        }
-
-        .content-section h2 {
-            color: var(--accent-bronze);
-            font-size: 2rem;
-            margin-bottom: 1.5rem;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-        }
-
-        .content-section h3 {
-            color: var(--accent-bronze-light);
-            font-size: 1.5rem;
-            margin: 2rem 0 1rem;
-            font-weight: 600;
-        }
-
-        .content-section p {
-            color: var(--text-light);
-            margin-bottom: 1.5rem;
-            line-height: 1.9;
-            font-size: 1.05rem;
-        }
-
-        .content-section strong {
-            color: var(--accent-gold);
-            font-weight: 600;
-        }
-
-        .content-section ul {
-            list-style: none;
-            padding-left: 0;
-            margin: 1.5rem 0;
-        }
-
-        .content-section li {
-            padding: 1rem 0 1rem 2.5rem;
-            position: relative;
-            color: var(--text-light);
-            line-height: 1.8;
-            border-bottom: 1px solid rgba(139, 111, 71, 0.1);
-        }
-
-        .content-section li:last-child {
-            border-bottom: none;
-        }
-
-        .content-section li:before {
-            content: "🎯";
-            position: absolute;
-            left: 0;
-            font-size: 1.2rem;
-        }
-
-        /* Highlight Boxes */
-        .highlight-box {
-            background: #101010;
-            border-left: 5px solid var(--accent-gold);
-            padding: 2rem;
-            margin: 2rem 0;
-            border-radius: 8px;
-        }
-
-        .highlight-box h4 {
-            color: var(--accent-gold);
-            margin-bottom: 1rem;
-            font-size: 1.3rem;
-        }
-
-        .highlight-box p {
-            margin-bottom: 1rem;
-        }
-
-        /* Comparison Grid */
-        .comparison-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 2rem;
-            margin: 2rem 0;
-        }
-
-        .comparison-card {
-            background: rgba(0, 0, 0, 0.3);
-            padding: 2rem;
-            border-radius: 12px;
-            transition: all 0.3s ease;
-        }
-
-        .comparison-card.austrian {
-            border: 2px solid var(--accent-gold);
-        }
-
-        .comparison-card.mainstream {
-            border: 2px solid var(--text-dim);
-        }
-
-        .comparison-card h4 {
-            font-size: 1.2rem;
-            margin-bottom: 1rem;
-        }
-
-        .comparison-card.austrian h4 {
-            color: var(--accent-gold);
-        }
-
-        .comparison-card.mainstream h4 {
-            color: var(--text-dim);
-        }
-
-        /* Socratic Section */
-        .socratic-section {
-            background: #101010;
-            border-radius: 16px;
-            padding: 3rem;
-            margin-bottom: 2.5rem;
-            border: 2px solid #2A2A2A;
-            border-left: 4px solid #FF7A00;
-        }
-
-        .socratic-section h3 {
-            color: #FF7A00;
-            margin-bottom: 2rem;
-            font-size: 1.8rem;
-        }
-
-        .question {
-            background: rgba(0, 0, 0, 0.3);
-            padding: 1.5rem;
-            border-radius: 8px;
-            margin-bottom: 1.5rem;
-            border-left: 4px solid #FF7A00;
-        }
-
-        .question-number {
-            color: #FF7A00;
-            font-weight: 700;
-            font-size: 1.2rem;
-            margin-right: 0.5rem;
-        }
-
-        /* Navigation */
-        .nav-buttons {
-            display: flex;
-            gap: 1.5rem;
-            justify-content: space-between;
-            margin: 3rem 0;
-            flex-wrap: wrap;
-        }
-
-        .nav-btn {
-            display: inline-block;
-            padding: 1rem 2rem;
-            background: var(--secondary-dark);
-            color: var(--text-light);
-            text-decoration: none;
-            border-radius: 12px;
-            border: 2px solid var(--accent-bronze);
-            font-weight: 600;
-            transition: all 0.3s ease;
-            text-align: center;
-            flex: 1;
-            min-width: 200px;
-        }
-
-        .nav-btn:hover {
-            background: var(--accent-bronze);
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(139, 111, 71, 0.3);
-        }
-
-        .nav-btn.primary {
-            background: var(--accent-bronze);
-            color: white;
-        }
-
-        .nav-btn.primary:hover {
-            background: var(--accent-gold);
-        }
-
-        /* Responsive */
         @media (max-width: 768px) {
-            .module-header {
-                padding: 2rem 1rem;
-            }
-
-            h1 {
-                font-size: 2rem;
-            }
-
-            .module-subtitle {
-                font-size: 1.1rem;
-            }
-
-            .content-section {
-                padding: 2rem 1.5rem;
-            }
-
-            .comparison-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .nav-buttons {
-                flex-direction: column;
-            }
+            .module-header { padding: 2rem 1rem; }
+            h1 { font-size: 2rem; }
+            .module-subtitle { font-size: 1.1rem; }
+            .content-section { padding: 2rem 1.5rem; }
+            .nav-buttons { flex-direction: column; }
         }
     </style>
     <link rel="stylesheet" href="/css/icons.css">
-<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/praxeology-human-action"><meta property="og:title" content="Praxeology Human Action - Bitcoin Sovereign Academy"><meta property="og:description" content="Learn about praxeology human action at Bitcoin Sovereign Academy. Interactive Bitcoin education with hands-on exercises and expert guidance."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/praxeology-human-action"><meta property="og:type" content="website"><script type="application/ld+json">{
+<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/praxeology-human-action"><meta property="og:title" content="Praxeology: Can You Reason About the Economy From One Axiom?"><meta property="og:description" content="Classify human action yourself, see what Mises's a priori method claims, and weigh the serious objection that it cannot be falsified."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/praxeology-human-action"><meta property="og:type" content="article"><script type="application/ld+json">{
   "@context": "https://schema.org",
-  "@type": "EducationalOrganization",
-  "name": "Bitcoin Sovereign Academy",
-  "description": "Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here.",
-  "url": "https://bitcoinsovereign.academy",
-  "logo": "https://bitcoinsovereign.academy/assets/og-image.jpg",
-  "sameAs": [
-    "https://github.com/Sovereigndwp/bitcoin-sovereign-academy"
-  ],
-  "educationalLevel": "Beginner to Advanced",
+  "@type": "LearningResource",
+  "name": "Praxeology: Can You Reason About the Economy From One Axiom?",
+  "learningResourceType": "Deep dive",
+  "educationalLevel": "Intermediate to Advanced",
+  "isAccessibleForFree": true,
   "teaches": [
-    "Bitcoin Fundamentals",
-    "Cryptocurrency Technology",
-    "Financial Sovereignty",
-    "Digital Asset Security"
+    "The action axiom and what praxeology claims",
+    "Why the a priori method is methodologically contested",
+    "Subjective value and marginal utility",
+    "The positivist critique of Austrian method",
+    "How Austrian and mainstream economics actually differ"
   ],
-  "audience": {
-    "@type": "Audience",
-    "audienceType": "Students interested in Bitcoin and cryptocurrency"
-  }
+  "publisher": { "@type": "EducationalOrganization", "name": "Bitcoin Sovereign Academy", "url": "https://bitcoinsovereign.academy" }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
+
+<!-- content-graph edges (BSA ontology)
+content_type: deep_dive
+strategic_role: economics_first_principles
+teaches: [action_axiom, praxeology_method, subjective_value, marginal_utility, austrian_vs_mainstream]
+repairs: [misconception_praxeology_proves_with_certainty, misconception_mainstream_treats_people_as_billiard_balls, misconception_mises_would_have_loved_bitcoin]
+supports_decision: [how_to_weigh_a_priori_arguments_vs_evidence]
+bridges_to: [/deep-dives/austrian-economics/sound-money-theory.html, /deep-dives/austrian-economics/economic-calculation-problem.html, /deep-dives/austrian-economics/time-preference-fundamentals.html]
+blocked_by_boundary: [no_direct_tba_funnel]
+-->
 </head>
 <body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
-        <!-- Header -->
         <header class="module-header">
             <div class="module-icon">🎯</div>
-            <h1>Praxeology &amp; Human Action</h1>
+            <h1>Praxeology and Human Action</h1>
             <p class="module-subtitle">
-                Discover Mises' science of human action — a revolutionary approach to understanding economics through the logic of choice. Learn why this framework explains Bitcoin better than any mainstream theory.
+                A research lab on Mises's claim that economics can be reasoned out from a single starting point: that humans act. We will define the method, let you test it on real cases, compare it fairly with the mainstream, and take seriously the objection that it cannot be proven wrong.
             </p>
             <div class="breadcrumb">
                 <a href="/">Home</a> →
@@ -357,464 +160,167 @@
             </div>
         </header>
 
-        <!-- Introduction -->
+        <div class="research-question">
+            <span class="label">The question we are investigating</span>
+            <p>Mises claimed you can derive economic laws from one self-evident axiom: that humans act purposefully. Is that a powerful foundation, or a way to reach conclusions no evidence could ever overturn?</p>
+        </div>
+
         <section class="content-section">
-            <h2><span data-icon="brain"></span> What Is Praxeology?</h2>
-            
+            <h2>Why this matters</h2>
             <p>
-                In 1949, Ludwig von Mises published <em>Human Action</em> — one of the most important economics books ever written. In it, he introduced <strong>praxeology</strong>: the science of human action.
+                Praxeology is the engine under the rest of Austrian economics. Time preference, sound money, and the calculation problem all rest on it. So whether it is a rigorous method or an unfalsifiable one is not a side issue; it decides how much weight the conclusions can carry. This page treats that as the live question it is, rather than assuming the answer.
             </p>
-
-            <div class="highlight-box">
-                <h4>📖 Praxeology Defined</h4>
-                <p style="font-size: 1.1rem;">
-                    <strong>"Praxeology is the science of purposeful human behavior. It studies the logical structure of action — what all humans must do whenever they act."</strong>
-                </p>
-                <p style="margin: 0; font-size: 0.95rem; font-style: italic;">
-                    — Ludwig von Mises
-                </p>
-            </div>
-
             <p>
-                Praxeology doesn't study <em>what</em> people want or <em>why</em> they want it. It studies the <strong>logic of choice itself</strong> — the unavoidable truths that apply whenever a human being acts.
-            </p>
-
-            <h3>The Axiom of Action</h3>
-            <p>
-                Praxeology begins with one undeniable starting point: <strong>humans act</strong>.
-            </p>
-
-            <p>
-                This sounds trivial. But from this single axiom, Mises derived <strong>the entire structure of economic theory</strong> — through pure logic, without needing data, experiments, or statistics.
-            </p>
-
-            <div class="highlight-box">
-                <h4>🔑 What "Action" Means</h4>
-                <p>
-                    To <strong>act</strong> means:
-                </p>
-                <ul style="margin: 1rem 0;">
-                    <li><strong>Purposeful behavior:</strong> You have a goal</li>
-                    <li><strong>Choice:</strong> You select among alternatives</li>
-                    <li><strong>Means and ends:</strong> You use scarce resources to achieve your goal</li>
-                    <li><strong>Time preference:</strong> You prefer satisfaction sooner rather than later</li>
-                    <li><strong>Uncertainty:</strong> The future is unknown</li>
-                </ul>
-                <p style="margin: 0;">
-                    <strong>Every action, everywhere, by anyone, exhibits these properties.</strong> This is not a hypothesis — it's a logical necessity.
-                </p>
-            </div>
-
-            <p>
-                From the axiom of action, praxeology derives:
-            </p>
-            <ul>
-                <li>The concept of value (subjective, not objective)</li>
-                <li>The laws of exchange (voluntary trade benefits both parties)</li>
-                <li>The role of prices (signals for coordination)</li>
-                <li>The impossibility of central planning (calculation problem)</li>
-                <li>Time preference and interest rates</li>
-            </ul>
-
-            <p>
-                <strong>Bitcoin makes sense only through the lens of praxeology.</strong> Mainstream economics cannot explain why Bitcoin works. Austrian economics can.
+                In <em>Human Action</em> (1949), Mises set out praxeology as the science of human action. Its starting point, the <strong>action axiom</strong>, is that humans act: they use means to pursue ends, choosing one thing over another under uncertainty. From this, Austrians argue, much of economic theory follows by logic rather than by measurement.
             </p>
         </section>
 
-        <!-- Austrian vs. Mainstream -->
         <section class="content-section">
-            <h2>⚖️ Austrian Economics vs. Mainstream Economics</h2>
-
+            <h2>Try it: is this human action?</h2>
             <p>
-                Austrian economics and mainstream economics are <strong>fundamentally different</strong>. They ask different questions, use different methods, and reach different conclusions.
+                The axiom sounds abstract until you apply it. Praxeology counts something as <strong>action</strong> when it is purposeful behavior aimed at a preferred outcome, as opposed to a reflex or an involuntary event. Classify each case, then reveal how the method would.
             </p>
 
-            <div class="comparison-grid">
-                <div class="comparison-card austrian">
-                    <h4>🏛️ Austrian Economics (Praxeology)</h4>
-                    <ul style="list-style: disc; padding-left: 1.5rem; line-height: 1.8;">
-                        <li><strong>Method:</strong> Deductive logic from axiom of action</li>
-                        <li><strong>Focus:</strong> Individual choice and subjective value</li>
-                        <li><strong>Knowledge:</strong> Dispersed, local, tacit</li>
-                        <li><strong>Markets:</strong> Discovery process, not equilibrium</li>
-                        <li><strong>Prices:</strong> Signals carrying knowledge</li>
-                        <li><strong>Goal:</strong> Understand human behavior logically</li>
-                    </ul>
+            <div class="interactive" id="action-tool">
+                <h4>Action, or not action?</h4>
+                <p class="hint">Pick for each. The point is not to score points; it is to feel where the line sits, including the cases that are genuinely tricky.</p>
+                <div id="action-list"></div>
+                <p class="readout" id="action-score" style="margin-top:1rem;" aria-live="polite"></p>
+            </div>
+        </section>
+
+        <section class="content-section">
+            <h2>Subjective value: the same thing, different worth</h2>
+            <p>
+                A second praxeological idea: value is not a property baked into objects, it is assigned by acting people at the margin. The classic puzzle is the diamond-water paradox: water is essential yet cheap, diamonds are useless yet dear, because what we value is the <em>next</em> unit in our actual situation, not the thing in the abstract. Pick a situation and see.
+            </p>
+            <div class="interactive" id="value-tool">
+                <h4>What is it worth here?</h4>
+                <div id="value-choices">
+                    <button class="choice-btn" data-key="water-home" type="button">A glass of water, in your kitchen</button>
+                    <button class="choice-btn" data-key="water-desert" type="button">A glass of water, lost in a desert</button>
+                    <button class="choice-btn" data-key="btc-saver" type="button">Bitcoin, to a saver in a high-inflation country</button>
+                    <button class="choice-btn" data-key="btc-skeptic" type="button">Bitcoin, to a skeptic with a stable currency</button>
                 </div>
-                <div class="comparison-card mainstream">
-                    <h4>📊 Mainstream Economics (Neoclassical)</h4>
-                    <ul style="list-style: disc; padding-left: 1.5rem; line-height: 1.8;">
-                        <li><strong>Method:</strong> Empirical data, mathematical models</li>
-                        <li><strong>Focus:</strong> Aggregate statistics and averages</li>
-                        <li><strong>Knowledge:</strong> Centralized, measurable</li>
-                        <li><strong>Markets:</strong> Equilibrium systems</li>
-                        <li><strong>Prices:</strong> Outcomes of supply/demand curves</li>
-                        <li><strong>Goal:</strong> Predict and control economies</li>
-                    </ul>
-                </div>
-            </div>
-
-            <h3>Why the Difference Matters</h3>
-            <p>
-                <strong>Mainstream economics treats humans like physics objects</strong> — predictable, measurable, controllable. It tries to model economies the way physicists model planetary motion.
-            </p>
-
-            <p>
-                <strong>Austrian economics recognizes that humans are not billiard balls.</strong> We act with purpose, adapt to circumstances, learn from mistakes, and create new knowledge. No equation can capture this.
-            </p>
-
-            <h3>The Mainstream Approach Fails for Bitcoin</h3>
-            <p>
-                Many prominent economists were openly skeptical of Bitcoin in its early years:
-            </p>
-            <ul>
-                <li><strong>Paul Krugman (2013):</strong> titled a column "Bitcoin Is Evil" and argued it was a foolish, gold-like throwback</li>
-                <li><strong>Nouriel Roubini (2018):</strong> "Bitcoin is the mother of all scams"</li>
-                <li><strong>Kenneth Rogoff (2017):</strong> "Bitcoin will eventually collapse"</li>
-            </ul>
-
-            <p>
-                They all made the same mistake: <strong>treating Bitcoin as a static object instead of understanding it as a product of human action</strong>.
-            </p>
-
-            <p>
-                Austrian economists, by contrast, immediately recognized Bitcoin's significance:
-            </p>
-            <ul>
-                <li><strong>It's sound money</strong> (Mises' monetary theory)</li>
-                <li><strong>It solves the calculation problem</strong> (Hayek's knowledge problem)</li>
-                <li><strong>It rewards low time preference</strong> (Austrian capital theory)</li>
-                <li><strong>It's spontaneous order</strong> (Hayek's coordination without coercion)</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>💡 The Austrian Advantage</h4>
-                <p>
-                    <strong>Praxeology approaches Bitcoin not by modeling it, but by understanding the logic of human action that helps explain why Bitcoin emerged.</strong>
-                </p>
-                <p style="margin: 0;">
-                    When you understand why people act, why they choose, why they value scarcity — Bitcoin starts to make a great deal of sense.
-                </p>
+                <div class="reveal" id="value-result" hidden></div>
             </div>
         </section>
 
-        <!-- Key Praxeological Concepts -->
         <section class="content-section">
-            <h2>🔑 Key Praxeological Concepts</h2>
-
-            <h3>1. Subjective Value Theory</h3>
+            <h2>Austrian and mainstream economics, fairly stated</h2>
             <p>
-                <strong>Value is not objective</strong> — it exists only in the minds of acting individuals.
+                Austrian economics is often taught by caricaturing the mainstream. That is not honest, and it is not necessary. They genuinely differ on method, but they also share a great deal, including marginal utility, which both adopted in the 1870s.
             </p>
-            <ul>
-                <li><strong>Water is more "useful" than diamonds</strong> — yet diamonds cost more. Why?</li>
-                <li>Because <strong>value = marginal utility</strong>, not intrinsic properties</li>
-                <li>A thirsty person in the desert values water infinitely more than someone with a full glass</li>
-            </ul>
+            <div class="data-table-wrap">
+                <table class="compare">
+                    <thead><tr><th>Question</th><th>Austrian view</th><th>Mainstream / neoclassical view</th></tr></thead>
+                    <tbody>
+                        <tr><td>Where do laws come from?</td><td>Deduced from the action axiom</td><td>Built and tested against data and models</td></tr>
+                        <tr><td>Role of empirical data</td><td>Illustrates theory, does not test core claims</td><td>Tests and refines theory; central</td></tr>
+                        <tr><td>Model of the person</td><td>Purposeful actor under real uncertainty</td><td>Optimizer with preferences and expectations</td></tr>
+                        <tr><td>Theory of value</td><td>Subjective, marginal</td><td>Subjective, marginal (shared since the 1870s)</td></tr>
+                        <tr><td>Typical tools</td><td>Verbal logic, thought experiments</td><td>Mathematics, statistics, experiments</td></tr>
+                    </tbody>
+                    <caption>Note the shared row: marginalism is common ground, not an Austrian monopoly. The real divide is about method and the role of evidence.</caption>
+                </table>
+            </div>
+        </section>
 
+        <section class="content-section">
+            <h2>The strongest objection: is this science?</h2>
             <p>
-                <strong>For Bitcoin:</strong> Critics ask "What backs Bitcoin?" Austrian economists reply: "Human valuation backs Bitcoin — the same thing that backs gold, art, or any money."
+                The deepest criticism of praxeology is not about any single conclusion; it is about the method itself. It deserves its full strength.
             </p>
-
-            <h3>2. Marginal Analysis</h3>
-            <p>
-                Humans make decisions <strong>at the margin</strong> — comparing the next unit, not the total stock.
-            </p>
-            <ul>
-                <li><strong>Example:</strong> You wouldn't trade your house for a sandwich. But if you're hungry, you'll trade $10 for a sandwich</li>
-                <li>This is because you value the <strong>marginal sandwich</strong> more than the marginal $10, even though you value your house more than all sandwiches</li>
-            </ul>
-
-            <p>
-                <strong>For Bitcoin:</strong> Early adopters valued the marginal bitcoin very highly (breakthrough technology). Late adopters value it less per unit (already established). This explains the price discovery process.
-            </p>
-
-            <h3>3. Time Preference</h3>
-            <p>
-                All action takes place across time. <strong>People prefer satisfaction sooner rather than later</strong> — this is time preference.
-            </p>
-            <p>
-                (We covered this in depth in <a href="/deep-dives/austrian-economics/time-preference-fundamentals.html" style="color: var(--accent-gold);">Time Preference Fundamentals</a>.)
-            </p>
-
-            <h3>4. Opportunity Cost</h3>
-            <p>
-                Every choice means <strong>rejecting alternatives</strong>. The value of the next-best alternative is the opportunity cost.
-            </p>
-            <ul>
-                <li>If you buy bitcoin, you forgo buying stocks, bonds, or consumer goods</li>
-                <li>The value of what you gave up is the real cost — not the dollar price</li>
-            </ul>
-
-            <p>
-                <strong>For Bitcoin:</strong> HODLing bitcoin means forgoing present consumption. This is only rational if you expect future purchasing power to exceed present opportunity cost. Sound money rewards this choice.
-            </p>
-
-            <h3>5. Entrepreneurship and Uncertainty</h3>
-            <p>
-                The future is <strong>genuinely uncertain</strong> — not just risky, but unknowable. Entrepreneurs act despite uncertainty, betting on their judgment.
-            </p>
-            <ul>
-                <li><strong>Risk:</strong> Known probabilities (coin flip)</li>
-                <li><strong>Uncertainty:</strong> Unknown probabilities (will Bitcoin succeed?)</li>
-            </ul>
-
-            <p>
-                <strong>For Bitcoin:</strong> Early adopters were entrepreneurs. They couldn't "calculate" Bitcoin's odds — they acted on insight, conviction, and skin in the game. This is praxeology in action.
-            </p>
-
-            <div class="highlight-box">
-                <h4>🎯 Why These Concepts Matter</h4>
+            <div class="steelman-box">
+                <h4>1. An unfalsifiable theory cannot be science</h4>
                 <p>
-                    Every one of these concepts explains <strong>why Bitcoin works</strong>:
+                    On the influential view of Karl Popper, a claim is scientific only if some possible observation could refute it. Praxeology says its core is true by logic, prior to any data, and therefore no observation can refute it. The economist Bryan Caplan, in "Why I Am Not an Austrian Economist," presses exactly this: if the action axiom and what follows from it cannot be tested, then calling the results "economic science" overstates them, and disagreements become impossible to settle by evidence.
                 </p>
-                <ul style="margin: 1rem 0;">
-                    <li><strong>Subjective value:</strong> Bitcoin doesn't need "backing" — human valuation is enough</li>
-                    <li><strong>Marginal utility:</strong> Explains price discovery and adoption curve</li>
-                    <li><strong>Time preference:</strong> HODLing is rational under sound money</li>
-                    <li><strong>Opportunity cost:</strong> Fiat loses value over time → bitcoin compares favorably as a place to hold savings</li>
-                    <li><strong>Entrepreneurship:</strong> Early adopters took uncertainty, earned massive gains</li>
-                </ul>
-                <p style="margin: 0;">
-                    <strong>Praxeology described the properties sound money would need long before Bitcoin existed.</strong>
+                <p class="response">
+                    <strong>The response, and where it lands:</strong> Austrians answer that economics studies meaningful human choice, which is not the same kind of object as a falling rock, and that some starting points (you cannot deny that you act without acting) are reasonably treated as secure. That defense has force for the bare axiom. It gets weaker the further a chain of deductions travels toward specific policy conclusions, where unstated assumptions can slip in. A fair reader can accept the axiom as nearly self-evident while still doubting that detailed real-world claims follow from logic alone.
+                </p>
+            </div>
+            <div class="steelman-box">
+                <h4>2. Deduction can smuggle in ideology, and behavior is often statistical</h4>
+                <p>
+                    A second worry: long verbal deductions are easy to steer toward a conclusion you already favor, with the value judgments hidden in the premises. And behavioral economics (Kahneman, Tversky, Thaler) shows that real choices are systematically biased and context-dependent in ways a clean logic of action does not predict, which is why much of modern economics is empirical and statistical.
+                </p>
+                <p class="response">
+                    <strong>The response, and where it lands:</strong> Austrians reply that bias does not abolish purpose; a person acting on a biased belief is still acting. True, but it concedes the practical point: to know <em>how</em> people actually act, in detail, you generally need evidence, not only the axiom. The honest position holds the axiom as a real insight and treats grand deductive claims with caution.
                 </p>
             </div>
         </section>
 
-        <!-- Praxeology Applied to Bitcoin -->
         <section class="content-section">
-            <h2>₿ Praxeology Applied to Bitcoin</h2>
-
-            <h3>Bitcoin Is Human Action Encoded</h3>
+            <h2>Praxeology as a lens on Bitcoin</h2>
             <p>
-                Bitcoin is not just software. <strong>Bitcoin is a coordination tool that respects the logic of human action.</strong>
+                Used carefully, the action lens is genuinely useful for Bitcoin, because Bitcoin is a system held together entirely by purposeful actors, not by a central authority. Miners weigh the cost of power against block rewards. Node operators choose to enforce rules. Developers, users, exchanges, savers, and even attackers each pursue ends under uncertainty. Seeing the network as a web of human action, rather than as a machine, explains why it behaves the way it does.
             </p>
-
-            <h3>Purposeful Behavior</h3>
-            <ul>
-                <li><strong>Miners act purposefully:</strong> They expend resources (electricity, hardware) to earn bitcoin rewards</li>
-                <li><strong>Users act purposefully:</strong> They hold bitcoin to preserve wealth or transact voluntarily</li>
-                <li><strong>Developers act purposefully:</strong> They improve the protocol to increase value for everyone</li>
-            </ul>
-
-            <p>
-                Nobody is forced. <strong>All coordination is voluntary</strong> — pure praxeology.
-            </p>
-
-            <h3>Means and Ends</h3>
-            <ul>
-                <li><strong>End:</strong> Secure, scarce, censorship-resistant money</li>
-                <li><strong>Means:</strong> Proof-of-work, decentralized nodes, cryptography, economic incentives</li>
-            </ul>
-
-            <p>
-                Bitcoin uses <strong>scarce resources (energy, time, capital)</strong> to achieve an <strong>end valued by millions</strong>. This is the essence of economic action.
-            </p>
-
-            <h3>Time Preference in Bitcoin</h3>
-            <p>
-                Bitcoin is <strong>designed for low time preference actors</strong>:
-            </p>
-            <ul>
-                <li><strong>Fixed supply:</strong> Rewards those who save (low time preference)</li>
-                <li><strong>Halving schedule:</strong> Predictable scarcity over time</li>
-                <li><strong>HODL culture:</strong> Community values patience, long-term thinking</li>
-            </ul>
-
-            <p>
-                Fiat money punishes savers. Bitcoin rewards them. <strong>Praxeology explains why Bitcoin attracts the most patient, disciplined actors.</strong>
-            </p>
-
-            <h3>Voluntary Exchange</h3>
-            <p>
-                Every bitcoin transaction is <strong>voluntary</strong>. Both parties expect to benefit, or the trade doesn't happen.
-            </p>
-            <p>
-                <strong>Contrast with fiat:</strong>
-            </p>
-            <ul>
-                <li>Legal tender laws force acceptance</li>
-                <li>Inflation forces spending</li>
-                <li>Capital controls prevent exit</li>
-            </ul>
-
-            <p>
-                Bitcoin is pure market money — <strong>chosen freely, not mandated by law.</strong>
-            </p>
-
             <div class="highlight-box">
-                <h4>🏛️ Mises Would Have Loved Bitcoin</h4>
-                <p>
-                    If Mises were alive today, he would recognize Bitcoin as <strong>the practical application of his life's work</strong>:
-                </p>
-                <ul style="margin: 1rem 0;">
-                    <li><strong>Sound money theory:</strong> Bitcoin is harder than gold</li>
-                    <li><strong>Economic calculation:</strong> Decentralized coordination beats central planning</li>
-                    <li><strong>Praxeology:</strong> Bitcoin respects human action, choice, and time preference</li>
-                    <li><strong>Separation of money and state:</strong> Bitcoin achieves it</li>
-                </ul>
-                <p style="margin: 0;">
-                    <strong>Bitcoin is Austrian economics in code.</strong>
+                <h4>A lens, not a proof, and a live Austrian disagreement</h4>
+                <p style="margin:0;">
+                    Praxeology helps you <em>describe</em> Bitcoin; it does not <em>prove</em> Bitcoin must succeed. And Austrians themselves disagree about Bitcoin: some invoke Mises's own regression theorem, which traces money's value back to an earlier non-monetary use, to argue that Bitcoin cannot truly be money. Others argue the theorem is satisfied or does not apply. The point worth keeping is that "Bitcoin is Austrian economics in code" is a slogan, and the actual Austrian literature is divided.
                 </p>
             </div>
         </section>
 
-        <!-- Why Mainstream Economics Fails Bitcoin -->
         <section class="content-section">
-            <h2>❌ Why Mainstream Economics Fails to Understand Bitcoin</h2>
-
-            <h3>They Treat Bitcoin Like a Stock</h3>
-            <p>
-                Mainstream economists analyze Bitcoin using <strong>models designed for stocks and bonds</strong>:
-            </p>
-            <ul>
-                <li>"What's the present value of future cash flows?" (Bitcoin has no cash flows)</li>
-                <li>"What's the P/E ratio?" (Bitcoin has no earnings)</li>
-                <li>"Is it correlated with inflation?" (Missing the point entirely)</li>
-            </ul>
-
-            <p>
-                <strong>Bitcoin is not an investment asset. Bitcoin is money.</strong> You can't analyze money the same way you analyze a company.
-            </p>
-
-            <h3>They Ignore Subjective Value</h3>
-            <p>
-                Mainstream economics assumes <strong>value is determined by production costs or utility functions</strong>.
-            </p>
-            <p>
-                But Bitcoin has minimal production cost (after mining) and no physical utility. <strong>Its value is purely subjective</strong> — people value it because <em>other people</em> value it, creating a network effect.
-            </p>
-
-            <p>
-                Austrian economics explains this perfectly. Mainstream economics can't.
-            </p>
-
-            <h3>They Believe in Equilibrium</h3>
-            <p>
-                Mainstream models assume markets reach <strong>static equilibrium</strong> where supply equals demand.
-            </p>
-
-            <p>
-                But Bitcoin is a <strong>dynamic discovery process</strong>. Price volatility isn't a "market failure" — it's the market <em>searching</em> for the correct valuation of this revolutionary technology.
-            </p>
-
-            <p>
-                Austrian economics embraces disequilibrium. Mainstream economics fears it.
-            </p>
-
-            <h3>They Demand "Intrinsic Value"</h3>
-            <p>
-                Critics endlessly ask: <strong>"What backs Bitcoin?"</strong>
-            </p>
-
-            <p>
-                Austrian economists reply: <strong>"What backs gold? What backs art? What backs any money?"</strong>
-            </p>
-
-            <p>
-                The answer: <strong>Human valuation.</strong> Money doesn't need "intrinsic" value — it needs <strong>market value</strong>, which emerges from voluntary exchange.
-            </p>
-
-            <p>
-                Praxeology understands this. Mainstream economics does not.
-            </p>
+            <h2>Claims to handle with care</h2>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Praxeology proves the Austrian conclusions with certainty, so data is irrelevant."</p>
+                <span class="reality-label">Reality</span>
+                <p>The a priori method is contested, not settled. The bare action axiom is hard to deny, but the claim that detailed economic conclusions follow from logic alone is exactly what critics reject. Treat the results as arguments to weigh, not proofs to accept.</p>
+            </div>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Mainstream economics treats people like billiard balls."</p>
+                <span class="reality-label">Reality</span>
+                <p>A caricature. Mainstream economics models purposeful choice under preferences and expectations, and it shares subjective marginal value with the Austrians. The genuine disagreement is about method and the role of evidence, not about whether people have goals.</p>
+            </div>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Mises would have loved Bitcoin; Bitcoin is Austrian economics in code."</p>
+                <span class="reality-label">Reality</span>
+                <p>This is counterfactual speculation. Mises died in 1973. His own regression theorem is used by some Austrians to argue against Bitcoin being money. Whatever you conclude, present it as a live debate, not as Mises's settled endorsement.</p>
+            </div>
         </section>
 
-        <!-- Socratic Reflection -->
         <section class="socratic-section">
-            <h3>💭 Socratic Reflection Questions</h3>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">1.</span> If economics is the study of human action, why do mainstream economists rely on models that assume humans behave like machines?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">2.</span> You can't prove the axiom "humans act" is true — but can you deny it without acting to deny it? What does this tell you about praxeology?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">3.</span> Gold has been money for thousands of years. What "backs" gold? If gold needs no backing beyond human valuation, why does Bitcoin?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">4.</span> Many mainstream economists were skeptical that Bitcoin would last, while many Austrian-influenced thinkers took it seriously early. What might explain the difference in how they saw it?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">5.</span> If you choose to HODL bitcoin, you forgo present consumption. What are you betting on? Is this rational under praxeological analysis?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">6.</span> "Bitcoin has no intrinsic value, therefore it's worthless." How would a praxeologist respond to this claim?
-                </p>
-            </div>
+            <h3>💭 Reflection questions</h3>
+            <p style="color:var(--text-dim);margin-bottom:1.5rem;">No answer key. Argue them in both directions.</p>
+            <div class="question"><p><span class="question-number">1.</span> Which cases in the action classifier felt genuinely hard, and why? Does the difficulty reveal a limit of the axiom, or just of your first intuition?</p></div>
+            <div class="question"><p><span class="question-number">2.</span> Can you deny that you act without performing an action in doing so? If not, does that make the axiom true, useful, or merely undeniable? Are those the same thing?</p></div>
+            <div class="question"><p><span class="question-number">3.</span> State Bryan Caplan's objection in your own words as strongly as you can. Then give the best Austrian reply. Which side carried more weight for you?</p></div>
+            <div class="question"><p><span class="question-number">4.</span> If a conclusion follows by logic from a true axiom, why might smart economists still disagree about it? Where could the hidden premises be?</p></div>
+            <div class="question"><p><span class="question-number">5.</span> Subjective value says worth depends on the actor and the situation. How does that change what "Bitcoin's value" even means as a question?</p></div>
+            <div class="question"><p><span class="question-number">6.</span> If praxeology cannot be falsified by data, what would honestly change your confidence in any of its conclusions?</p></div>
         </section>
 
-        <!-- Key Takeaways -->
-        <section class="content-section">
-            <h2>🎯 Key Takeaways</h2>
-
-            <ul>
-                <li><strong>Praxeology</strong> is the science of purposeful human behavior — the logic of choice</li>
-                <li><strong>Axiom of action:</strong> Humans act to achieve goals using scarce means. Everything else follows logically</li>
-                <li><strong>Austrian vs. mainstream:</strong> Austrians study individual choice; mainstream studies aggregates and models</li>
-                <li><strong>Subjective value theory:</strong> Value exists in minds, not objects. Bitcoin doesn't need "intrinsic" value</li>
-                <li><strong>Time preference:</strong> Bitcoin rewards low time preference (saving over spending)</li>
-                <li><strong>Opportunity cost:</strong> Every choice involves trade-offs. Bitcoin's scarcity makes it the ultimate opportunity</li>
-                <li><strong>Entrepreneurship:</strong> Early adopters acted under uncertainty, betting on Bitcoin's promise</li>
-                <li><strong>Voluntary exchange:</strong> Bitcoin is chosen freely, not mandated by law</li>
-                <li><strong>Mainstream failure:</strong> Models built for stocks can't analyze money. Praxeology can</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>🌟 The Big Picture</h4>
-                <p>
-                    <strong>Praxeology is the theoretical foundation that explains why Bitcoin works.</strong>
-                </p>
-                <p>
-                    When you understand that:
-                </p>
-                <ul style="margin: 1rem 0;">
-                    <li>Value is subjective</li>
-                    <li>Action is purposeful</li>
-                    <li>Time preference drives civilization</li>
-                    <li>Sound money emerges from voluntary choice</li>
-                </ul>
-                <p>
-                    ...then <strong>Bitcoin looks less like a curiosity and more like a logical answer.</strong>
-                </p>
-                <p style="margin: 0;">
-                    Mises gave us the theory. Satoshi gave us the code. Together, they changed the world.
-                </p>
-            </div>
+        <section class="sources-section">
+            <h2>Sources and claim ledger</h2>
+            <p class="asof">Last reviewed June 17, 2026.</p>
+            <ol>
+                <li>Praxeology and the action axiom: Ludwig von Mises, <em>Human Action</em> (1949).</li>
+                <li>Method defense: Murray Rothbard, "Praxeology: The Methodology of Austrian Economics" (1976); "In Defense of Extreme Apriorism" (1957).</li>
+                <li>Subjective value and marginal utility: Carl Menger, <em>Principles of Economics</em> (1871); William Stanley Jevons (1871).</li>
+                <li>Risk versus uncertainty: Frank Knight, <em>Risk, Uncertainty and Profit</em> (1921).</li>
+                <li>The falsifiability standard: Karl Popper, <em>The Logic of Scientific Discovery</em> (1959).</li>
+                <li>The core critique: Bryan Caplan, "Why I Am Not an Austrian Economist" (online essay).</li>
+                <li>Systematic bias in real choices: Daniel Kahneman and Amos Tversky; Richard Thaler (behavioral economics).</li>
+                <li>The regression theorem and the Bitcoin-as-money debate: Mises, <em>The Theory of Money and Credit</em> (1912); subsequent Austrian commentary on both sides.</li>
+            </ol>
         </section>
 
-        <!-- Navigation -->
         <div class="nav-buttons">
-            <a href="/deep-dives/austrian-economics/" class="nav-btn">
-                ← Back to Austrian Economics
-            </a>
-            <a href="/deep-dives/philosophy-economics/" class="nav-btn primary">
-                Explore Philosophy &amp; Economics →
-            </a>
+            <a href="/deep-dives/austrian-economics/" class="nav-btn">← Back to Austrian Economics</a>
+            <a href="/deep-dives/austrian-economics/sound-money-theory.html" class="nav-btn primary">Read: Sound Money Theory →</a>
         </div>
     </main>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>
     <script>
-        // Inject icons after DOM loads
         document.addEventListener('DOMContentLoaded', function() {
             if (window.IconLibrary) {
                 document.querySelectorAll('[data-icon]').forEach(function(element) {
@@ -834,15 +340,85 @@
         });
     </script>
 
+    <!-- Deep-dive interactives (vanilla JS, no external data) -->
+    <script>
+    (function () {
+        // "Is this human action?" classifier
+        var SCENARIOS = [
+            { t: 'Blinking when dust blows into your eye', action: false, why: 'A reflex. It is not chosen toward a goal, so praxeology does not count it as action.' },
+            { t: 'Choosing which wallet app to download', action: true, why: 'A purposeful choice among means toward an end. Action.' },
+            { t: 'Panic-selling during a crash', action: true, why: 'Still action. You chose to relieve a felt unease, even if you later regret it. Regret does not make it a reflex.' },
+            { t: 'Forgetting your seed phrase', action: false, why: 'Forgetting is not a chosen act. Writing the phrase down, or failing to, was the action; the forgetting is not.' },
+            { t: 'Mining bitcoin', action: true, why: 'Deploying energy and hardware toward a reward. Clearly action.' },
+            { t: 'Paying taxes under threat of penalty', action: true, why: 'Coercion changes your options, it does not remove the choice. You choose compliance over the alternative, so it is action.' },
+            { t: 'Your heart beating', action: false, why: 'Autonomic, not chosen. Not action.' },
+            { t: 'Holding through a downturn instead of selling', action: true, why: 'Choosing not to act on the market is itself a choice. Action.' }
+        ];
+        var list = document.getElementById('action-list');
+        var scoreOut = document.getElementById('action-score');
+        var answered = 0, correct = 0;
+        SCENARIOS.forEach(function (s, i) {
+            var row = document.createElement('div'); row.className = 'scenario';
+            var label = document.createElement('span'); label.className = 'stext'; label.textContent = (i + 1) + '. ' + s.t;
+            var btns = document.createElement('div'); btns.className = 'btns';
+            var bAction = document.createElement('button'); bAction.type = 'button'; bAction.textContent = 'Action';
+            var bNot = document.createElement('button'); bNot.type = 'button'; bNot.className = 'secondary'; bNot.textContent = 'Not action';
+            var verdict = document.createElement('div'); verdict.className = 'verdict'; verdict.hidden = true;
+            btns.appendChild(bAction); btns.appendChild(bNot);
+            row.appendChild(label); row.appendChild(btns); row.appendChild(verdict);
+            list.appendChild(row);
+            var done = false;
+            function choose(guess){
+                if (done) return; done = true;
+                var right = (guess === s.action);
+                answered++; if (right) correct++;
+                verdict.hidden = false;
+                var tag = document.createElement('span'); tag.className = 'tag';
+                tag.style.color = right ? 'var(--accent-bronze)' : '#9db8da';
+                tag.textContent = (s.action ? 'Action. ' : 'Not action. ');
+                verdict.appendChild(tag);
+                verdict.appendChild(document.createTextNode(s.why));
+                bAction.disabled = true; bNot.disabled = true;
+                bAction.style.opacity = '0.6'; bNot.style.opacity = '0.6';
+                scoreOut.textContent = 'You matched the method on ' + correct + ' of ' + answered + ' so far. The tricky ones (taxes, panic-selling, holding) are where the axiom is doing real work.';
+            }
+            bAction.addEventListener('click', function(){ choose(true); });
+            bNot.addEventListener('click', function(){ choose(false); });
+        });
+
+        // Subjective-value selector
+        var VALUE = {
+            'water-home': 'Cheap, almost an afterthought. You already have plenty, so the next glass barely matters. Marginal value is low even though water is essential.',
+            'water-desert': 'Suddenly priceless. Same glass, same chemistry, but in this situation the next unit can save your life. The value was never in the water; it was in your circumstance.',
+            'btc-saver': 'Potentially high. If your local currency loses value quickly, a money no government can debase solves a real problem you face, so you weigh it heavily.',
+            'btc-skeptic': 'Possibly near zero. With a stable currency and no felt need it solves, the same asset can look like noise. Same Bitcoin, different actor, different value.'
+        };
+        var valueResult = document.getElementById('value-result');
+        document.querySelectorAll('#value-choices .choice-btn').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var key = btn.getAttribute('data-key');
+                valueResult.hidden = false;
+                valueResult.textContent = '';
+                var p = document.createElement('p');
+                p.textContent = VALUE[key] || '';
+                valueResult.appendChild(p);
+                var note = document.createElement('p');
+                note.style.color = '#b3b3b3'; note.style.fontSize = '0.9rem'; note.style.marginBottom = '0';
+                note.textContent = 'That is subjective value: worth is assigned by an actor in a situation, at the margin, not fixed in the object.';
+                valueResult.appendChild(note);
+            });
+        });
+    })();
+    </script>
 
     <!-- Navigation Context (return-to-path functionality) -->
     <script src="/js/navigation-context.js"></script>
     <!-- Reflect: Socratic questions after activity -->
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
-             data-topic="money"
+             data-topic="praxeology"
              data-path="principled"
-             data-title="Reflect: What drives human action?">
+             data-title="Reflect: Can economics be reasoned from one axiom?">
         </div>
     </div>
     <script src="/js/reflect-widget.js"></script>

--- a/deep-dives/austrian-economics/sound-money-theory.html
+++ b/deep-dives/austrian-economics/sound-money-theory.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sound Money Theory: The Foundation of Prosperity | Bitcoin Sovereign Academy</title>
-    <meta name="description" content="Understand what makes money 'sound' - from the gold standard to Bitcoin. Learn why hardness, verifiability, and scarcity define monetary excellence.">
+    <title>Sound Money Theory: Does Any Money Hold Value Across Time? | Bitcoin Sovereign Academy</title>
+    <meta name="description" content="A research lab on monetary hardness: what 'sound money' means, how gold, fiat, and Bitcoin compare on six properties, what the data shows, and the strongest case against the hard-money view. Inform, not convince.">
 
     <style>
         :root {
@@ -57,21 +57,21 @@
             0%, 100% { transform: scale(1); }
             50% { transform: scale(1.05); }
         }
+        @media (prefers-reduced-motion: reduce) {
+            .module-icon { animation: none; }
+        }
 
         h1 {
             font-size: 2.8rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-gold));
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
+            color: var(--accent-bronze);
             margin-bottom: 1rem;
             font-weight: 800;
         }
 
         .module-subtitle {
-            font-size: 1.3rem;
+            font-size: 1.25rem;
             color: var(--text-dim);
-            max-width: 800px;
+            max-width: 820px;
             margin: 0 auto 1.5rem;
             line-height: 1.8;
         }
@@ -93,6 +93,29 @@
             color: var(--accent-gold);
         }
 
+        /* Research question banner */
+        .research-question {
+            background: #101010;
+            border: 2px solid var(--accent-bronze);
+            border-radius: 12px;
+            padding: 1.75rem 2rem;
+            margin: 0 auto 2.5rem;
+            max-width: 1000px;
+        }
+        .research-question .label {
+            font-size: 0.8rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--accent-bronze);
+            font-weight: 700;
+        }
+        .research-question p {
+            font-size: 1.25rem;
+            line-height: 1.6;
+            margin-top: 0.5rem;
+            color: var(--text-light);
+        }
+
         /* Content Sections */
         .content-section {
             background: var(--secondary-dark);
@@ -100,12 +123,6 @@
             padding: 3rem;
             margin-bottom: 2.5rem;
             border: 2px solid rgba(139, 111, 71, 0.3);
-            transition: all 0.3s ease;
-        }
-
-        .content-section:hover {
-            border-color: var(--accent-bronze);
-            box-shadow: 0 8px 24px rgba(139, 111, 71, 0.2);
         }
 
         .content-section h2 {
@@ -113,14 +130,11 @@
             font-size: 2rem;
             margin-bottom: 1.5rem;
             font-weight: 700;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
         }
 
         .content-section h3 {
             color: var(--accent-bronze-light);
-            font-size: 1.5rem;
+            font-size: 1.4rem;
             margin: 2rem 0 1rem;
             font-weight: 600;
         }
@@ -144,7 +158,7 @@
         }
 
         .content-section li {
-            padding: 1rem 0 1rem 2.5rem;
+            padding: 0.85rem 0 0.85rem 1.5rem;
             position: relative;
             color: var(--text-light);
             line-height: 1.8;
@@ -156,10 +170,11 @@
         }
 
         .content-section li:before {
-            content: "💰";
+            content: "›";
             position: absolute;
             left: 0;
-            font-size: 1.2rem;
+            color: var(--accent-bronze);
+            font-weight: 700;
         }
 
         /* Highlight Boxes */
@@ -174,48 +189,125 @@
         .highlight-box h4 {
             color: var(--accent-gold);
             margin-bottom: 1rem;
-            font-size: 1.3rem;
+            font-size: 1.25rem;
         }
 
-        .highlight-box p {
-            margin-bottom: 1rem;
-        }
+        .highlight-box p { margin-bottom: 1rem; }
+        .highlight-box p:last-child { margin-bottom: 0; }
 
-        /* Comparison Grid */
-        .comparison-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 2rem;
+        /* Steelman box */
+        .steelman-box {
+            background: #101010;
+            border: 2px solid #5a78a0;
+            border-radius: 12px;
+            padding: 2rem;
             margin: 2rem 0;
         }
-
-        .comparison-card {
-            background: rgba(0, 0, 0, 0.3);
-            padding: 2rem;
-            border-radius: 12px;
-            transition: all 0.3s ease;
-        }
-
-        .comparison-card.good {
-            border: 2px solid #2A2A2A;
-        }
-
-        .comparison-card.bad {
-            border: 2px solid var(--error-red);
-        }
-
-        .comparison-card h4 {
+        .steelman-box h4 {
+            color: #9db8da;
             font-size: 1.2rem;
             margin-bottom: 1rem;
         }
-
-        .comparison-card.good h4 {
-            color: #F7F7F2;
+        .steelman-box .response {
+            margin-top: 1.25rem;
+            padding-top: 1.25rem;
+            border-top: 1px solid rgba(255,255,255,0.12);
         }
+        .steelman-box .response strong { color: var(--accent-gold); }
 
-        .comparison-card.bad h4 {
-            color: var(--error-red);
+        /* Misconception repair */
+        .myth {
+            background: rgba(0,0,0,0.3);
+            border-radius: 10px;
+            padding: 1.5rem;
+            margin: 1.25rem 0;
+            border-left: 4px solid #2A2A2A;
         }
+        .myth .myth-label { color: var(--text-dim); font-weight: 700; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .myth .reality-label { color: var(--accent-bronze); font-weight: 700; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .myth p { margin: 0.35rem 0 1rem; }
+        .myth p:last-child { margin-bottom: 0; }
+
+        /* Comparison / data table */
+        .data-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
+        table.compare {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.95rem;
+            min-width: 560px;
+        }
+        table.compare th, table.compare td {
+            padding: 0.75rem 0.85rem;
+            text-align: left;
+            border-bottom: 1px solid rgba(255,255,255,0.1);
+        }
+        table.compare thead th {
+            color: var(--accent-bronze);
+            border-bottom: 2px solid rgba(255,122,0,0.4);
+            font-weight: 700;
+        }
+        table.compare td:first-child, table.compare th:first-child { font-weight: 600; }
+        table.compare caption { caption-side: bottom; color: var(--text-dim); font-size: 0.82rem; padding-top: 0.75rem; text-align: left; }
+
+        /* Interactive panels */
+        .interactive {
+            background: #101010;
+            border: 2px solid var(--accent-bronze);
+            border-radius: 12px;
+            padding: 2rem;
+            margin: 2rem 0;
+        }
+        .interactive h4 { color: var(--accent-bronze); font-size: 1.2rem; margin-bottom: 0.5rem; }
+        .interactive .hint { color: var(--text-dim); font-size: 0.9rem; margin-bottom: 1.25rem; }
+        .interactive label { display: block; margin: 0.75rem 0 0.35rem; font-weight: 600; }
+        .interactive input[type="range"] { width: 100%; accent-color: var(--accent-bronze); }
+        .interactive input[type="number"] {
+            background: var(--secondary-dark);
+            color: var(--text-light);
+            border: 1px solid rgba(255,255,255,0.2);
+            border-radius: 6px;
+            padding: 0.5rem 0.65rem;
+            font-size: 1rem;
+            width: 100%;
+            max-width: 240px;
+        }
+        .interactive .readout { font-size: 1.05rem; font-weight: 700; color: var(--accent-bronze); }
+        .interactive button {
+            background: var(--accent-bronze);
+            color: #101010;
+            border: none;
+            border-radius: 8px;
+            padding: 0.65rem 1.4rem;
+            font-weight: 700;
+            font-size: 0.95rem;
+            cursor: pointer;
+            margin-top: 1rem;
+        }
+        .interactive button:hover { background: var(--accent-gold); }
+        .reveal {
+            margin-top: 1.25rem;
+            padding-top: 1.25rem;
+            border-top: 1px solid rgba(255,255,255,0.12);
+        }
+        .reveal[hidden] { display: none; }
+        .reveal p { margin-bottom: 0.75rem; }
+        .checkbox-row { display: flex; flex-wrap: wrap; gap: 0.85rem 1.5rem; margin: 1rem 0; }
+        .checkbox-row label { display: flex; align-items: center; gap: 0.4rem; margin: 0; font-weight: 500; }
+        .checkbox-row input { accent-color: var(--accent-bronze); width: 1.05rem; height: 1.05rem; }
+
+        /* Simple bar chart */
+        .barchart { margin: 1.5rem 0; }
+        .bar-row { display: grid; grid-template-columns: 90px 1fr; align-items: center; gap: 0.75rem; margin: 0.5rem 0; }
+        .bar-row .name { color: var(--text-dim); font-size: 0.9rem; }
+        .bar-row .bar-track { background: rgba(255,255,255,0.06); border-radius: 4px; overflow: hidden; }
+        .bar-row .bar-fill { background: var(--accent-bronze); height: 1.6rem; display: flex; align-items: center; justify-content: flex-end; padding-right: 0.5rem; color: #101010; font-weight: 700; font-size: 0.82rem; border-radius: 4px; min-width: 2.5rem; }
+
+        /* Tradeoff cards */
+        .tradeoff-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin: 1.5rem 0; }
+        .tradeoff-card { background: rgba(0,0,0,0.3); padding: 1.5rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.1); }
+        .tradeoff-card h4 { margin-bottom: 0.75rem; font-size: 1.05rem; color: var(--text-light); }
+        .tradeoff-card ul { margin: 0; }
+        .tradeoff-card li { padding: 0.5rem 0 0.5rem 1.25rem; border: none; }
 
         /* Socratic Section */
         .socratic-section {
@@ -225,13 +317,7 @@
             margin-bottom: 2.5rem;
             border: 2px solid #2A2A2A;
         }
-
-        .socratic-section h3 {
-            color: #FF7A00;
-            margin-bottom: 2rem;
-            font-size: 1.8rem;
-        }
-
+        .socratic-section h3 { color: #FF7A00; margin-bottom: 2rem; font-size: 1.8rem; }
         .question {
             background: rgba(0, 0, 0, 0.3);
             padding: 1.5rem;
@@ -239,23 +325,19 @@
             margin-bottom: 1.5rem;
             border-left: 4px solid #FF7A00;
         }
+        .question-number { color: #FF7A00; font-weight: 700; font-size: 1.2rem; margin-right: 0.5rem; }
 
-        .question-number {
-            color: #FF7A00;
-            font-weight: 700;
-            font-size: 1.2rem;
-            margin-right: 0.5rem;
-        }
+        /* Sources / claim ledger */
+        .sources-section { background: var(--secondary-dark); border-radius: 16px; padding: 2.5rem 3rem; margin-bottom: 2.5rem; border: 2px solid rgba(139,111,71,0.3); }
+        .sources-section h2 { color: var(--accent-bronze); font-size: 1.6rem; margin-bottom: 0.5rem; }
+        .sources-section .asof { color: var(--text-dim); font-size: 0.85rem; margin-bottom: 1.5rem; }
+        .sources-section ol { padding-left: 1.25rem; }
+        .sources-section li { padding: 0.5rem 0; color: var(--text-dim); font-size: 0.92rem; line-height: 1.6; }
+        .sources-section a { color: var(--accent-bronze); text-decoration: none; }
+        .sources-section a:hover { text-decoration: underline; }
 
         /* Navigation */
-        .nav-buttons {
-            display: flex;
-            gap: 1.5rem;
-            justify-content: space-between;
-            margin: 3rem 0;
-            flex-wrap: wrap;
-        }
-
+        .nav-buttons { display: flex; gap: 1.5rem; justify-content: space-between; margin: 3rem 0; flex-wrap: wrap; }
         .nav-btn {
             display: inline-block;
             padding: 1rem 2rem;
@@ -270,73 +352,52 @@
             flex: 1;
             min-width: 200px;
         }
-
-        .nav-btn:hover {
-            background: var(--accent-bronze);
-            transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgba(139, 111, 71, 0.3);
-        }
-
-        .nav-btn.primary {
-            background: var(--accent-bronze);
-            color: white;
-        }
-
-        .nav-btn.primary:hover {
-            background: var(--accent-gold);
-        }
+        .nav-btn:hover { background: var(--accent-bronze); transform: translateY(-2px); }
+        .nav-btn.primary { background: var(--accent-bronze); color: white; }
+        .nav-btn.primary:hover { background: var(--accent-gold); }
 
         /* Responsive */
         @media (max-width: 768px) {
-            .module-header {
-                padding: 2rem 1rem;
-            }
-
-            h1 {
-                font-size: 2rem;
-            }
-
-            .module-subtitle {
-                font-size: 1.1rem;
-            }
-
-            .content-section {
-                padding: 2rem 1.5rem;
-            }
-
-            .comparison-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .nav-buttons {
-                flex-direction: column;
-            }
+            .module-header { padding: 2rem 1rem; }
+            h1 { font-size: 2rem; }
+            .module-subtitle { font-size: 1.1rem; }
+            .content-section { padding: 2rem 1.5rem; }
+            .tradeoff-grid { grid-template-columns: 1fr; }
+            .nav-buttons { flex-direction: column; }
         }
     </style>
     <link rel="stylesheet" href="/css/icons.css">
-<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/sound-money-theory"><meta property="og:title" content="Sound Money Theory - Bitcoin Sovereign Academy"><meta property="og:description" content="Learn about sound money theory at Bitcoin Sovereign Academy. Interactive Bitcoin education with hands-on exercises and expert guidance."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/sound-money-theory"><meta property="og:type" content="website"><script type="application/ld+json">{
+<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/sound-money-theory"><meta property="og:title" content="Sound Money Theory: Does Any Money Hold Value Across Time?"><meta property="og:description" content="A research lab on monetary hardness. Compare gold, fiat, and Bitcoin on six properties, check the data yourself, and weigh the strongest case against the hard-money view."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/sound-money-theory"><meta property="og:type" content="article"><script type="application/ld+json">{
   "@context": "https://schema.org",
-  "@type": "EducationalOrganization",
-  "name": "Bitcoin Sovereign Academy",
-  "description": "Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here.",
-  "url": "https://bitcoinsovereign.academy",
-  "logo": "https://bitcoinsovereign.academy/assets/og-image.jpg",
-  "sameAs": [
-    "https://github.com/Sovereigndwp/bitcoin-sovereign-academy"
-  ],
-  "educationalLevel": "Beginner to Advanced",
+  "@type": "LearningResource",
+  "name": "Sound Money Theory: Does Any Money Hold Value Across Time?",
+  "learningResourceType": "Deep dive",
+  "educationalLevel": "Intermediate to Advanced",
+  "isAccessibleForFree": true,
   "teaches": [
-    "Bitcoin Fundamentals",
-    "Cryptocurrency Technology",
-    "Financial Sovereignty",
-    "Digital Asset Security"
+    "What 'sound money' means in first-principles terms",
+    "The six monetary properties and their tradeoffs",
+    "Stock-to-flow as a hardness heuristic and its limits",
+    "How to read inflation, money-supply, and debt data critically",
+    "The mainstream case against a hard-money standard"
   ],
-  "audience": {
-    "@type": "Audience",
-    "audienceType": "Students interested in Bitcoin and cryptocurrency"
+  "publisher": {
+    "@type": "EducationalOrganization",
+    "name": "Bitcoin Sovereign Academy",
+    "url": "https://bitcoinsovereign.academy"
   }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
+
+<!-- content-graph edges (BSA ontology)
+content_type: deep_dive
+strategic_role: economics_first_principles
+teaches: [sound_money_definition, six_monetary_properties, stock_to_flow_and_limits, reading_macro_data, gold_standard_debate]
+repairs: [misconception_dollar_lost_97pct_since_1971, misconception_s2f_predicts_price, misconception_hard_money_means_stable_prices, misconception_bitcoin_perfectly_fungible]
+supports_decision: [how_to_think_about_storing_value_long_term]
+bridges_to: [/deep-dives/austrian-economics/time-preference-fundamentals.html, /interactive-demos/stock-to-flow/, /deep-dives/austrian-economics/economic-calculation-problem.html]
+blocked_by_boundary: [no_direct_tba_funnel]
+-->
 </head>
 <body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
@@ -346,7 +407,7 @@
             <div class="module-icon">💰</div>
             <h1>Sound Money Theory</h1>
             <p class="module-subtitle">
-                What makes money "sound"? Explore the properties that define monetary excellence and discover why Bitcoin represents the hardest, most sound money ever created.
+                A research lab on monetary hardness. We will define what "sound money" means, compare gold, fiat, and Bitcoin on six properties, check the historical data ourselves, and weigh the strongest argument against the whole idea before drawing any conclusion.
             </p>
             <div class="breadcrumb">
                 <a href="/">Home</a> →
@@ -356,359 +417,319 @@
             </div>
         </header>
 
-        <!-- Introduction -->
+        <!-- Research question -->
+        <div class="research-question">
+            <span class="label">The question we are investigating</span>
+            <p>If you had to store the value of your work for thirty years, which money would you trust, and what property are you actually betting on?</p>
+        </div>
+
+        <!-- Why it matters -->
         <section class="content-section">
-            <h2><span data-icon="dollar"></span> What Is "Sound Money"?</h2>
-            
+            <h2>Why this matters</h2>
             <p>
-                Throughout history, civilizations have experimented with countless forms of money — seashells, cattle, salt, precious metals, paper notes, and now digital tokens. But only a few have stood the test of time. What separates <strong>sound money</strong> from failed experiments?
+                Every time you save, you make a quiet bet: that the money you set aside will still command roughly the same goods and labor when you need it. A retirement account, a down payment fund, an inheritance left for a child: each one is a wager on a money holding its value across decades.
             </p>
-
             <p>
-                Austrian economists define <strong>sound money</strong> as money that:
-            </p>
-
-            <ul>
-                <li><strong>Resists inflation:</strong> Supply cannot be arbitrarily expanded</li>
-                <li><strong>Maintains purchasing power:</strong> Preserves wealth across time</li>
-                <li><strong>Enables economic calculation:</strong> Provides a stable unit of account</li>
-                <li><strong>Separates money from state:</strong> Free from political manipulation</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>💡 The Austrian Definition</h4>
-                <p>
-                    <strong>"Sound money is money that is free from government manipulation and resistant to debasement. It emerges naturally from the market and maintains its value over time."</strong>
-                </p>
-                <p style="margin: 0;">
-                    — Ludwig von Mises, <em>The Theory of Money and Credit</em> (1912)
-                </p>
-            </div>
-
-            <p>
-                The Austrian School emphasizes that <strong>sound money is not a government decree</strong> — it's a <strong>market phenomenon</strong>. The best money wins through voluntary adoption, not legal tender laws.
+                "Sound money" is the name one school of economics gives to money that wins that bet reliably. But the phrase carries assumptions worth testing. This deep dive treats it as a question, not a slogan: what makes money hold value across time, how do the candidates actually compare, and where does the hard-money argument run into its strongest objections?
             </p>
         </section>
 
-        <!-- The Six Properties of Good Money -->
+        <!-- Definition / current system -->
         <section class="content-section">
-            <h2>🔑 The Six Properties of Good Money</h2>
-
+            <h2>What does "sound money" mean?</h2>
             <p>
-                Austrian economists (following Carl Menger's foundational work) identified six critical properties that determine whether something can serve as effective money:
+                Start from function, before naming any school. Money does three jobs: it is a <strong>medium of exchange</strong> (you can trade with it), a <strong>unit of account</strong> (you can price things in it), and a <strong>store of value</strong> (it carries purchasing power into the future). "Soundness" is mostly about that third job: how well the money resists having its purchasing power diluted.
             </p>
-
-            <h3>1. Scarcity (Stock-to-Flow Ratio)</h3>
             <p>
-                Good money must be <strong>hard to produce</strong>. If supply can be easily expanded, value evaporates.
+                The Austrian School, following Carl Menger and Ludwig von Mises, argued that the best money is the one the market chooses through voluntary use, not the one a government decrees. Mises developed this in <em>The Theory of Money and Credit</em> (1912). The core idea: money whose supply cannot be expanded cheaply protects savers, because no one can quietly print claims against the goods they have stored.
             </p>
-            <ul>
-                <li><strong>Gold:</strong> Difficult to mine. Stock-to-flow ratio ~60 (60 years of current production = existing supply)</li>
-                <li><strong>Silver:</strong> Easier to mine. Stock-to-flow ratio ~20</li>
-                <li><strong>Fiat currencies:</strong> Infinite supply. Central banks print at will</li>
-                <li><strong>Bitcoin:</strong> Fixed supply (21 million). Stock-to-flow approaching ∞ after final halving</li>
-            </ul>
-
-            <h3>2. Durability</h3>
-            <p>
-                Money must <strong>withstand time</strong>. Perishable goods cannot store value.
-            </p>
-            <ul>
-                <li><strong>Gold:</strong> Lasts forever. Ancient Roman coins still exist</li>
-                <li><strong>Paper:</strong> Degrades, burns, rots</li>
-                <li><strong>Bitcoin:</strong> Digital information — indestructible if properly backed up</li>
-            </ul>
-
-            <h3>3. Portability</h3>
-            <p>
-                Money must be <strong>easy to transport</strong> for trade.
-            </p>
-            <ul>
-                <li><strong>Gold:</strong> Heavy. $1 million = ~28 kg</li>
-                <li><strong>Cash:</strong> Lighter, but bulk becomes a problem</li>
-                <li><strong>Bitcoin:</strong> Infinite value transported by 12 words (seed phrase)</li>
-            </ul>
-
-            <h3>4. Divisibility</h3>
-            <p>
-                Money must be <strong>easily divided</strong> into smaller units without losing value.
-            </p>
-            <ul>
-                <li><strong>Gold:</strong> Can be divided, but small amounts are impractical</li>
-                <li><strong>Cattle:</strong> Impossible to divide without destruction</li>
-                <li><strong>Bitcoin:</strong> Divisible to 100 million units (satoshis). 1 BTC = 100,000,000 sats</li>
-            </ul>
-
-            <h3>5. Verifiability</h3>
-            <p>
-                Money must be <strong>easy to verify as authentic</strong>. Counterfeits destroy trust.
-            </p>
-            <ul>
-                <li><strong>Gold:</strong> Requires testing (density, acid test, expensive assay)</li>
-                <li><strong>Cash:</strong> Advanced counterfeits fool most people</li>
-                <li><strong>Bitcoin:</strong> Cryptographically provable. Verification is instant and free via any node</li>
-            </ul>
-
-            <h3>6. Fungibility</h3>
-            <p>
-                Every unit must be <strong>identical and interchangeable</strong>.
-            </p>
-            <ul>
-                <li><strong>Gold:</strong> One ounce = one ounce (if pure)</li>
-                <li><strong>Diamonds:</strong> Not fungible (each is unique)</li>
-                <li><strong>Bitcoin:</strong> One sat = one sat. Perfectly fungible at the protocol level</li>
-            </ul>
-
             <div class="highlight-box">
-                <h4>🏆 How Bitcoin Measures Up on All Six</h4>
-                <p>
-                    By the Austrian criteria, Bitcoin is the first monetary technology to <strong>score strongly on all six properties at once</strong>. Gold excelled for millennia but is weaker on portability and verifiability. Fiat money is weakest on scarcity. On these criteria, Bitcoin makes a strong case as <strong>sound money for the digital age</strong> — judge the six for yourself.
+                <h4>A note on sourcing</h4>
+                <p style="margin:0;">
+                    The popular "six properties" checklist below is a useful teaching synthesis, widely associated with Saifedean Ammous's <em>The Bitcoin Standard</em> (2018). It is not a verbatim list from Menger or Mises, who wrote about money's origin and value in different terms. We use it because it is a clear lens, not because it is an ancient canon.
                 </p>
             </div>
         </section>
 
-        <!-- History of Sound Money -->
+        <!-- Six properties + interactive matrix (comparison table) -->
         <section class="content-section">
-            <h2>📜 A Brief History of Sound Money</h2>
-
-            <h3>Gold Standard (1870s–1971)</h3>
+            <h2>The six properties, and the tradeoff between them</h2>
             <p>
-                For most of human history, <strong>gold was the monetary standard</strong>. Why? Because it naturally satisfied the six properties better than any alternative.
+                Six properties are commonly used to judge whether something works as money: <strong>scarcity</strong> (hard to produce), <strong>durability</strong> (survives time), <strong>portability</strong> (easy to move), <strong>divisibility</strong> (splits into small units), <strong>verifiability</strong> (easy to check as genuine), and <strong>fungibility</strong> (each unit interchangeable).
             </p>
-            <ul>
-                <li><strong>1870s–1914:</strong> Classical gold standard. Currencies backed by gold. Stable prices, capital accumulation, low time preference civilization</li>
-                <li><strong>1944–1971:</strong> Bretton Woods. Dollar backed by gold. Other currencies backed by dollar. Partial soundness</li>
-                <li><strong>August 15, 1971:</strong> Nixon closes the gold window. Fiat era begins. Money becomes political</li>
-            </ul>
-
-            <h3>The Fiat Experiment (1971–Present)</h3>
             <p>
-                Since 1971, humanity has lived under a <strong>purely fiat monetary system</strong> — money by government decree, with no commodity backing.
+                Here is the key point most explanations skip: <strong>no money is best on all six at once.</strong> Gold is extraordinarily durable but hard to move and hard to verify. Fiat is easy to move but easy to create. Bitcoin scores high on most axes but its fungibility is imperfect, because coins carry a public history that can be analyzed and sometimes treated differently. Which money looks best depends on which properties you weight most. The tool below lets you test that.
             </p>
 
-            <p>
-                <strong>Results of the fiat experiment:</strong>
-            </p>
-            <ul>
-                <li><strong>Inflation:</strong> US dollar lost 97%+ purchasing power since 1971</li>
-                <li><strong>Debt explosion:</strong> US national debt grew from $398B (1971) to $36+ trillion (2024)</li>
-                <li><strong>High time preference culture:</strong> Borrow-and-consume replaced save-and-invest</li>
-                <li><strong>Wealth inequality:</strong> Cantillon effect — those closest to money printer benefit most</li>
-                <li><strong>Boom-bust cycles:</strong> Central bank manipulation creates malinvestment</li>
-            </ul>
-
-            <div class="comparison-grid">
-                <div class="comparison-card good">
-                    <h4>✅ Gold Standard Era (pre-1971)</h4>
-                    <ul style="list-style: disc; padding-left: 1.5rem;">
-                        <li>Stable purchasing power</li>
-                        <li>Long-term infrastructure projects</li>
-                        <li>Low debt levels</li>
-                        <li>Savings culture</li>
-                        <li>Predictable economic calculation</li>
-                    </ul>
+            <div class="interactive" id="matrix-tool">
+                <h4>Weigh the properties yourself</h4>
+                <p class="hint">Uncheck the properties you do not care about for your use case (for example, a 30-year store of value versus everyday spending). The fit score is the average of the scores on the properties you keep. Scores are illustrative, on a 1 to 5 scale, with brief reasoning in the table below.</p>
+                <div class="checkbox-row" id="matrix-checks">
+                    <label><input type="checkbox" value="scarcity" checked> Scarcity</label>
+                    <label><input type="checkbox" value="durability" checked> Durability</label>
+                    <label><input type="checkbox" value="portability" checked> Portability</label>
+                    <label><input type="checkbox" value="divisibility" checked> Divisibility</label>
+                    <label><input type="checkbox" value="verifiability" checked> Verifiability</label>
+                    <label><input type="checkbox" value="fungibility" checked> Fungibility</label>
                 </div>
-                <div class="comparison-card bad">
-                    <h4>❌ Fiat Era (post-1971)</h4>
-                    <ul style="list-style: disc; padding-left: 1.5rem;">
-                        <li>Constant inflation</li>
-                        <li>Short-term thinking</li>
-                        <li>Debt-driven economy</li>
-                        <li>Consumption culture</li>
-                        <li>Distorted price signals</li>
-                    </ul>
+                <div class="data-table-wrap">
+                    <table class="compare" id="matrix-table">
+                        <thead>
+                            <tr>
+                                <th>Money</th>
+                                <th data-prop="scarcity">Scarcity</th>
+                                <th data-prop="durability">Durability</th>
+                                <th data-prop="portability">Portability</th>
+                                <th data-prop="divisibility">Divisibility</th>
+                                <th data-prop="verifiability">Verifiability</th>
+                                <th data-prop="fungibility">Fungibility</th>
+                                <th>Fit score</th>
+                            </tr>
+                        </thead>
+                        <tbody><!-- filled by JS --></tbody>
+                        <caption>Scores are a teaching illustration, not a measurement. Reasoning: gold loses on portability/verifiability; fiat loses on scarcity; Bitcoin's fungibility is marked down because on-chain history is public and can be analyzed.</caption>
+                    </table>
+                </div>
+                <p class="readout" id="matrix-readout" aria-live="polite"></p>
+            </div>
+        </section>
+
+        <!-- Mechanism: stock-to-flow + chart + misconception -->
+        <section class="content-section">
+            <h2>Measuring hardness: stock-to-flow</h2>
+            <p>
+                "Hardness" means resistance to supply inflation. One way to put a number on it is the <strong>stock-to-flow (S2F) ratio</strong>: the existing supply divided by the amount produced each year.
+            </p>
+            <div class="highlight-box">
+                <h4>Stock-to-flow</h4>
+                <p style="font-size: 1.15rem; text-align: center; margin: 0;">
+                    <strong>S2F = existing stock ÷ annual new production</strong>
+                </p>
+                <p style="margin:0.75rem 0 0; text-align:center; color:var(--text-dim); font-size:0.9rem;">
+                    A high ratio means new supply is small next to what already exists. An S2F of 60 means it would take about 60 years of current production to reproduce the entire existing stock.
+                </p>
+            </div>
+
+            <div class="barchart" aria-hidden="false">
+                <div class="bar-row"><span class="name">Fiat</span><div class="bar-track"><div class="bar-fill" style="width:4%;">~0&ndash;5</div></div></div>
+                <div class="bar-row"><span class="name">Silver</span><div class="bar-track"><div class="bar-fill" style="width:16%;">~20</div></div></div>
+                <div class="bar-row"><span class="name">Gold</span><div class="bar-track"><div class="bar-fill" style="width:50%;">~60</div></div></div>
+                <div class="bar-row"><span class="name">Bitcoin</span><div class="bar-track"><div class="bar-fill" style="width:100%;">~120</div></div></div>
+                <p style="color:var(--text-dim);font-size:0.82rem;margin-top:0.75rem;">Approximate stock-to-flow ratios. Gold from World Gold Council above-ground stock divided by annual mine production. Bitcoin computed from circulating supply near 19.9 million and post-2024-halving issuance of about 164,000 BTC per year. Figures are rounded and will drift.</p>
+            </div>
+
+            <p>
+                After Bitcoin's 2024 halving, the block subsidy fell to 3.125 BTC, so annual issuance is small relative to the roughly 19.9 million already mined. Each future halving raises the ratio further, and issuance ends near the year 2140. On this single metric, Bitcoin is the hardest of the four.
+            </p>
+
+            <h3>Where the S2F story breaks down</h3>
+            <div class="myth">
+                <span class="myth-label">Common claim</span>
+                <p>"A high stock-to-flow ratio predicts the price. Bitcoin's rising S2F means a predictable rising price."</p>
+                <span class="reality-label">What the evidence shows</span>
+                <p>S2F measures supply hardness. It says nothing about demand, and price depends on both. The popular "stock-to-flow price model" that circulated from 2019 onward predicted six-figure prices on a fixed schedule and visibly diverged from reality afterward. Treat S2F as a description of supply, not a forecast of value. Hardness is necessary for a store of value, but it is not sufficient.</p>
+            </div>
+        </section>
+
+        <!-- Evidence: predict then measure -->
+        <section class="content-section">
+            <h2>The fiat era: predict, then check the data</h2>
+            <p>
+                Since the United States ended dollar-for-gold convertibility on August 15, 1971 (the end of the Bretton Woods arrangement), the dollar has been a pure fiat currency, backed by government and central-bank policy rather than a commodity. Hard-money advocates point to what happened to its purchasing power. Before you read the number, predict it.
+            </p>
+
+            <div class="interactive" id="ppp-tool">
+                <h4>How much of a 1971 dollar survives?</h4>
+                <p class="hint">A dollar saved in 1971, under the mattress, buys how much in goods today? Drag to your guess, then reveal the figure from official inflation data.</p>
+                <label for="ppp-range">Your guess: a 1971 dollar buys <span class="readout" id="ppp-guess">50</span>&cent; of goods today</label>
+                <input type="range" id="ppp-range" min="1" max="100" value="50" step="1">
+                <button id="ppp-reveal" type="button">Reveal the data</button>
+                <div class="reveal" id="ppp-result" hidden>
+                    <p><strong>About 12 to 13 cents.</strong> Using the US Consumer Price Index, one 1971 dollar has the purchasing power of roughly eight 2026 dollars, which means the 1971 dollar has lost on the order of 87 percent of its purchasing power (BLS CPI-U, as of mid-2026). You can check the exact figure with the <a href="https://www.bls.gov/data/inflation_calculator.htm" target="_blank" rel="noopener">BLS inflation calculator</a>.</p>
+                    <div class="myth" style="margin-top:1rem;">
+                        <span class="myth-label">Where the "96 to 97 percent" figure comes from</span>
+                        <p>You will often see "the dollar lost 97 percent of its value." That figure is measured from <strong>1913</strong>, when the Federal Reserve was created, not from 1971. Measured from 1971 the loss is closer to 87 percent. Both are real, but quoting the larger number against the 1971 date is a common error. Getting the base year right is part of reading the claim honestly.</p>
+                    </div>
                 </div>
             </div>
 
+            <p>The same era shows two other figures that hard-money advocates cite, and that are straightforward to verify:</p>
+            <ul>
+                <li><strong>Money supply (M2):</strong> about <strong>$22.8 trillion</strong> as of April 2026 (Federal Reserve H.6 release), up from under $1 trillion in the early 1970s.</li>
+                <li><strong>Federal debt:</strong> about <strong>$39 trillion</strong> as of mid-2026 (US Treasury), up from roughly $0.4 trillion in 1971.</li>
+            </ul>
             <p>
-                Austrian economists warned this would happen. Mises, Hayek, and Rothbard all predicted that <strong>fiat money leads to economic instability, wealth confiscation through inflation, and the erosion of civilization's time horizon</strong>.
+                These numbers are not in dispute. What they <em>mean</em> is where the real argument starts, and that is the next section. Correlation between a policy regime and an outcome is not the same as proof that the regime caused it.
             </p>
+
+            <div class="interactive" id="gold-tool">
+                <h4>Side calculation: the portability tradeoff</h4>
+                <p class="hint">Scarcity and durability are not free. Gold's weight is the price it pays on portability. Enter an amount to see it.</p>
+                <label for="gold-usd">Amount in US dollars</label>
+                <input type="number" id="gold-usd" value="1000000" min="0" step="1000">
+                <p class="reveal" id="gold-result" style="border:none;padding:0;margin-top:1rem;" aria-live="polite"></p>
+                <p style="color:var(--text-dim);font-size:0.82rem;margin-top:0.5rem;">At a gold price of about $4,371 per troy ounce (spot, June 17, 2026). The same value in Bitcoin is carried by a 12 or 24 word seed phrase. That is the portability tradeoff in one comparison.</p>
+            </div>
         </section>
 
-        <!-- Bitcoin: The Hardest Money Ever -->
+        <!-- Steelman -->
         <section class="content-section">
-            <h2>₿ Bitcoin: The Hardest Money Ever Created</h2>
-
+            <h2>The strongest case against the hard-money view</h2>
             <p>
-                "Hardness" in monetary economics refers to <strong>resistance to supply inflation</strong>. The harder the money, the more it preserves value over time.
+                A deep dive owes you the other side at full strength, not a strawman. Most professional economists do not favor a return to a gold-style standard, and their reasons are serious. Here are the strongest, each followed by how a hard-money advocate responds. Decide for yourself where each one lands.
             </p>
 
-            <h3>Stock-to-Flow: Measuring Hardness</h3>
-            <p>
-                The stock-to-flow (S2F) ratio measures hardness mathematically:
-            </p>
-            <div class="highlight-box">
-                <h4>📐 Stock-to-Flow Formula</h4>
-                <p style="font-size: 1.2rem; text-align: center; margin: 0;">
-                    <strong>S2F = Existing Supply ÷ Annual New Production</strong>
+            <div class="steelman-box">
+                <h4>1. A little inflation may be useful, and deflation can be dangerous</h4>
+                <p>
+                    Mainstream macroeconomics generally targets low positive inflation (around 2 percent) for two reasons. Wages are "sticky" downward: in a downturn it is easier to let inflation trim real wages than to cut nominal pay, which workers resist. And a small inflation buffer keeps interest rates away from zero, leaving the central bank room to cut in a crisis. Under a fixed-supply money, a demand shock can tip into falling prices, and Irving Fisher's "debt-deflation" theory (1933) argues that falling prices raise the real burden of debt, causing defaults that push prices down further.
+                </p>
+                <p class="response">
+                    <strong>The hard-money response:</strong> mild, productivity-driven deflation (prices falling because goods get cheaper to make) is not the same as a debt-deflation spiral, and may be benign. Advocates also argue the "stickiness" and crisis-room benefits come at the cost of a permanent, hidden tax on savers, and that the flexibility is used to delay necessary adjustments rather than avoid them.
                 </p>
             </div>
 
-            <ul>
-                <li><strong>Gold:</strong> S2F ≈ 60. If all mining stopped, it would take 60 years to double supply at current rate</li>
-                <li><strong>Silver:</strong> S2F ≈ 20</li>
-                <li><strong>Fiat currencies:</strong> S2F ≈ 0–5 (central banks can print unlimited amounts)</li>
-                <li><strong>Bitcoin (2024):</strong> S2F ≈ 120 and rising exponentially toward infinity</li>
-            </ul>
-
-            <p>
-                After Bitcoin's final halving (~2140), <strong>new production drops to zero</strong>. Stock-to-flow becomes infinite. Bitcoin will be the <strong>hardest asset ever known to humanity</strong> — harder than gold, harder than anything.
-            </p>
-
-            <h3>Fixed Supply: 21 Million</h3>
-            <p>
-                Bitcoin's supply is <strong>algorithmically enforced</strong>. No human, government, or corporation can change it without convincing the entire network to adopt new rules — which has proven impossible for supply increases.
-            </p>
-            <ul>
-                <li><strong>Every ~10 minutes:</strong> New block mined, new bitcoin issued</li>
-                <li><strong>Every ~4 years:</strong> Halving event cuts issuance by 50%</li>
-                <li><strong>Year 2140:</strong> Final satoshi mined. Supply fixed forever at 21 million BTC</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>🔒 Why Can't Supply Be Changed?</h4>
+            <div class="steelman-box">
+                <h4>2. Economists overwhelmingly reject a gold standard</h4>
                 <p>
-                    Bitcoin's supply is protected by <strong>network consensus</strong>. To increase the 21M cap, you would need:
+                    This is not a close call among experts. In a January 2012 survey of a geographically and ideologically diverse panel of leading academic economists (the Chicago Booth IGM / Clark Center Economic Experts Panel), <strong>not one</strong> agreed that replacing discretionary monetary policy with a gold standard would improve price stability and employment for the average American. Among those who answered, about 91 percent disagreed or strongly disagreed.
                 </p>
-                <ul style="margin: 1rem 0;">
+                <p class="response">
+                    <strong>The hard-money response:</strong> expert consensus reflects the framework experts are trained in, and the question asked specifically about a government-run gold standard, which is not the same as a market-chosen money like Bitcoin that no government manages. Still, anyone reaching the opposite conclusion should be able to say why nearly every monetary economist disagrees.
+                </p>
+            </div>
+
+            <div class="steelman-box">
+                <h4>3. The gold standard era was not a golden age of stability</h4>
+                <p>
+                    The classical gold standard (roughly 1870s to 1914) had real virtues, but it also had frequent banking panics (1873, 1893, 1907) and sharp swings in prices, including a long deflation from 1873 to 1896. The era's stability is often overstated in hindsight.
+                </p>
+                <p class="response">
+                    <strong>The hard-money response:</strong> many of those panics trace to fractional-reserve banking and government intervention rather than to gold itself, and the long-run price level was far more stable than anything since 1971. Whether that defense holds is exactly the kind of thing this page wants you to investigate rather than take on faith.
+                </p>
+            </div>
+        </section>
+
+        <!-- Tradeoffs -->
+        <section class="content-section">
+            <h2>The tradeoff, stated plainly</h2>
+            <p>
+                Strip away the advocacy on both sides and a genuine tradeoff remains. Hard money and flexible money optimize for different things. Neither is free.
+            </p>
+            <div class="tradeoff-grid">
+                <div class="tradeoff-card">
+                    <h4>What hard money offers</h4>
+                    <ul>
+                        <li>Credible, predictable scarcity that no single party can dilute</li>
+                        <li>Protection of long-term savings from quiet debasement</li>
+                        <li>A unit of account that is not steered by policy</li>
+                    </ul>
+                </div>
+                <div class="tradeoff-card">
+                    <h4>What hard money gives up</h4>
+                    <ul>
+                        <li>No lender-of-last-resort flexibility in a liquidity crisis</li>
+                        <li>No policy lever to cushion shocks or fight unemployment</li>
+                        <li>For a young money like Bitcoin, high volatility during adoption</li>
+                    </ul>
+                </div>
+            </div>
+            <p>
+                Your view on sound money is really a view on which side of this tradeoff you would rather live with, and for which purpose. Storing value across decades and managing a national economy through a recession are not the same problem, and may not want the same money.
+            </p>
+        </section>
+
+        <!-- Where Bitcoin fits -->
+        <section class="content-section">
+            <h2>Where Bitcoin fits, and what is still open</h2>
+            <p>
+                Against the six properties and the S2F metric, Bitcoin makes a strong case as hard money: a fixed supply of 21 million, enforced not by a promise but by every node that validates the chain. Changing that cap would require near-unanimous agreement across node operators, miners, and the economy that uses it, and anyone who tried would simply create a separate fork the market is free to reject.
+            </p>
+            <div class="highlight-box">
+                <h4>The 21 million cap, precisely</h4>
+                <p style="margin-bottom:0.75rem;">The cap is enforced by network consensus, not by any authority. To raise it you would need, in practice:</p>
+                <ul style="margin:0.5rem 0;">
                     <li>Effectively every node operator to adopt the change</li>
-                    <li>An overwhelming majority of miners to adopt the change</li>
+                    <li>An overwhelming majority of miners to follow</li>
                     <li>The wider economy to accept the new coins as "bitcoin"</li>
                 </ul>
-                <p style="margin: 0;">
-                    In practice this is extraordinarily hard to coordinate: anyone attempting to inflate the supply would create a separate fork that the market is free to reject. <strong>Bitcoin's hardness rests on this consensus</strong> — the supply rules are enforced by every node that validates the chain, not by any single authority.
-                </p>
+                <p style="margin:0;">That coordination has so far proven impractical for supply increases, which is the source of Bitcoin's credibility on scarcity.</p>
             </div>
+            <p>But honesty requires naming what is <strong>not</strong> settled:</p>
+            <ul>
+                <li><strong>Volatility.</strong> Bitcoin has had multi-year drawdowns (2018, 2022). Over short horizons its purchasing power is anything but stable. The store-of-value case is a claim about the long run that is still being tested in real time.</li>
+                <li><strong>Scarcity is not the whole of "money."</strong> Some economists, including some Austrians citing Mises's own regression theorem, question whether fixed supply alone is enough to make something money rather than a scarce asset. That debate is live.</li>
+                <li><strong>The long-run security budget.</strong> As the block subsidy approaches zero, Bitcoin's security will depend on transaction fees. Whether fees alone will be sufficient is an open engineering and economic question.</li>
+            </ul>
+            <p>
+                None of these closes the case in either direction. They are the questions a serious learner should keep open while watching the evidence accumulate.
+            </p>
         </section>
 
-        <!-- Why Sound Money Matters -->
+        <!-- Misconception repair -->
         <section class="content-section">
-            <h2>🌍 Why Sound Money Matters for Civilization</h2>
-
-            <p>
-                Sound money isn't just an economic concept — it's the foundation of <strong>civilizational health</strong>.
-            </p>
-
-            <h3>Economic Calculation</h3>
-            <p>
-                Friedrich Hayek explained that <strong>prices are knowledge</strong>. When money is stable, prices convey accurate information about scarcity, demand, and value.
-            </p>
-            <p>
-                <strong>Fiat money distorts price signals:</strong>
-            </p>
-            <ul>
-                <li>Inflation makes everything appear more expensive</li>
-                <li>Interest rate manipulation creates false investment signals</li>
-                <li>Entrepreneurs can't distinguish real demand from monetary inflation</li>
-                <li>Result: Malinvestment, boom-bust cycles, wasted resources</li>
-            </ul>
-
-            <p>
-                <strong>Sound money enables accurate economic calculation:</strong>
-            </p>
-            <ul>
-                <li>Stable unit of account</li>
-                <li>Prices reflect true supply and demand</li>
-                <li>Entrepreneurs can plan long-term projects</li>
-                <li>Capital flows to genuinely productive uses</li>
-            </ul>
-
-            <h3>Time Preference and Civilization</h3>
-            <p>
-                As we explored in <a href="/deep-dives/austrian-economics/time-preference-fundamentals.html" style="color: var(--accent-gold);">Time Preference Fundamentals</a>, <strong>money shapes time preference</strong>.
-            </p>
-            <ul>
-                <li><strong>Inflating fiat money:</strong> Forces high time preference (spend now, save nothing)</li>
-                <li><strong>Sound money:</strong> Rewards low time preference (save, invest, build for the future)</li>
-            </ul>
-
-            <p>
-                Sound money builds cathedrals. Fiat money builds disposable consumer goods.
-            </p>
-
-            <h3>Separation of Money and State</h3>
-            <p>
-                Austrian economists argue that <strong>money should be separated from state control</strong> — just as religion was separated from state in the Enlightenment.
-            </p>
-            <ul>
-                <li><strong>When states control money:</strong> They print to fund wars, expand power, reward cronies</li>
-                <li><strong>When money is sound:</strong> Governments must tax honestly, borrow responsibly, or cut spending</li>
-            </ul>
-
-            <p>
-                Bitcoin achieves this separation. No government can print bitcoin. No central bank can manipulate supply. <strong>Bitcoin is money outside state control</strong> — the first in modern history.
-            </p>
+            <h2>Three claims to handle with care</h2>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Hard money means stable prices."</p>
+                <span class="reality-label">Reality</span>
+                <p>Hard money limits supply growth. It does not guarantee a stable price level, because demand and credit still move. The gold standard had notable price swings and panics. Predictable <em>supply</em> is not the same as predictable <em>prices</em>.</p>
+            </div>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Bitcoin is perfectly fungible."</p>
+                <span class="reality-label">Reality</span>
+                <p>At the protocol level every satoshi is equal, but every coin's history is public. Analytics firms and some exchanges treat coins differently based on where they have been, which is a real fungibility limit. This is why the matrix above scores Bitcoin below gold on fungibility.</p>
+            </div>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"The dollar's decline since 1971 proves Bitcoin will hold value."</p>
+                <span class="reality-label">Reality</span>
+                <p>The dollar's debasement is a fact about the dollar. Whether Bitcoin holds value over decades is a separate question that depends on future demand, and it has not yet been tested across a full lifetime of saving. One claim does not establish the other.</p>
+            </div>
         </section>
 
         <!-- Socratic Reflection -->
         <section class="socratic-section">
-            <h3>💭 Socratic Reflection Questions</h3>
+            <h3>💭 Reflection questions</h3>
+            <p style="color:var(--text-dim);margin-bottom:1.5rem;">No answer key. These are meant to be argued in both directions.</p>
 
             <div class="question">
-                <p>
-                    <span class="question-number">1.</span> If you could choose between saving in an asset that inflates 7% per year or one with a fixed supply, which would you choose? Why do most people still save in the inflating asset?
-                </p>
+                <p><span class="question-number">1.</span> In the matrix above, which properties did you keep, and which money won for you? Would a central banker managing a recession weight those properties the same way you did?</p>
             </div>
-
             <div class="question">
-                <p>
-                    <span class="question-number">2.</span> Gold was the monetary standard for thousands of years. Why did governments abandon it in 1971? Who benefits from fiat money?
-                </p>
+                <p><span class="question-number">2.</span> If hard money protects savers but removes the central bank's tools in a crisis, who gains and who loses from each choice? Are they the same people across a full economic cycle?</p>
             </div>
-
             <div class="question">
-                <p>
-                    <span class="question-number">3.</span> If prices constantly rise, how do entrepreneurs know if their business is profitable or just benefiting from monetary inflation?
-                </p>
+                <p><span class="question-number">3.</span> Nearly every monetary economist rejects a gold standard. Make the strongest version of <em>their</em> case in your own words before deciding whether you agree.</p>
             </div>
-
             <div class="question">
-                <p>
-                    <span class="question-number">4.</span> Bitcoin's supply is fixed at 21 million forever. Fiat supply can double overnight. Which system incentivizes long-term thinking? Why?
-                </p>
+                <p><span class="question-number">4.</span> The stock-to-flow price model failed as a forecast. What does that tell you about using any single metric to predict an asset's value?</p>
             </div>
-
             <div class="question">
-                <p>
-                    <span class="question-number">5.</span> "Money is just a tool — it doesn't matter if supply expands." Do you agree or disagree? What does history teach us?
-                </p>
+                <p><span class="question-number">5.</span> "Mild deflation from rising productivity is good; debt-deflation spirals are bad." Can a money have one without risking the other? How would you tell them apart in real time?</p>
             </div>
-
             <div class="question">
-                <p>
-                    <span class="question-number">6.</span> If Bitcoin becomes the global monetary standard, what happens to government spending? War funding? Social programs? Is this good or bad?
-                </p>
+                <p><span class="question-number">6.</span> What single piece of evidence over the next ten years would most change your mind about whether Bitcoin is sound money? If you cannot name one, is your view falsifiable?</p>
             </div>
         </section>
 
-        <!-- Key Takeaways -->
-        <section class="content-section">
-            <h2>🎯 Key Takeaways</h2>
-
-            <ul>
-                <li><strong>Sound money</strong> resists inflation, maintains purchasing power, and enables economic calculation</li>
-                <li><strong>Six properties of good money:</strong> scarcity, durability, portability, divisibility, verifiability, fungibility</li>
-                <li><strong>Gold standard (pre-1971)</strong> provided sound money foundation for civilization</li>
-                <li><strong>Fiat era (post-1971)</strong> has produced inflation, debt, malinvestment, and high time preference</li>
-                <li><strong>Stock-to-flow ratio</strong> measures monetary hardness. Bitcoin has the highest S2F in history</li>
-                <li><strong>Bitcoin's 21 million cap</strong> is enforced by network consensus and cannot be changed by any single party</li>
-                <li><strong>Sound money enables accurate economic calculation</strong> by providing stable price signals</li>
-                <li><strong>Sound money rewards low time preference,</strong> encouraging savings and long-term thinking</li>
-                <li><strong>Bitcoin separates money from state,</strong> preventing political manipulation of supply</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>🌟 The Big Picture</h4>
-                <p>
-                    Sound money is not a luxury — it's the <strong>foundation of prosperity, freedom, and civilization</strong>. When money is sound, individuals can plan, save, and build. When money is corrupted, society descends into chaos, debt, and short-term thinking.
-                </p>
-                <p>
-                    Bitcoin is the <strong>soundest money ever created</strong>. By returning to sound monetary principles — this time with mathematics instead of gold — Bitcoin offers humanity a path back to prosperity, stability, and a low time preference future.
-                </p>
-                <p style="margin: 0;">
-                    This is why Bitcoin matters. This is why Austrian economics matters. This is why <strong>you</strong> matter — every sat you save in Bitcoin is a vote for sound money and a better future.
-                </p>
-            </div>
+        <!-- Sources / claim ledger -->
+        <section class="sources-section">
+            <h2>Sources and claim ledger</h2>
+            <p class="asof">Data figures verified as of June 17, 2026. Empirical values drift; check the linked primary sources for current numbers.</p>
+            <ol>
+                <li>Purchasing power of the dollar since 1971 (about 87 percent loss; one 1971 dollar near eight 2026 dollars): US Bureau of Labor Statistics, <a href="https://www.bls.gov/data/inflation_calculator.htm" target="_blank" rel="noopener">CPI inflation calculator</a> (CPI-U). The frequently quoted "96 to 97 percent" figure is measured from 1913.</li>
+                <li>M2 money supply near $22.8 trillion (April 2026): Federal Reserve, <a href="https://www.federalreserve.gov/releases/h6/current/default.htm" target="_blank" rel="noopener">H.6 Money Stock Measures</a>.</li>
+                <li>Federal debt near $39 trillion (mid-2026) and roughly $0.4 trillion in 1971: US Treasury, <a href="https://fiscaldata.treasury.gov/datasets/debt-to-the-penny/" target="_blank" rel="noopener">Debt to the Penny</a>.</li>
+                <li>Gold spot price about $4,371 per troy ounce (June 17, 2026), used for the portability calculation: public spot-price data (Kitco, World Gold Council).</li>
+                <li>Stock-to-flow ratios (gold ~60, silver ~20, Bitcoin ~120): gold from World Gold Council above-ground stock and annual mine production; Bitcoin computed from circulating supply near 19.9 million and post-2024-halving issuance of about 164,000 BTC per year (Bitcoin protocol; mempool.space).</li>
+                <li>Economist consensus against a gold standard (0 of 40 agreed; about 91 percent of respondents disagreed, January 2012): Chicago Booth IGM / Kent Clark Center, <a href="https://kentclarkcenter.org/surveys/gold-standard/" target="_blank" rel="noopener">Gold Standard survey</a>.</li>
+                <li>Debt-deflation theory: Irving Fisher, "The Debt-Deflation Theory of Great Depressions," <em>Econometrica</em> (1933).</li>
+                <li>End of dollar-gold convertibility, August 15, 1971; Bretton Woods (1944): standard monetary history.</li>
+                <li>Austrian monetary theory: Carl Menger, "On the Origins of Money" (1892); Ludwig von Mises, <em>The Theory of Money and Credit</em> (1912); F. A. Hayek, "The Use of Knowledge in Society" (1945); Murray Rothbard, <em>What Has Government Done to Our Money?</em> (1963).</li>
+                <li>The "six properties" teaching synthesis: Saifedean Ammous, <em>The Bitcoin Standard</em> (2018). A partisan source, cited as the origin of the framing, not as neutral authority.</li>
+            </ol>
         </section>
 
         <!-- Navigation -->
@@ -717,7 +738,7 @@
                 ← Back to Austrian Economics
             </a>
             <a href="/interactive-demos/stock-to-flow/" class="nav-btn primary">
-                Explore Stock-to-Flow Model →
+                Explore the Stock-to-Flow demo →
             </a>
         </div>
     </main>
@@ -745,13 +766,101 @@
         });
     </script>
 
+    <!-- Deep-dive interactives (vanilla JS, no external data) -->
+    <script>
+    (function () {
+        // --- Six-property weighted matrix ---
+        var SCORES = {
+            'Gold':    { scarcity: 4, durability: 5, portability: 2, divisibility: 3, verifiability: 2, fungibility: 4 },
+            'Silver':  { scarcity: 3, durability: 4, portability: 2, divisibility: 3, verifiability: 2, fungibility: 4 },
+            'Fiat (US dollar)': { scarcity: 1, durability: 3, portability: 4, divisibility: 4, verifiability: 3, fungibility: 4 },
+            'Bitcoin': { scarcity: 5, durability: 4, portability: 5, divisibility: 5, verifiability: 5, fungibility: 3 }
+        };
+        var PROPS = ['scarcity','durability','portability','divisibility','verifiability','fungibility'];
+        var tbody = document.querySelector('#matrix-table tbody');
+        var checks = Array.prototype.slice.call(document.querySelectorAll('#matrix-checks input'));
+        var readout = document.getElementById('matrix-readout');
+
+        function selectedProps() {
+            return checks.filter(function (c) { return c.checked; }).map(function (c) { return c.value; });
+        }
+        function fit(money, sel) {
+            if (!sel.length) return 0;
+            var sum = 0;
+            sel.forEach(function (p) { sum += SCORES[money][p]; });
+            return sum / sel.length;
+        }
+        function render() {
+            var sel = selectedProps();
+            // header emphasis
+            document.querySelectorAll('#matrix-table thead th[data-prop]').forEach(function (th) {
+                th.style.opacity = (sel.indexOf(th.getAttribute('data-prop')) === -1) ? '0.35' : '1';
+            });
+            var rows = '';
+            var best = null, bestScore = -1;
+            Object.keys(SCORES).forEach(function (money) {
+                var score = fit(money, sel);
+                if (score > bestScore) { bestScore = score; best = money; }
+            });
+            Object.keys(SCORES).forEach(function (money) {
+                var cells = PROPS.map(function (p) {
+                    var dim = (sel.indexOf(p) === -1) ? ' style="opacity:0.35"' : '';
+                    return '<td' + dim + '>' + SCORES[money][p] + '</td>';
+                }).join('');
+                var score = fit(money, sel);
+                var label = sel.length ? score.toFixed(2) : 'n/a';
+                var strong = (money === best && sel.length) ? ' style="color:var(--accent-bronze);font-weight:700;"' : '';
+                rows += '<tr><td>' + money + '</td>' + cells + '<td' + strong + '>' + label + '</td></tr>';
+            });
+            tbody.innerHTML = rows; // values are from the fixed SCORES table, no user input injected
+            if (!sel.length) {
+                readout.textContent = 'Select at least one property to see which money fits best.';
+            } else {
+                readout.textContent = 'For the properties you kept, ' + best + ' scores highest (' + bestScore.toFixed(2) + ' of 5). Change the selection and the winner can change.';
+            }
+        }
+        checks.forEach(function (c) { c.addEventListener('change', render); });
+        render();
+
+        // --- Purchasing-power predictor ---
+        var pppRange = document.getElementById('ppp-range');
+        var pppGuess = document.getElementById('ppp-guess');
+        var pppReveal = document.getElementById('ppp-reveal');
+        var pppResult = document.getElementById('ppp-result');
+        pppRange.addEventListener('input', function () { pppGuess.textContent = pppRange.value; });
+        pppReveal.addEventListener('click', function () {
+            pppResult.hidden = false;
+            pppReveal.textContent = 'Data shown below';
+            pppReveal.disabled = true;
+        });
+
+        // --- Gold portability calculator ---
+        var GOLD_USD_PER_OZT = 4371.25;      // spot, 2026-06-17
+        var GRAMS_PER_OZT = 31.1034768;
+        var goldInput = document.getElementById('gold-usd');
+        var goldResult = document.getElementById('gold-result');
+        function renderGold() {
+            var usd = parseFloat(goldInput.value);
+            if (!isFinite(usd) || usd < 0) { goldResult.textContent = 'Enter a positive dollar amount.'; return; }
+            var ozt = usd / GOLD_USD_PER_OZT;
+            var grams = ozt * GRAMS_PER_OZT;
+            var kg = grams / 1000;
+            var weight = kg >= 1 ? (kg.toFixed(kg >= 100 ? 0 : 1) + ' kg') : (grams.toFixed(0) + ' g');
+            // toLocaleString on a parsed Number is safe; no markup is built from user text
+            goldResult.textContent = '$' + usd.toLocaleString('en-US') + ' of gold weighs about ' + weight + '. The same value in Bitcoin fits in a seed phrase you can memorize.';
+        }
+        goldInput.addEventListener('input', renderGold);
+        renderGold();
+    })();
+    </script>
+
 
     <!-- Navigation Context (return-to-path functionality) -->
     <script src="/js/navigation-context.js"></script>
     <!-- Reflect: Socratic questions after activity -->
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
-             data-topic="money"
+             data-topic="sound-money"
              data-path="principled"
              data-title="Reflect: What makes money &quot;sound&quot;?">
         </div>

--- a/deep-dives/austrian-economics/sound-money-theory.html
+++ b/deep-dives/austrian-economics/sound-money-theory.html
@@ -233,8 +233,8 @@
         table.compare {
             width: 100%;
             border-collapse: collapse;
-            font-size: 0.95rem;
-            min-width: 560px;
+            font-size: 0.92rem;
+            min-width: 820px;
         }
         table.compare th, table.compare td {
             padding: 0.75rem 0.85rem;
@@ -453,24 +453,26 @@ blocked_by_boundary: [no_direct_tba_funnel]
 
         <!-- Six properties + interactive matrix (comparison table) -->
         <section class="content-section">
-            <h2>The six properties, and the tradeoff between them</h2>
+            <h2>The monetary properties, and the tradeoff between them</h2>
             <p>
-                Six properties are commonly used to judge whether something works as money: <strong>scarcity</strong> (hard to produce), <strong>durability</strong> (survives time), <strong>portability</strong> (easy to move), <strong>divisibility</strong> (splits into small units), <strong>verifiability</strong> (easy to check as genuine), and <strong>fungibility</strong> (each unit interchangeable).
+                Eight properties are useful for judging whether something works as money: <strong>scarcity</strong> (hard to produce), <strong>durability</strong> (survives time), <strong>portability</strong> (easy to move), <strong>divisibility</strong> (splits into small units), <strong>verifiability</strong> (easy to check as genuine), <strong>censorship resistance</strong> (no third party can block a payment), <strong>seizure resistance</strong> (no third party can confiscate it), and <strong>settlement finality</strong> (once settled, it cannot be reversed).
             </p>
             <p>
-                Here is the key point most explanations skip: <strong>no money is best on all six at once.</strong> Gold is extraordinarily durable but hard to move and hard to verify. Fiat is easy to move but easy to create. Bitcoin scores high on most axes but its fungibility is imperfect, because coins carry a public history that can be analyzed and sometimes treated differently. Which money looks best depends on which properties you weight most. The tool below lets you test that.
+                Here is the key point most explanations skip: <strong>no money is best on all eight at once.</strong> Gold is extraordinarily durable and final to settle but hard to move and hard to verify. A bank deposit is easy to divide and move but can be frozen or reversed by the bank. Bitcoin scores high on most axes, while a young and volatile market is the price it pays elsewhere. Which money looks best depends on which properties you weight most, and that depends on what you need money to do. The tool below lets you test that across seven things people actually use as money today.
             </p>
 
             <div class="interactive" id="matrix-tool">
                 <h4>Weigh the properties yourself</h4>
-                <p class="hint">Uncheck the properties you do not care about for your use case (for example, a 30-year store of value versus everyday spending). The fit score is the average of the scores on the properties you keep. Scores are illustrative, on a 1 to 5 scale, with brief reasoning in the table below.</p>
+                <p class="hint">Uncheck the properties you do not care about for your use case (for example, a 30-year store of value versus everyday spending versus moving money past a hostile government). The fit score is the average of the scores on the properties you keep. Scores are illustrative, on a 1 to 5 scale, with reasoning in the caption.</p>
                 <div class="checkbox-row" id="matrix-checks">
                     <label><input type="checkbox" value="scarcity" checked> Scarcity</label>
                     <label><input type="checkbox" value="durability" checked> Durability</label>
                     <label><input type="checkbox" value="portability" checked> Portability</label>
                     <label><input type="checkbox" value="divisibility" checked> Divisibility</label>
                     <label><input type="checkbox" value="verifiability" checked> Verifiability</label>
-                    <label><input type="checkbox" value="fungibility" checked> Fungibility</label>
+                    <label><input type="checkbox" value="censorship" checked> Censorship res.</label>
+                    <label><input type="checkbox" value="seizure" checked> Seizure res.</label>
+                    <label><input type="checkbox" value="finality" checked> Finality</label>
                 </div>
                 <div class="data-table-wrap">
                     <table class="compare" id="matrix-table">
@@ -482,15 +484,35 @@ blocked_by_boundary: [no_direct_tba_funnel]
                                 <th data-prop="portability">Portability</th>
                                 <th data-prop="divisibility">Divisibility</th>
                                 <th data-prop="verifiability">Verifiability</th>
-                                <th data-prop="fungibility">Fungibility</th>
+                                <th data-prop="censorship">Censorship res.</th>
+                                <th data-prop="seizure">Seizure res.</th>
+                                <th data-prop="finality">Finality</th>
                                 <th>Fit score</th>
                             </tr>
                         </thead>
                         <tbody><!-- filled by JS --></tbody>
-                        <caption>Scores are a teaching illustration, not a measurement. Reasoning: gold loses on portability/verifiability; fiat loses on scarcity; Bitcoin's fungibility is marked down because on-chain history is public and can be analyzed.</caption>
+                        <caption>Scores are a teaching illustration on a 1 to 5 scale, not a measurement. Bearer assets (gold, cash, self-custodied Bitcoin) score high on seizure and censorship resistance because no issuer can freeze them; bank deposits, stablecoins, and CBDCs score low there because issuers can and do freeze or reverse. Stablecoin and CBDC scores reflect documented address freezes and programmable controls. "Other crypto" is a broad, varied category scored as a rough average.</caption>
                     </table>
                 </div>
                 <p class="readout" id="matrix-readout" aria-live="polite"></p>
+            </div>
+        </section>
+
+        <!-- "Backed by" module -->
+        <section class="content-section">
+            <h2>What does "backed by" actually mean?</h2>
+            <p>
+                People often ask what a money is "backed by," as if every money must be backed by something. That question hides a confusion worth untangling, because there are two different kinds of money and only one of them is "backed" at all.
+            </p>
+            <ul>
+                <li><strong>Claims (IOUs).</strong> A bank deposit is a promise from the bank to pay you. A stablecoin is a promise from its issuer to redeem it for a dollar. A CBDC is a direct liability of the central bank. These are "backed" by the issuer's reserves and solvency, and they are only as good as that promise. If the issuer fails, or freezes you, the backing is what you are left arguing about.</li>
+                <li><strong>Bearer assets.</strong> Physical gold, cash in your hand, and bitcoin in self-custody are not promises from anyone. They are not "backed" by an external thing; they are valued directly for their own properties. Asking what gold is "backed by" is a category error: gold is the asset, not a claim on one.</li>
+            </ul>
+            <div class="highlight-box">
+                <h4>A better question than "what backs it?"</h4>
+                <p style="margin:0;">
+                    Ask instead: "what gives it value, and who can take it away?" Fiat is valued because a government collects taxes in it and makes it legal tender. Gold and bitcoin are valued for their monetary properties and the network of people who accept them. Neither answer is "nothing"; they are different stories. The sharp difference is that a bearer asset has no issuer who can revoke it, which is exactly the tradeoff the matrix above measures as censorship resistance and seizure resistance.
+                </p>
             </div>
         </section>
 
@@ -521,6 +543,20 @@ blocked_by_boundary: [no_direct_tba_funnel]
             <p>
                 After Bitcoin's 2024 halving, the block subsidy fell to 3.125 BTC, so annual issuance is small relative to the roughly 19.9 million already mined. Each future halving raises the ratio further, and issuance ends near the year 2140. On this single metric, Bitcoin is the hardest of the four.
             </p>
+
+            <h3>Issuance falls on a fixed schedule</h3>
+            <p>
+                For Bitcoin, hardness is not really a single number; it is a schedule written into the protocol. The block subsidy (new bitcoin paid to miners per block) halves about every four years, stepping issuance down toward zero. Roughly 19.9 million of the eventual 21 million already exist, near 95 percent of the total.
+            </p>
+            <div class="barchart" aria-hidden="false">
+                <div class="bar-row"><span class="name">2009</span><div class="bar-track"><div class="bar-fill" style="width:100%;">50 BTC</div></div></div>
+                <div class="bar-row"><span class="name">2012</span><div class="bar-track"><div class="bar-fill" style="width:50%;">25</div></div></div>
+                <div class="bar-row"><span class="name">2016</span><div class="bar-track"><div class="bar-fill" style="width:25%;">12.5</div></div></div>
+                <div class="bar-row"><span class="name">2020</span><div class="bar-track"><div class="bar-fill" style="width:12.5%;">6.25</div></div></div>
+                <div class="bar-row"><span class="name">2024</span><div class="bar-track"><div class="bar-fill" style="width:6.25%;">3.125</div></div></div>
+                <div class="bar-row"><span class="name">2028</span><div class="bar-track"><div class="bar-fill" style="width:3.1%;">1.5625</div></div></div>
+                <p style="color:var(--text-dim);font-size:0.82rem;margin-top:0.75rem;">Block subsidy in BTC per block by halving epoch (start year). Issuance continues halving until it reaches zero near the year 2140. Source: Bitcoin protocol.</p>
+            </div>
 
             <h3>Where the S2F story breaks down</h3>
             <div class="myth">
@@ -608,6 +644,16 @@ blocked_by_boundary: [no_direct_tba_funnel]
                     <strong>The hard-money response:</strong> many of those panics trace to fractional-reserve banking and government intervention rather than to gold itself, and the long-run price level was far more stable than anything since 1971. Whether that defense holds is exactly the kind of thing this page wants you to investigate rather than take on faith.
                 </p>
             </div>
+
+            <div class="steelman-box">
+                <h4>4. Hard money has "no intrinsic value"</h4>
+                <p>
+                    A common objection: gold and Bitcoin produce no cash flow and have little or no essential industrial use, so their value is purely what the next person will pay. On this view a monetary asset can fall a long way, even to zero, if belief in it evaporates, unlike a bond or a productive business with underlying earnings.
+                </p>
+                <p class="response">
+                    <strong>The response:</strong> since the marginal revolution of the 1870s, economists have largely set aside "intrinsic value" as a concept. Value is subjective and set at the margin by what people want, not baked into an object. Money is valued for its monetary properties and the network that accepts it, which is how gold held value for millennia with almost no industrial use. The honest caveat cuts both ways: a network effect that confers value can also reverse, so "no cash flow" is a genuine risk to weigh, not a settled non-issue.
+                </p>
+            </div>
         </section>
 
         <!-- Tradeoffs -->
@@ -679,7 +725,7 @@ blocked_by_boundary: [no_direct_tba_funnel]
                 <span class="myth-label">Myth</span>
                 <p>"Bitcoin is perfectly fungible."</p>
                 <span class="reality-label">Reality</span>
-                <p>At the protocol level every satoshi is equal, but every coin's history is public. Analytics firms and some exchanges treat coins differently based on where they have been, which is a real fungibility limit. This is why the matrix above scores Bitcoin below gold on fungibility.</p>
+                <p>At the protocol level every satoshi is equal, but every coin's history is public. Analytics firms and some exchanges treat coins differently based on where they have been, which is a real fungibility limit that physical gold does not share.</p>
             </div>
             <div class="myth">
                 <span class="myth-label">Myth</span>
@@ -725,6 +771,7 @@ blocked_by_boundary: [no_direct_tba_funnel]
                 <li>Gold spot price about $4,371 per troy ounce (June 17, 2026), used for the portability calculation: public spot-price data (Kitco, World Gold Council).</li>
                 <li>Stock-to-flow ratios (gold ~60, silver ~20, Bitcoin ~120): gold from World Gold Council above-ground stock and annual mine production; Bitcoin computed from circulating supply near 19.9 million and post-2024-halving issuance of about 164,000 BTC per year (Bitcoin protocol; mempool.space).</li>
                 <li>Economist consensus against a gold standard (0 of 40 agreed; about 91 percent of respondents disagreed, January 2012): Chicago Booth IGM / Kent Clark Center, <a href="https://kentclarkcenter.org/surveys/gold-standard/" target="_blank" rel="noopener">Gold Standard survey</a>.</li>
+                <li>Stablecoin and CBDC freeze capability (basis for the matrix censorship and seizure scores): stablecoin issuers Tether and Circle have publicly frozen tokens at law-enforcement and sanctions request (issuer transparency statements); CBDC designs are programmable by the issuing central bank by construction (central-bank design papers, e.g. BIS).</li>
                 <li>Debt-deflation theory: Irving Fisher, "The Debt-Deflation Theory of Great Depressions," <em>Econometrica</em> (1933).</li>
                 <li>End of dollar-gold convertibility, August 15, 1971; Bretton Woods (1944): standard monetary history.</li>
                 <li>Austrian monetary theory: Carl Menger, "On the Origins of Money" (1892); Ludwig von Mises, <em>The Theory of Money and Credit</em> (1912); F. A. Hayek, "The Use of Knowledge in Society" (1945); Murray Rothbard, <em>What Has Government Done to Our Money?</em> (1963).</li>
@@ -771,12 +818,15 @@ blocked_by_boundary: [no_direct_tba_funnel]
     (function () {
         // --- Six-property weighted matrix ---
         var SCORES = {
-            'Gold':    { scarcity: 4, durability: 5, portability: 2, divisibility: 3, verifiability: 2, fungibility: 4 },
-            'Silver':  { scarcity: 3, durability: 4, portability: 2, divisibility: 3, verifiability: 2, fungibility: 4 },
-            'Fiat (US dollar)': { scarcity: 1, durability: 3, portability: 4, divisibility: 4, verifiability: 3, fungibility: 4 },
-            'Bitcoin': { scarcity: 5, durability: 4, portability: 5, divisibility: 5, verifiability: 5, fungibility: 3 }
+            'Gold':         { scarcity: 4, durability: 5, portability: 2, divisibility: 3, verifiability: 2, censorship: 4, seizure: 3, finality: 5 },
+            'Fiat cash':    { scarcity: 1, durability: 2, portability: 3, divisibility: 4, verifiability: 3, censorship: 4, seizure: 3, finality: 5 },
+            'Bank deposit': { scarcity: 1, durability: 4, portability: 4, divisibility: 5, verifiability: 4, censorship: 1, seizure: 1, finality: 2 },
+            'Bitcoin':      { scarcity: 5, durability: 4, portability: 5, divisibility: 5, verifiability: 5, censorship: 4, seizure: 4, finality: 5 },
+            'Stablecoin':   { scarcity: 1, durability: 3, portability: 5, divisibility: 5, verifiability: 3, censorship: 2, seizure: 2, finality: 3 },
+            'CBDC':         { scarcity: 1, durability: 4, portability: 5, divisibility: 5, verifiability: 4, censorship: 1, seizure: 1, finality: 2 },
+            'Other crypto': { scarcity: 2, durability: 3, portability: 5, divisibility: 5, verifiability: 4, censorship: 3, seizure: 3, finality: 3 }
         };
-        var PROPS = ['scarcity','durability','portability','divisibility','verifiability','fungibility'];
+        var PROPS = ['scarcity','durability','portability','divisibility','verifiability','censorship','seizure','finality'];
         var tbody = document.querySelector('#matrix-table tbody');
         var checks = Array.prototype.slice.call(document.querySelectorAll('#matrix-checks input'));
         var readout = document.getElementById('matrix-readout');

--- a/deep-dives/austrian-economics/sound-money-theory.html
+++ b/deep-dives/austrian-economics/sound-money-theory.html
@@ -2,7 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sound Money Theory: Does Any Money Hold Value Across Time? | Bitcoin Sovereign Academy</title>
-    <meta name="description" content="A research lab on monetary hardness: what 'sound money' means, how gold, fiat, and Bitcoin compare on six properties, what the data shows, and the strongest case against the hard-money view. Inform, not convince.">
+    <meta name="description" content="A research lab on monetary hardness: what 'sound money' means, how gold, fiat, Bitcoin, and other money compare across eight properties, what the data shows, and the strongest case against the hard-money view. Inform, not convince.">
 
     <style>
         :root {
@@ -367,7 +367,7 @@
         }
     </style>
     <link rel="stylesheet" href="/css/icons.css">
-<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/sound-money-theory"><meta property="og:title" content="Sound Money Theory: Does Any Money Hold Value Across Time?"><meta property="og:description" content="A research lab on monetary hardness. Compare gold, fiat, and Bitcoin on six properties, check the data yourself, and weigh the strongest case against the hard-money view."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/sound-money-theory"><meta property="og:type" content="article"><script type="application/ld+json">{
+<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/sound-money-theory"><meta property="og:title" content="Sound Money Theory: Does Any Money Hold Value Across Time?"><meta property="og:description" content="A research lab on monetary hardness. Compare the moneys people use across eight properties, check the data yourself, and weigh the strongest case against the hard-money view."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/sound-money-theory"><meta property="og:type" content="article"><script type="application/ld+json">{
   "@context": "https://schema.org",
   "@type": "LearningResource",
   "name": "Sound Money Theory: Does Any Money Hold Value Across Time?",
@@ -376,7 +376,7 @@
   "isAccessibleForFree": true,
   "teaches": [
     "What 'sound money' means in first-principles terms",
-    "The six monetary properties and their tradeoffs",
+    "The eight monetary properties and their tradeoffs",
     "Stock-to-flow as a hardness heuristic and its limits",
     "How to read inflation, money-supply, and debt data critically",
     "The mainstream case against a hard-money standard"
@@ -392,7 +392,7 @@
 <!-- content-graph edges (BSA ontology)
 content_type: deep_dive
 strategic_role: economics_first_principles
-teaches: [sound_money_definition, six_monetary_properties, stock_to_flow_and_limits, reading_macro_data, gold_standard_debate]
+teaches: [sound_money_definition, eight_monetary_properties, stock_to_flow_and_limits, reading_macro_data, gold_standard_debate]
 repairs: [misconception_dollar_lost_97pct_since_1971, misconception_s2f_predicts_price, misconception_hard_money_means_stable_prices, misconception_bitcoin_perfectly_fungible]
 supports_decision: [how_to_think_about_storing_value_long_term]
 bridges_to: [/deep-dives/austrian-economics/time-preference-fundamentals.html, /interactive-demos/stock-to-flow/, /deep-dives/austrian-economics/economic-calculation-problem.html]
@@ -407,7 +407,7 @@ blocked_by_boundary: [no_direct_tba_funnel]
             <div class="module-icon">💰</div>
             <h1>Sound Money Theory</h1>
             <p class="module-subtitle">
-                A research lab on monetary hardness. We will define what "sound money" means, compare gold, fiat, and Bitcoin on six properties, check the historical data ourselves, and weigh the strongest argument against the whole idea before drawing any conclusion.
+                A research lab on monetary hardness. We will define what "sound money" means, compare the moneys people actually use across eight properties, check the historical data ourselves, and weigh the strongest argument against the whole idea before drawing any conclusion.
             </p>
             <div class="breadcrumb">
                 <a href="/">Home</a> →
@@ -446,7 +446,7 @@ blocked_by_boundary: [no_direct_tba_funnel]
             <div class="highlight-box">
                 <h4>A note on sourcing</h4>
                 <p style="margin:0;">
-                    The popular "six properties" checklist below is a useful teaching synthesis, widely associated with Saifedean Ammous's <em>The Bitcoin Standard</em> (2018). It is not a verbatim list from Menger or Mises, who wrote about money's origin and value in different terms. We use it because it is a clear lens, not because it is an ancient canon.
+                    The properties checklist below is a useful teaching synthesis. The classic short list of six is widely associated with Saifedean Ammous's <em>The Bitcoin Standard</em> (2018); we extend it to eight by adding censorship resistance, seizure resistance, and settlement finality, which matter for digital money. It is not a verbatim list from Menger or Mises, who wrote about money's origin and value in different terms. We use it because it is a clear lens, not because it is an ancient canon.
                 </p>
             </div>
         </section>
@@ -689,7 +689,7 @@ blocked_by_boundary: [no_direct_tba_funnel]
         <section class="content-section">
             <h2>Where Bitcoin fits, and what is still open</h2>
             <p>
-                Against the six properties and the S2F metric, Bitcoin makes a strong case as hard money: a fixed supply of 21 million, enforced not by a promise but by every node that validates the chain. Changing that cap would require near-unanimous agreement across node operators, miners, and the economy that uses it, and anyone who tried would simply create a separate fork the market is free to reject.
+                Against the eight properties and the S2F metric, Bitcoin makes a strong case as hard money: a fixed supply of 21 million, enforced not by a promise but by every node that validates the chain. Changing that cap would require near-unanimous agreement across node operators, miners, and the economy that uses it, and anyone who tried would simply create a separate fork the market is free to reject.
             </p>
             <div class="highlight-box">
                 <h4>The 21 million cap, precisely</h4>
@@ -775,7 +775,7 @@ blocked_by_boundary: [no_direct_tba_funnel]
                 <li>Debt-deflation theory: Irving Fisher, "The Debt-Deflation Theory of Great Depressions," <em>Econometrica</em> (1933).</li>
                 <li>End of dollar-gold convertibility, August 15, 1971; Bretton Woods (1944): standard monetary history.</li>
                 <li>Austrian monetary theory: Carl Menger, "On the Origins of Money" (1892); Ludwig von Mises, <em>The Theory of Money and Credit</em> (1912); F. A. Hayek, "The Use of Knowledge in Society" (1945); Murray Rothbard, <em>What Has Government Done to Our Money?</em> (1963).</li>
-                <li>The "six properties" teaching synthesis: Saifedean Ammous, <em>The Bitcoin Standard</em> (2018). A partisan source, cited as the origin of the framing, not as neutral authority.</li>
+                <li>The monetary-properties teaching synthesis (the classic short list of six, here extended to eight): Saifedean Ammous, <em>The Bitcoin Standard</em> (2018). A partisan source, cited as the origin of the framing, not as neutral authority.</li>
             </ol>
         </section>
 

--- a/deep-dives/austrian-economics/time-preference-fundamentals.html
+++ b/deep-dives/austrian-economics/time-preference-fundamentals.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Time Preference: The Foundation of Economic Civilization | Bitcoin Sovereign Academy</title>
-    <meta name="description" content="Understand time preference - the most important economic concept for understanding why Bitcoin matters. Learn how low time preference builds civilizations and why sound money rewards delayed gratification.">
+    <title>Time Preference: What Is a Future Dollar Worth to You? | Bitcoin Sovereign Academy</title>
+    <meta name="description" content="A research lab on time preference: what it is, what it reveals about you, what the savings and inflation data show, and the strongest case against moralizing it. Inform, not convince.">
 
     <style>
         :root {
@@ -18,11 +18,7 @@
             --error-red: #dc3545;
         }
 
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -32,12 +28,8 @@
             padding: 2rem 1rem;
         }
 
-        .container {
-            max-width: 1000px;
-            margin: 0 auto;
-        }
+        .container { max-width: 1000px; margin: 0 auto; }
 
-        /* Header */
         .module-header {
             text-align: center;
             margin-bottom: 3rem;
@@ -46,770 +38,360 @@
             border-radius: 16px;
             border: 3px solid var(--accent-bronze);
         }
+        .module-icon { font-size: 5rem; margin-bottom: 1rem; animation: pulse 3s ease-in-out infinite; }
+        @keyframes pulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.05); } }
+        @media (prefers-reduced-motion: reduce) { .module-icon { animation: none; } }
 
-        .module-icon {
-            font-size: 5rem;
-            margin-bottom: 1rem;
-            animation: pulse 3s ease-in-out infinite;
-        }
+        h1 { font-size: 2.8rem; color: var(--accent-bronze); margin-bottom: 1rem; font-weight: 800; }
+        .module-subtitle { font-size: 1.25rem; color: var(--text-dim); max-width: 820px; margin: 0 auto 1.5rem; line-height: 1.8; }
+        .breadcrumb { text-align: center; margin-top: 1.5rem; font-size: 0.9rem; color: var(--text-dim); }
+        .breadcrumb a { color: var(--accent-bronze); text-decoration: none; transition: color 0.3s; }
+        .breadcrumb a:hover { color: var(--accent-gold); }
 
-        @keyframes pulse {
-            0%, 100% { transform: scale(1); }
-            50% { transform: scale(1.05); }
-        }
+        .research-question { background: #101010; border: 2px solid var(--accent-bronze); border-radius: 12px; padding: 1.75rem 2rem; margin: 0 auto 2.5rem; max-width: 1000px; }
+        .research-question .label { font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent-bronze); font-weight: 700; }
+        .research-question p { font-size: 1.25rem; line-height: 1.6; margin-top: 0.5rem; color: var(--text-light); }
 
-        h1 {
-            font-size: 2.8rem;
-            background: linear-gradient(135deg, var(--accent-bronze), var(--accent-gold));
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            margin-bottom: 1rem;
-            font-weight: 800;
-        }
+        .content-section { background: var(--secondary-dark); border-radius: 16px; padding: 3rem; margin-bottom: 2.5rem; border: 2px solid rgba(139, 111, 71, 0.3); }
+        .content-section h2 { color: var(--accent-bronze); font-size: 2rem; margin-bottom: 1.5rem; font-weight: 700; }
+        .content-section h3 { color: var(--accent-bronze-light); font-size: 1.4rem; margin: 2rem 0 1rem; font-weight: 600; }
+        .content-section p { color: var(--text-light); margin-bottom: 1.5rem; line-height: 1.9; font-size: 1.05rem; }
+        .content-section strong { color: var(--accent-gold); font-weight: 600; }
+        .content-section ul { list-style: none; padding-left: 0; margin: 1.5rem 0; }
+        .content-section li { padding: 0.85rem 0 0.85rem 1.5rem; position: relative; color: var(--text-light); line-height: 1.8; border-bottom: 1px solid rgba(139, 111, 71, 0.1); }
+        .content-section li:last-child { border-bottom: none; }
+        .content-section li:before { content: "›"; position: absolute; left: 0; color: var(--accent-bronze); font-weight: 700; }
 
-        .module-subtitle {
-            font-size: 1.3rem;
-            color: var(--text-dim);
-            max-width: 800px;
-            margin: 0 auto 1.5rem;
-            line-height: 1.8;
-        }
+        .highlight-box { background: #101010; border-left: 5px solid var(--accent-gold); padding: 2rem; margin: 2rem 0; border-radius: 8px; }
+        .highlight-box h4 { color: var(--accent-gold); margin-bottom: 1rem; font-size: 1.25rem; }
+        .highlight-box p { margin-bottom: 1rem; }
+        .highlight-box p:last-child { margin-bottom: 0; }
 
-        .breadcrumb {
-            text-align: center;
-            margin-top: 1.5rem;
-            font-size: 0.9rem;
-            color: var(--text-dim);
-        }
+        .steelman-box { background: #101010; border: 2px solid #5a78a0; border-radius: 12px; padding: 2rem; margin: 2rem 0; }
+        .steelman-box h4 { color: #9db8da; font-size: 1.2rem; margin-bottom: 1rem; }
+        .steelman-box .response { margin-top: 1.25rem; padding-top: 1.25rem; border-top: 1px solid rgba(255,255,255,0.12); }
+        .steelman-box .response strong { color: var(--accent-gold); }
 
-        .breadcrumb a {
-            color: var(--accent-bronze);
-            text-decoration: none;
-            transition: color 0.3s;
-        }
+        .myth { background: rgba(0,0,0,0.3); border-radius: 10px; padding: 1.5rem; margin: 1.25rem 0; border-left: 4px solid #2A2A2A; }
+        .myth .myth-label { color: var(--text-dim); font-weight: 700; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .myth .reality-label { color: var(--accent-bronze); font-weight: 700; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em; }
+        .myth p { margin: 0.35rem 0 1rem; }
+        .myth p:last-child { margin-bottom: 0; }
 
-        .breadcrumb a:hover {
-            color: var(--accent-gold);
-        }
+        .data-table-wrap { overflow-x: auto; margin: 1.5rem 0; }
+        table.compare { width: 100%; border-collapse: collapse; font-size: 0.95rem; min-width: 560px; }
+        table.compare th, table.compare td { padding: 0.75rem 0.85rem; text-align: left; border-bottom: 1px solid rgba(255,255,255,0.1); vertical-align: top; }
+        table.compare thead th { color: var(--accent-bronze); border-bottom: 2px solid rgba(255,122,0,0.4); font-weight: 700; }
+        table.compare td:first-child, table.compare th:first-child { font-weight: 600; }
+        table.compare caption { caption-side: bottom; color: var(--text-dim); font-size: 0.82rem; padding-top: 0.75rem; text-align: left; }
 
-        /* Content Sections */
-        .content-section {
-            background: var(--secondary-dark);
-            border-radius: 16px;
-            padding: 3rem;
-            margin-bottom: 2.5rem;
-            border: 2px solid rgba(139, 111, 71, 0.3);
-            transition: all 0.3s ease;
-        }
+        .interactive { background: #101010; border: 2px solid var(--accent-bronze); border-radius: 12px; padding: 2rem; margin: 2rem 0; }
+        .interactive h4 { color: var(--accent-bronze); font-size: 1.2rem; margin-bottom: 0.5rem; }
+        .interactive .hint { color: var(--text-dim); font-size: 0.9rem; margin-bottom: 1.25rem; }
+        .interactive label { display: block; margin: 0.75rem 0 0.35rem; font-weight: 600; }
+        .interactive input[type="range"] { width: 100%; accent-color: var(--accent-bronze); }
+        .interactive input[type="number"] { background: var(--secondary-dark); color: var(--text-light); border: 1px solid rgba(255,255,255,0.2); border-radius: 6px; padding: 0.5rem 0.65rem; font-size: 1rem; width: 100%; max-width: 200px; }
+        .interactive .field-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; }
+        .interactive .readout { font-size: 1.05rem; font-weight: 700; color: var(--accent-bronze); }
+        .reveal { margin-top: 1.25rem; padding-top: 1.25rem; border-top: 1px solid rgba(255,255,255,0.12); }
+        .reveal p { margin-bottom: 0.75rem; }
 
-        .content-section:hover {
-            border-color: var(--accent-bronze);
-            box-shadow: 0 8px 24px rgba(139, 111, 71, 0.2);
-        }
+        .barchart { margin: 1.5rem 0; }
+        .bar-row { display: grid; grid-template-columns: 130px 1fr; align-items: center; gap: 0.75rem; margin: 0.5rem 0; }
+        .bar-row .name { color: var(--text-dim); font-size: 0.9rem; }
+        .bar-row .bar-track { background: rgba(255,255,255,0.06); border-radius: 4px; overflow: hidden; }
+        .bar-row .bar-fill { background: var(--accent-bronze); height: 1.6rem; display: flex; align-items: center; justify-content: flex-end; padding-right: 0.5rem; color: #101010; font-weight: 700; font-size: 0.82rem; border-radius: 4px; min-width: 2.5rem; }
 
-        .content-section h2 {
-            color: var(--accent-bronze);
-            font-size: 2rem;
-            margin-bottom: 1.5rem;
-            font-weight: 700;
-            display: flex;
-            align-items: center;
-            gap: 0.75rem;
-        }
+        .socratic-section { background: #101010; border-radius: 16px; padding: 3rem; margin-bottom: 2.5rem; border: 2px solid #2A2A2A; }
+        .socratic-section h3 { color: #FF7A00; margin-bottom: 2rem; font-size: 1.8rem; }
+        .question { background: rgba(0, 0, 0, 0.3); padding: 1.5rem; border-radius: 8px; margin-bottom: 1.5rem; border-left: 4px solid #FF7A00; }
+        .question-number { color: #FF7A00; font-weight: 700; font-size: 1.2rem; margin-right: 0.5rem; }
 
-        .content-section h3 {
-            color: var(--accent-bronze-light);
-            font-size: 1.5rem;
-            margin: 2rem 0 1rem;
-            font-weight: 600;
-        }
+        .sources-section { background: var(--secondary-dark); border-radius: 16px; padding: 2.5rem 3rem; margin-bottom: 2.5rem; border: 2px solid rgba(139,111,71,0.3); }
+        .sources-section h2 { color: var(--accent-bronze); font-size: 1.6rem; margin-bottom: 0.5rem; }
+        .sources-section .asof { color: var(--text-dim); font-size: 0.85rem; margin-bottom: 1.5rem; }
+        .sources-section ol { padding-left: 1.25rem; }
+        .sources-section li { padding: 0.5rem 0; color: var(--text-dim); font-size: 0.92rem; line-height: 1.6; }
+        .sources-section a { color: var(--accent-bronze); text-decoration: none; }
+        .sources-section a:hover { text-decoration: underline; }
 
-        .content-section p {
-            color: var(--text-light);
-            margin-bottom: 1.5rem;
-            line-height: 1.9;
-            font-size: 1.05rem;
-        }
+        .nav-buttons { display: flex; gap: 1.5rem; justify-content: space-between; margin: 3rem 0; flex-wrap: wrap; }
+        .nav-btn { display: inline-block; padding: 1rem 2rem; background: var(--secondary-dark); color: var(--text-light); text-decoration: none; border-radius: 12px; border: 2px solid var(--accent-bronze); font-weight: 600; transition: all 0.3s ease; text-align: center; flex: 1; min-width: 200px; }
+        .nav-btn:hover { background: var(--accent-bronze); transform: translateY(-2px); }
+        .nav-btn.primary { background: var(--accent-bronze); color: white; }
+        .nav-btn.primary:hover { background: var(--accent-gold); }
 
-        .content-section strong {
-            color: var(--accent-gold);
-            font-weight: 600;
-        }
-
-        .content-section ul {
-            list-style: none;
-            padding-left: 0;
-            margin: 1.5rem 0;
-        }
-
-        .content-section li {
-            padding: 1rem 0 1rem 2.5rem;
-            position: relative;
-            color: var(--text-light);
-            line-height: 1.8;
-            border-bottom: 1px solid rgba(139, 111, 71, 0.1);
-        }
-
-        .content-section li:last-child {
-            border-bottom: none;
-        }
-
-        .content-section li:before {
-            content: "⏳";
-            position: absolute;
-            left: 0;
-            font-size: 1.2rem;
-        }
-
-        /* Highlight Boxes */
-        .highlight-box {
-            background: #101010;
-            border-left: 5px solid var(--accent-gold);
-            padding: 2rem;
-            margin: 2rem 0;
-            border-radius: 8px;
-        }
-
-        .highlight-box h4 {
-            color: var(--accent-gold);
-            margin-bottom: 1rem;
-            font-size: 1.3rem;
-        }
-
-        .highlight-box p {
-            margin-bottom: 1rem;
-        }
-
-        /* Comparison Grid */
-        .comparison-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 2rem;
-            margin: 2rem 0;
-        }
-
-        .comparison-card {
-            background: rgba(0, 0, 0, 0.3);
-            padding: 2rem;
-            border-radius: 12px;
-            transition: all 0.3s ease;
-        }
-
-        .comparison-card.high-time-pref {
-            border: 3px solid var(--error-red);
-        }
-
-        .comparison-card.low-time-pref {
-            border: 3px solid #2A2A2A;
-        }
-
-        .comparison-card:hover {
-            transform: translateY(-4px);
-            box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
-        }
-
-        .comparison-card h4 {
-            margin-bottom: 1.5rem;
-            font-size: 1.4rem;
-        }
-
-        .comparison-card.high-time-pref h4 {
-            color: var(--error-red);
-        }
-
-        .comparison-card.low-time-pref h4 {
-            color: #F7F7F2;
-        }
-
-        .comparison-card ul {
-            margin: 0;
-        }
-
-        .comparison-card li {
-            padding: 0.75rem 0 0.75rem 2rem;
-            border: none;
-            font-size: 0.95rem;
-        }
-
-        .comparison-card.high-time-pref li:before {
-            content: "❌";
-        }
-
-        .comparison-card.low-time-pref li:before {
-            content: "✅";
-        }
-
-        /* Quote Box */
-        .quote-box {
-            background: #101010;
-            border-left: 4px solid var(--accent-bronze);
-            padding: 2rem 2rem 2rem 3rem;
-            margin: 2.5rem 0;
-            border-radius: 8px;
-            position: relative;
-            font-style: italic;
-        }
-
-        .quote-box:before {
-            content: """;
-            position: absolute;
-            left: 1rem;
-            top: 1rem;
-            font-size: 4rem;
-            color: var(--accent-bronze);
-            opacity: 0.3;
-            font-family: Georgia, serif;
-        }
-
-        .quote-box p {
-            font-size: 1.15rem;
-            line-height: 1.9;
-            margin-bottom: 1rem;
-        }
-
-        .quote-box cite {
-            display: block;
-            text-align: right;
-            color: var(--accent-bronze);
-            font-style: normal;
-            font-weight: 600;
-            margin-top: 1rem;
-        }
-
-        /* Socratic Questions */
-        .socratic-section {
-            background: #101010;
-            border: 2px solid #2A2A2A;
-            border-radius: 12px;
-            padding: 2.5rem;
-            margin: 2.5rem 0;
-        }
-
-        .socratic-section h3 {
-            color: #F7F7F2;
-            margin-bottom: 1.5rem;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-
-        .question {
-            background: rgba(0, 0, 0, 0.3);
-            padding: 1.5rem;
-            margin-bottom: 1.5rem;
-            border-radius: 8px;
-            border-left: 3px solid var(--accent-gold);
-        }
-
-        .question p {
-            color: var(--text-light);
-            font-size: 1.1rem;
-            margin: 0;
-        }
-
-        .question-number {
-            color: var(--accent-gold);
-            font-weight: 700;
-            margin-right: 0.5rem;
-        }
-
-        /* Navigation */
-        .nav-buttons {
-            display: flex;
-            justify-content: space-between;
-            gap: 1rem;
-            margin-top: 3rem;
-            flex-wrap: wrap;
-        }
-
-        .nav-btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.5rem;
-            padding: 1rem 2rem;
-            background: var(--accent-bronze);
-            color: white;
-            text-decoration: none;
-            border-radius: 8px;
-            font-weight: 600;
-            font-size: 1.05rem;
-            transition: all 0.3s ease;
-            border: 2px solid var(--accent-bronze);
-        }
-
-        .nav-btn:hover {
-            background: var(--accent-gold);
-            border-color: var(--accent-gold);
-            transform: translateY(-2px);
-            box-shadow: 0 5px 15px rgba(139, 111, 71, 0.4);
-        }
-
-        .nav-btn.primary {
-            background: var(--accent-gold);
-            border-color: var(--accent-gold);
-        }
-
-        /* Responsive */
         @media (max-width: 768px) {
-            h1 {
-                font-size: 2rem;
-            }
-
-            .module-subtitle {
-                font-size: 1.1rem;
-            }
-
-            .comparison-grid {
-                grid-template-columns: 1fr;
-            }
-
-            .content-section {
-                padding: 2rem 1.5rem;
-            }
-
-            .nav-buttons {
-                flex-direction: column;
-            }
-
-            .nav-btn {
-                width: 100%;
-                justify-content: center;
-            }
-        }
-
-        /* Accessibility */
-        @media (prefers-reduced-motion: reduce) {
-            *, *::before, *::after {
-                animation-duration: 0.01ms !important;
-                animation-iteration-count: 1 !important;
-                transition-duration: 0.01ms !important;
-            }
+            .module-header { padding: 2rem 1rem; }
+            h1 { font-size: 2rem; }
+            .module-subtitle { font-size: 1.1rem; }
+            .content-section { padding: 2rem 1.5rem; }
+            .nav-buttons { flex-direction: column; }
         }
     </style>
     <link rel="stylesheet" href="/css/icons.css">
-<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/time-preference-fundamentals"><meta property="og:title" content="Time Preference Fundamentals - Bitcoin Sovereign Academy"><meta property="og:description" content="Learn about time preference fundamentals at Bitcoin Sovereign Academy. Interactive Bitcoin education with hands-on exercises and expert guidance."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/time-preference-fundamentals"><meta property="og:type" content="website"><script type="application/ld+json">{
+<link rel="canonical" href="https://bitcoinsovereign.academy/deep-dives/austrian-economics/time-preference-fundamentals"><meta property="og:title" content="Time Preference: What Is a Future Dollar Worth to You?"><meta property="og:description" content="A research lab on time preference. Reveal your own discount rate, read the savings and inflation data, and weigh the case against moralizing patience."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/deep-dives/austrian-economics/time-preference-fundamentals"><meta property="og:type" content="article"><script type="application/ld+json">{
   "@context": "https://schema.org",
-  "@type": "EducationalOrganization",
-  "name": "Bitcoin Sovereign Academy",
-  "description": "Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here.",
-  "url": "https://bitcoinsovereign.academy",
-  "logo": "https://bitcoinsovereign.academy/assets/og-image.jpg",
-  "sameAs": [
-    "https://github.com/Sovereigndwp/bitcoin-sovereign-academy"
-  ],
-  "educationalLevel": "Beginner to Advanced",
+  "@type": "LearningResource",
+  "name": "Time Preference: What Is a Future Dollar Worth to You?",
+  "learningResourceType": "Deep dive",
+  "educationalLevel": "Intermediate to Advanced",
+  "isAccessibleForFree": true,
   "teaches": [
-    "Bitcoin Fundamentals",
-    "Cryptocurrency Technology",
-    "Financial Sovereignty",
-    "Digital Asset Security"
+    "What time preference is and where the idea comes from",
+    "How inflation and expected return change the value of saving",
+    "How to read savings-rate and affordability data critically",
+    "Why high discount rates can reflect circumstance, not character",
+    "How a money's stability interacts with time horizons"
   ],
-  "audience": {
-    "@type": "Audience",
-    "audienceType": "Students interested in Bitcoin and cryptocurrency"
-  }
+  "publisher": { "@type": "EducationalOrganization", "name": "Bitcoin Sovereign Academy", "url": "https://bitcoinsovereign.academy" }
 }</script>    <link rel="stylesheet" href="/css/brand-consistency.css">
     <link rel="stylesheet" href="/css/deep-dive-brand.css">
+
+<!-- content-graph edges (BSA ontology)
+content_type: deep_dive
+strategic_role: economics_first_principles
+teaches: [time_preference_definition, discounting_and_real_return, reading_savings_and_affordability_data, money_stability_and_time_horizon]
+repairs: [misconception_low_time_preference_is_moral_virtue, misconception_saving_in_bitcoin_always_rewarded, misconception_time_preference_is_pure_psychology]
+supports_decision: [how_to_think_about_saving_vs_spending_under_inflation]
+bridges_to: [/deep-dives/austrian-economics/sound-money-theory.html, /interactive-demos/time-preference-explorer/, /deep-dives/austrian-economics/economic-calculation-problem.html]
+blocked_by_boundary: [no_direct_tba_funnel]
+-->
 </head>
 <body class="bsa-skin bsa-deepdive">
     <a href="#main-content" class="skip-link" style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;color:#fff;background:#FF7A00;padding:.35rem .75rem;border-radius:0 0 4px 0;text-decoration:none;font-weight:600;z-index:9999;" onfocus="this.style.left='0';this.style.top='0';this.style.width='auto';this.style.height='auto';" onblur="this.style.left='-9999px';this.style.width='1px';this.style.height='1px';">Skip to main content</a>
     <main id="main-content" class="container">
-        <!-- Header -->
         <header class="module-header">
             <div class="module-icon">⏳</div>
-            <h1>Time Preference: The Foundation of Civilization</h1>
+            <h1>Time Preference</h1>
             <p class="module-subtitle">
-                Discover the most important economic concept for understanding Bitcoin's revolutionary design. Learn how time preference shapes civilizations, economies, and why sound money rewards those who plan for the future.
+                A research lab on a single ratio: how much you value something now versus later. We will define it, let you measure your own, read what the savings and inflation data actually show, and weigh the strongest objection to treating patience as a virtue.
             </p>
             <div class="breadcrumb">
                 <a href="/">Home</a> →
                 <a href="/deep-dives/philosophy-economics/">Philosophy &amp; Economics</a> →
-                <strong>Time Preference Fundamentals</strong>
+                <a href="/deep-dives/austrian-economics/">Austrian Economics</a> →
+                <span>Time Preference</span>
             </div>
         </header>
 
-        <!-- Introduction -->
+        <div class="research-question">
+            <span class="label">The question we are investigating</span>
+            <p>If someone offered you $1,000 today or a larger amount in ten years, how much larger would it need to be? Your answer is a number about you, and it has consequences.</p>
+        </div>
+
         <section class="content-section">
-            <h2>💭 What is Time Preference?</h2>
-
+            <h2>Why this matters</h2>
             <p>
-                Imagine you're offered a choice: receive $1,000 today, or $1,100 in one year. Which would you choose?
+                Every financial decision hides a comparison between now and later. Spending is choosing now. Saving and investing are choosing later. Borrowing is pulling later into now and paying for the privilege. The rate at which you trade present satisfaction for future satisfaction is your <strong>time preference</strong>, and it quietly shapes how you save, borrow, and build.
             </p>
-
             <p>
-                Your answer reveals your <strong>time preference</strong> — the degree to which you value present goods over future goods. This simple concept is the invisible force that shapes entire civilizations.
-            </p>
-
-            <div class="highlight-box">
-                <h4>🎯 Core Definition</h4>
-                <p>
-                    <strong>Time preference</strong> is the ratio at which you trade present satisfaction for future satisfaction. It answers the question: <em>"How much am I willing to sacrifice now to gain more later?"</em>
-                </p>
-                <p>
-                    <strong>Low time preference:</strong> Willing to delay gratification for greater future rewards<br>
-                    <strong>High time preference:</strong> Prefer immediate rewards over uncertain future gains
-                </p>
-            </div>
-
-            <p>
-                This isn't just about money. Time preference determines whether you:
-            </p>
-
-            <ul>
-                <li>Save or spend your paycheck</li>
-                <li>Plant trees whose shade you'll never sit under</li>
-                <li>Build infrastructure for future generations</li>
-                <li>Study for years to master a skill</li>
-                <li>Invest in Bitcoin despite short-term volatility</li>
-            </ul>
-
-            <p>
-                Time preference is the lens through which all economic decisions are made. And as you'll discover, <strong>the type of money a society uses directly shapes its time preference</strong>.
+                It also scales up. Families, companies, and governments all reveal a time preference in how they spend and invest. And the money a society uses may tilt those choices. This deep dive treats that last claim as a question to test, not a conclusion to assume, because the popular version of this idea carries a moral charge that the economics does not support.
             </p>
         </section>
 
-        <!-- Austrian Economics Context -->
         <section class="content-section">
-            <h2>🏛️ The Austrian School Foundation</h2>
-
+            <h2>What time preference is, and where it comes from</h2>
             <p>
-                Time preference isn't a modern concept. It was developed by the <strong>Austrian School of Economics</strong>, a tradition that includes some of history's greatest economic minds.
+                The core observation is simple: people generally prefer a good now over the same good later. To give up the present version, they require more of the future version. That gap is the origin of interest in the Austrian account: interest is not mainly a creation of banks, it is the price of time, reflecting how strongly people prefer the present.
             </p>
-
-            <h3>Key Austrian Economists</h3>
-
-            <div class="quote-box">
-                <p>
-                    "The essence of the capitalist system is a rational saving policy."
-                </p>
-                <cite>— Ludwig von Mises (1881-1973)</cite>
-            </div>
-
             <p>
-                <strong>Ludwig von Mises</strong> established time preference as central to economic theory. He demonstrated that <strong>interest rates</strong> aren't arbitrary numbers set by central banks — they emerge naturally from humanity's universal time preference.
-            </p>
-
-            <p>
-                Think about it: If you lend someone money, you're sacrificing your ability to use it now. The interest rate compensates you for this sacrifice. It's not "greedy" — it's a mathematical reflection of time preference.
-            </p>
-
-            <div class="quote-box">
-                <p>
-                    "The curious task of economics is to demonstrate to men how little they really know about what they imagine they can design."
-                </p>
-                <cite>— Friedrich A. Hayek (1899-1992)</cite>
-            </div>
-
-            <p>
-                <strong>F.A. Hayek</strong> showed how centralized planning (like central banks setting interest rates) distorts natural time preferences. When governments artificially lower interest rates, they send false signals that encourage reckless borrowing and malinvestment.
-            </p>
-
-            <div class="quote-box">
-                <p>
-                    "It is impossible to grasp the meaning of the idea of sound money if one does not realize that it was devised as an instrument for the protection of civil liberties against despotic inroads on the part of governments."
-                </p>
-                <cite>— Ludwig von Mises</cite>
-            </div>
-
-            <p>
-                <strong>Sound money</strong> (money that can't be inflated at will) protects low time preference behavior. When money maintains its value, saving becomes rational. When money inflates, spending becomes urgent.
-            </p>
-
-            <p>
-                This is why Bitcoin's fixed 21 million supply is so revolutionary — it's <strong>Austrian economics in code</strong>.
+                In the Austrian tradition the idea runs from Eugen von Böhm-Bawerk, <em>Capital and Interest</em> (1884), through Ludwig von Mises, <em>Human Action</em> (1949). It is worth being honest about lineage: time preference is not uniquely Austrian. John Rae wrote about it in 1834, and the economist Irving Fisher built a full mainstream theory of interest around it in <em>The Theory of Interest</em> (1930). Different schools weigh it differently, but the basic insight is shared, not fringe.
             </p>
         </section>
 
-        <!-- High vs Low Time Preference -->
         <section class="content-section">
-            <h2>⚖️ High vs Low Time Preference: Two Worlds</h2>
-
+            <h2>Measure your own time preference</h2>
             <p>
-                Time preference exists on a spectrum. Societies with different time preferences develop radically different characteristics.
+                Before reading any more theory, find your own number. The tool below shows what a future sum is worth to you today, given the rate at which you discount the future.
             </p>
 
-            <div class="comparison-grid">
-                <div class="comparison-card high-time-pref">
-                    <h4>🔴 High Time Preference Society</h4>
-                    <ul>
-                        <li>Consumes more than it produces</li>
-                        <li>Accumulates debt for immediate pleasure</li>
-                        <li>Short-term thinking dominates</li>
-                        <li>Infrastructure crumbles from neglect</li>
-                        <li>Education focuses on quick credentials</li>
-                        <li>Savings rates decline year after year</li>
-                        <li>Political promises focus on immediate handouts</li>
-                        <li>Innovation stagnates (why invest in R&amp;D?)</li>
-                    </ul>
+            <div class="interactive" id="discount-tool">
+                <h4>What is a future $1,000 worth to you now?</h4>
+                <p class="hint">Drag the discount rate to the point where you would feel genuinely indifferent between the amount shown today and $1,000 in ten years. There is no right answer; the point is to see that you have one.</p>
+                <label for="disc-range">Your annual discount rate: <span class="readout" id="disc-rate">8</span>%</label>
+                <input type="range" id="disc-range" min="0" max="25" value="8" step="1">
+                <p style="margin-top:1rem;">$1,000 in ten years is worth about <span class="readout" id="disc-pv">$463</span> to you today.</p>
+                <p class="hint" id="disc-note" style="margin-top:0.5rem;"></p>
+            </div>
+
+            <div class="interactive" id="real-tool">
+                <h4>Does saving keep up? Real return calculator</h4>
+                <p class="hint">Time preference meets the real world through inflation. Enter what you save, the return you expect, the inflation you expect, and the horizon. The tool shows the nominal total and what it actually buys in today's money.</p>
+                <div class="field-grid">
+                    <div><label for="rt-amount">Amount saved ($)</label><input type="number" id="rt-amount" value="10000" min="0" step="100"></div>
+                    <div><label for="rt-return">Nominal return (%/yr)</label><input type="number" id="rt-return" value="4" step="0.1"></div>
+                    <div><label for="rt-infl">Inflation (%/yr)</label><input type="number" id="rt-infl" value="3" step="0.1"></div>
+                    <div><label for="rt-years">Years</label><input type="number" id="rt-years" value="20" min="1" step="1"></div>
                 </div>
-
-                <div class="comparison-card low-time-pref">
-                    <h4>🟢 Low Time Preference Society</h4>
-                    <ul>
-                        <li>Produces more than it consumes</li>
-                        <li>Saves and invests for the future</li>
-                        <li>Long-term planning is the norm</li>
-                        <li>Infrastructure built to last centuries</li>
-                        <li>Education emphasizes deep mastery</li>
-                        <li>Capital accumulation compounds over time</li>
-                        <li>Political focus on sustainable policies</li>
-                        <li>Innovation thrives (investment in moonshots)</li>
-                    </ul>
-                </div>
+                <div class="reveal" id="rt-result" aria-live="polite" style="border-top:1px solid rgba(255,255,255,0.12);"></div>
             </div>
-
             <p>
-                Which society would you rather live in? The answer seems obvious. Yet modern fiat monetary systems systematically push societies toward high time preference behavior.
+                The second tool makes a quiet point visible: a positive nominal return can still lose purchasing power if inflation runs higher. The "real" return, not the headline number, is what your future self actually spends.
             </p>
         </section>
 
-        <!-- Money and Time Preference -->
         <section class="content-section">
-            <h2>💰 How Money Shapes Time Preference</h2>
-
+            <h2>High and low time preference, across scales</h2>
             <p>
-                Here's the crucial insight: <strong>The type of money a society uses determines its time preference</strong>.
+                Economists describe a <strong>higher</strong> time preference as weighting the present heavily, and a <strong>lower</strong> time preference as being more willing to wait. The same spectrum shows up from individuals to governments. The table is descriptive, not a scorecard: which end is appropriate depends on circumstances.
+            </p>
+            <div class="data-table-wrap">
+                <table class="compare">
+                    <thead><tr><th>Scale</th><th>Higher time preference looks like</th><th>Lower time preference looks like</th></tr></thead>
+                    <tbody>
+                        <tr><td>Individual</td><td>Spend now, little saved, short planning horizon</td><td>Save and invest, plan years ahead</td></tr>
+                        <tr><td>Family</td><td>Consume current income, little set aside for children</td><td>Build savings, fund education, plan inheritance</td></tr>
+                        <tr><td>Company</td><td>Maximize this quarter, underinvest in capital</td><td>Invest in long-lived capital and research</td></tr>
+                        <tr><td>Government</td><td>Deficit-fund current spending, defer hard choices</td><td>Balance budgets, invest in durable institutions</td></tr>
+                    </tbody>
+                    <caption>A spectrum, not a verdict. The next section explains why a high reading often reflects circumstances rather than character.</caption>
+                </table>
+            </div>
+        </section>
+
+        <section class="content-section">
+            <h2>What the data shows (predict, then check)</h2>
+            <p>
+                Hard-money advocates argue that as the dollar became less stable after 1971, saving fell and long-horizon affordability worsened. Those are checkable claims. Predict each before you reveal it, and keep in mind that a correlation across an era is not proof of a single cause.
             </p>
 
-            <h3>Inflationary Fiat Money → High Time Preference</h3>
+            <h3>1. The US personal saving rate fell</h3>
+            <div class="barchart">
+                <div class="bar-row"><span class="name">1970s average</span><div class="bar-track"><div class="bar-fill" style="width:100%;">~12%</div></div></div>
+                <div class="bar-row"><span class="name">Jan 2026</span><div class="bar-track"><div class="bar-fill" style="width:37%;">~4.5%</div></div></div>
+                <p style="color:var(--text-dim);font-size:0.82rem;margin-top:0.75rem;">Personal saving as a share of disposable income. 1970s decade average near 12 percent; about 4.5 percent in January 2026. Source: US Bureau of Economic Analysis / FRED series PSAVERT.</p>
+            </div>
 
-            <p>
-                When money steadily loses value to inflation year after year, rational behavior changes:
-            </p>
+            <h3>2. A 1971 dollar buys far less</h3>
+            <p>One dollar saved in 1971 has the purchasing power of roughly eight dollars today, an erosion of about 87 percent (BLS CPI-U, as of mid-2026). Saving in a currency that loses value steadily is a different proposition than saving in one that holds it.</p>
 
-            <ul>
-                <li><strong>Saving becomes punishment:</strong> Your $10,000 loses $700-$1,500 in purchasing power annually</li>
-                <li><strong>Spending becomes urgent:</strong> "Buy now before prices rise!"</li>
-                <li><strong>Debt becomes attractive:</strong> Borrow today, repay with cheaper dollars tomorrow</li>
-                <li><strong>Investment horizons shorten:</strong> Why plan 30 years ahead when money won't hold value?</li>
-            </ul>
+            <h3>3. Homes cost more years of income</h3>
+            <div class="barchart">
+                <div class="bar-row"><span class="name">1985</span><div class="bar-track"><div class="bar-fill" style="width:70%;">3.5x</div></div></div>
+                <div class="bar-row"><span class="name">2025</span><div class="bar-track"><div class="bar-fill" style="width:100%;">~5.0x</div></div></div>
+                <p style="color:var(--text-dim);font-size:0.82rem;margin-top:0.75rem;">US median home price divided by median household income. Roughly 3.5 in 1985 and about 5.0 in 2025. Source: Harvard Joint Center for Housing Studies. (A clean national series starts in the mid-1980s; the long-run direction is up.)</p>
+            </div>
 
             <div class="highlight-box">
-                <h4>📉 The Inflation Trap</h4>
-                <p>
-                    Inflation isn't just "rising prices." It's a <strong>forced increase in time preference</strong> across an entire society. It punishes savers, rewards debtors, and creates a "live for today" mentality because tomorrow's money will be worth less.
-                </p>
-            </div>
-
-            <h3>Sound Money (Bitcoin) → Low Time Preference</h3>
-
-            <p>
-                When money is <strong>scarce and predictable</strong> (like Bitcoin's fixed 21M supply), incentives reverse:
-            </p>
-
-            <ul>
-                <li><strong>Saving becomes rewarding:</strong> Your bitcoin maintains (or increases) purchasing power</li>
-                <li><strong>Spending becomes deliberate:</strong> "Is this purchase worth more than holding?"</li>
-                <li><strong>Debt becomes expensive:</strong> You repay with more valuable money</li>
-                <li><strong>Investment horizons extend:</strong> Multi-decade planning makes sense</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>📈 The Bitcoin Standard</h4>
-                <p>
-                    Bitcoin doesn't just preserve wealth — it <strong>rewards low time preference behavior</strong>. Every 4 years, the halving makes bitcoin more scarce. Every year without inflation makes holding more attractive than spending. This creates a civilization-building incentive structure.
-                </p>
+                <h4>Read this carefully</h4>
+                <p style="margin:0;">These three facts are real and sourced. What they do <strong>not</strong> do is prove that unstable money alone caused them. Falling saving rates also track the spread of consumer credit, the rise of pension and retirement plans, and a "wealth effect" from rising asset prices. Housing costs reflect zoning, interest rates, and supply as much as monetary policy. The honest claim is that money is one force among several, and the burden is on any single-cause story to earn its certainty.</p>
             </div>
         </section>
 
-        <!-- Historical Examples -->
         <section class="content-section">
-            <h2>🏛️ Historical Evidence: Time Preference in Action</h2>
-
-            <h3>Medieval Cathedrals (Low Time Preference)</h3>
-
+            <h2>The strongest objection: is patience really a virtue?</h2>
             <p>
-                European cathedrals took 100-300 years to build. Architects began construction knowing they'd never see completion. Craftsmen carved stone details that would only be visible to God. Why?
+                The popular version of this topic slides quickly from economics into morality: low time preference as the mark of a better person, high time preference as a character flaw. That move is where the idea most needs a steelman, because the evidence cuts against it.
             </p>
 
-            <p>
-                <strong>Sound money.</strong> Gold and silver held value across generations. Investing in multi-century projects made economic sense because wealth transferred reliably to the future.
-            </p>
-
-            <h3>Weimar Germany 1921-1923 (High Time Preference)</h3>
-
-            <p>
-                When German marks lost 99.9% of their value, society transformed overnight:
-            </p>
-
-            <ul>
-                <li>People spent money the day they received it</li>
-                <li>Workers demanded payment twice daily</li>
-                <li>Wheelbarrows of cash bought a loaf of bread</li>
-                <li>Long-term contracts became impossible</li>
-                <li>Savings vanished; civilization regressed</li>
-            </ul>
-
-            <p>
-                Hyperinflation didn't just destroy wealth — it <strong>destroyed the ability to think beyond today</strong>. That's the ultimate high time preference outcome.
-            </p>
-
-            <h3>Post-War Japan 1950s-1980s (Low Time Preference)</h3>
-
-            <p>
-                After WWII devastation, Japan rebuilt with <strong>generational thinking</strong>:
-            </p>
-
-            <ul>
-                <li>Companies planned in 50-100 year timeframes</li>
-                <li>National savings rate exceeded 15%</li>
-                <li>Infrastructure built for centuries</li>
-                <li>Education emphasized mastery over speed</li>
-            </ul>
-
-            <p>
-                Result? Economic miracle. Why? Sound monetary policy (Yen was stable relative to gold) enabled low time preference decision-making.
-            </p>
-
-            <h3>Modern America (Shifting Time Preference)</h3>
-
-            <p>
-                Compare these statistics:
-            </p>
-
-            <ul>
-                <li><strong>1960s:</strong> a high personal savings rate and homes priced at a low multiple of median income</li>
-                <li><strong>2020s:</strong> a much lower savings rate and homes at a far higher multiple of median income <span style="color:#B3B3B3;font-size:0.85em;">(directional; US, BLS / Federal Reserve)</span></li>
-            </ul>
-
-            <p>
-                What changed? The dollar. Once backed by gold (until 1971), now infinitely printable. As money degraded, time preference increased. Saving became irrational. Debt became normal.
-            </p>
-        </section>
-
-        <!-- Bitcoin Connection -->
-        <section class="content-section">
-            <h2>₿ Why Bitcoin is a Time Preference Revolution</h2>
-
-            <p>
-                Bitcoin isn't just "digital gold." It's <strong>the hardest money ever created</strong> — and therefore the most powerful tool for lowering society's time preference.
-            </p>
-
-            <h3>Bitcoin's Time Preference Features</h3>
-
-            <ul>
-                <li><strong>Absolute scarcity:</strong> 21 million cap (no one can print more)</li>
-                <li><strong>Programmatic issuance:</strong> Halvings every 4 years (decreasing inflation to zero)</li>
-                <li><strong>Global accessibility:</strong> Anyone can save in the hardest money ever made</li>
-                <li><strong>Seizure resistance:</strong> Self-custodied savings are much harder to confiscate or inflate away</li>
-                <li><strong>Multigenerational transfer:</strong> Bitcoin is your great-great-grandchildren's inheritance</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>🔑 The HODL Mentality</h4>
+            <div class="steelman-box">
+                <h4>1. High discount rates often reflect circumstance, not character</h4>
                 <p>
-                    "HODL" (Hold On for Dear Life) isn't just a meme — it's <strong>low time preference in action</strong>. Bitcoiners who hold through volatility are practicing delayed gratification in its purest form. They're choosing future prosperity over present comfort.
+                    Research on scarcity (Sendhil Mullainathan and Eldar Shafir, <em>Scarcity</em>, 2013) finds that conditions of poverty and uncertainty rationally raise discount rates: when the future is unreliable and present needs are urgent, valuing the present more is sensible, not weak. Telling someone in precarity that they simply need lower time preference mistakes an effect of their situation for a flaw in their character.
                 </p>
-                <p>
-                    This is exactly what Austrian economists predicted: give people sound money, and they'll naturally develop low time preference behavior.
+                <p class="response">
+                    <strong>Where this lands:</strong> it does not refute time preference as a concept, but it should end the moralizing. A high reading is information about circumstances at least as much as about virtue.
                 </p>
             </div>
 
-            <h3>The Civilizational Impact</h3>
+            <div class="steelman-box">
+                <h4>2. People discount the future in messy, inconsistent ways</h4>
+                <p>
+                    Behavioral economics (David Laibson and others) documents <em>hyperbolic discounting</em>: people are not consistent across time, and reverse their own preferences as a reward gets near. This means "time preference" is not a single fixed dial each person carries, but a context-dependent and sometimes irrational tendency. A clean story of patient versus impatient people oversimplifies how discounting actually works.
+                </p>
+                <p class="response">
+                    <strong>Where this lands:</strong> the Austrian point that action implies some weighting of present against future survives, but the precise, stable "rate" the popular story assumes does not.
+                </p>
+            </div>
 
             <p>
-                If Bitcoin becomes the global standard, what happens to time preference?
-            </p>
-
-            <ul>
-                <li><strong>Savings culture returns:</strong> People plan decades ahead</li>
-                <li><strong>Debt culture fades:</strong> Borrowing with appreciating money is expensive</li>
-                <li><strong>Infrastructure improves:</strong> Multi-generational projects become economically viable</li>
-                <li><strong>Education deepens:</strong> Mastery trumps credentials when thinking long-term</li>
-                <li><strong>Innovation accelerates:</strong> Capital accumulation funds moonshot R&amp;D</li>
-                <li><strong>Environmental care increases:</strong> Future generations' needs matter when you're saving for them</li>
-            </ul>
-
-            <p>
-                Sound money doesn't just fix money — it <strong>fixes civilization's time horizon</strong>.
+                Hold both at once: the economics of time preference is sound, and the moralizing built on top of it is not. You can take saving seriously without treating impatience as a sin or poverty as a personal failing.
             </p>
         </section>
 
-        <!-- Socratic Reflection -->
+        <section class="content-section">
+            <h2>When money breaks: two extreme cases</h2>
+            <p>
+                Extreme monetary instability does seem to shorten time horizons, and history offers stark illustrations. Treat these as vivid examples of a mechanism, not as proof of a universal law, and beware retelling them with exaggeration.
+            </p>
+            <ul>
+                <li><strong>Weimar Germany (1921 to 1923).</strong> During hyperinflation the mark lost almost all of its value, and accounts from the period describe people spending wages within hours of receiving them, because holding cash was a guaranteed loss. A careful source is Adam Fergusson, <em>When Money Dies</em> (1975). The mechanism is clear: when money cannot store value even overnight, saving in it becomes irrational.</li>
+                <li><strong>Argentina and Venezuela (recent decades).</strong> Persistent high inflation pushed households toward spending quickly, holding foreign currency, or buying durable goods as stores of value. These are real patterns, well documented, but they are also complex episodes shaped by policy, sanctions, and politics. Cite them as evidence that unstable money raises time preference, not as simple morality tales.</li>
+            </ul>
+        </section>
+
+        <section class="content-section">
+            <h2>Where Bitcoin fits, and where it does not</h2>
+            <p>
+                The Bitcoin connection is narrow and worth stating precisely. Bitcoin's issuance is fixed and predictable, which means that, as a monetary rule, it cannot be debased to fund spending. For someone whose worry is the slow erosion the dollar chart above shows, a money with a credibly fixed supply changes the long-horizon calculation.
+            </p>
+            <div class="highlight-box">
+                <h4>Separate two different things</h4>
+                <p style="margin:0;">Bitcoin's <strong>monetary rule</strong> (predictable, fixed issuance) is not the same as its <strong>price behavior</strong> (highly volatile, with multi-year drawdowns in 2018 and 2022). The first supports long-horizon saving in principle; the second can punish it badly over any given decade so far. Anyone claiming Bitcoin straightforwardly rewards patience is conflating the rule with the price. The rule is stable; the price is not, at least not yet.</p>
+            </div>
+            <p>
+                So the careful statement is this: sound money can lower the cost of waiting by removing one reason the future is uncertain, namely debasement. It does not remove the others, and it adds a new one in Bitcoin's case, namely price volatility. Whether that trade is worth it depends on your horizon and your tolerance for risk, which is exactly the kind of judgment this page wants to inform rather than make for you.
+            </p>
+        </section>
+
+        <section class="content-section">
+            <h2>Claims to handle with care</h2>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Low time preference makes you a better person; high time preference is a character flaw."</p>
+                <span class="reality-label">Reality</span>
+                <p>Discount rates respond to circumstances. Scarcity and uncertainty rationally raise them. Time preference is an economic concept, not a moral ranking, and using it to judge people, especially the poor, goes well beyond what the economics supports.</p>
+            </div>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Saving in Bitcoin always rewards patience."</p>
+                <span class="reality-label">Reality</span>
+                <p>Bitcoin's fixed issuance is a stable rule, but its price has fallen for years at a time. Over some horizons patient holders did well; over others they sat through deep losses. The monetary rule is not a promise about the price.</p>
+            </div>
+            <div class="myth">
+                <span class="myth-label">Myth</span>
+                <p>"Time preference is just individual psychology and has nothing to do with money."</p>
+                <span class="reality-label">Reality</span>
+                <p>Psychology matters, but the reliability of the money also shapes the choice. When money holds value, waiting costs less; when it decays, waiting is penalized. Both the person and the money are in the equation.</p>
+            </div>
+        </section>
+
         <section class="socratic-section">
-            <h3>💭 Socratic Reflection Questions</h3>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">1.</span> If you knew your savings would double in purchasing power over 10 years, how would your spending habits change today?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">2.</span> Look around your city. What infrastructure was built 100+ years ago and still stands? What was built in the last 20 years that's already crumbling? What changed?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">3.</span> Why do you think medieval craftsmen spent decades building cathedrals they'd never see completed, while modern construction focuses on "cheap and fast"?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">4.</span> If inflation is 7% yearly, and your investment returns 8% yearly, are you actually getting richer? What if your investment was Bitcoin, returning 100% over 4 years?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">5.</span> Imagine a society where everyone has low time preference. What does education look like? What do cities look like? What do family structures look like?
-                </p>
-            </div>
-
-            <div class="question">
-                <p>
-                    <span class="question-number">6.</span> "Time preference is just individual psychology — it has nothing to do with money." Do you agree or disagree? Why?
-                </p>
-            </div>
+            <h3>💭 Reflection questions</h3>
+            <p style="color:var(--text-dim);margin-bottom:1.5rem;">No answer key. Argue them in both directions.</p>
+            <div class="question"><p><span class="question-number">1.</span> What discount rate did you land on in the tool above? Would it be different if your income were less certain? What does that tell you about reading other people's choices?</p></div>
+            <div class="question"><p><span class="question-number">2.</span> The US saving rate fell as consumer credit, pensions, and asset wealth all grew. How would you design a test to separate the effect of the money from these other causes?</p></div>
+            <div class="question"><p><span class="question-number">3.</span> Make the strongest case that calling someone "high time preference" is a way of blaming them for their circumstances. Then make the strongest case against your own argument.</p></div>
+            <div class="question"><p><span class="question-number">4.</span> If a money's rule is stable but its price is volatile, does it lower the cost of waiting or raise it? Could the answer depend entirely on your time horizon?</p></div>
+            <div class="question"><p><span class="question-number">5.</span> Weimar and Venezuela are dramatic. What is the risk of building a general theory of civilization out of extreme cases?</p></div>
+            <div class="question"><p><span class="question-number">6.</span> What evidence over the next decade would convince you that sound money does, or does not, change a society's time horizon?</p></div>
         </section>
 
-        <!-- Key Takeaways -->
-        <section class="content-section">
-            <h2>🎯 Key Takeaways</h2>
-
-            <ul>
-                <li><strong>Time preference</strong> is the ratio at which you value present goods over future goods</li>
-                <li><strong>Low time preference</strong> (delayed gratification) builds civilizations, infrastructure, and generational wealth</li>
-                <li><strong>High time preference</strong> (immediate gratification) leads to debt, decay, and short-term thinking</li>
-                <li><strong>Money shapes time preference</strong> — inflationary money forces high time preference, sound money enables low time preference</li>
-                <li><strong>Austrian economists</strong> (Mises, Hayek, Rothbard) identified time preference as central to economic understanding</li>
-                <li><strong>Bitcoin is the hardest money ever created</strong>, making it the most powerful tool for lowering society's time preference</li>
-                <li><strong>HODL culture</strong> is low time preference in action — choosing future prosperity over present comfort</li>
-                <li><strong>Historical evidence</strong> shows that sound money societies (gold standard) built lasting infrastructure; fiat societies (post-1971) prioritize immediate consumption</li>
-            </ul>
-
-            <div class="highlight-box">
-                <h4>🌟 The Big Picture</h4>
-                <p>
-                    Understanding time preference transforms how you see Bitcoin. It's not just a technology or an investment — it's <strong>a civilizational reset button</strong>. By fixing the money, Bitcoin fixes the incentives. By fixing the incentives, it fixes time preference. By fixing time preference, it fixes society.
-                </p>
-                <p>
-                    This is why Bitcoin matters. This is why Austrian economics matters. This is why <strong>you</strong> matter — every time you choose to save in Bitcoin instead of spending in fiat, you're lowering your time preference and contributing to a better future.
-                </p>
-            </div>
+        <section class="sources-section">
+            <h2>Sources and claim ledger</h2>
+            <p class="asof">Data figures verified as of June 17, 2026. Empirical values drift; check the linked primary sources for current numbers.</p>
+            <ol>
+                <li>Personal saving rate (about 12 percent average in the 1970s, about 4.5 percent in January 2026): US Bureau of Economic Analysis; FRED, <a href="https://fred.stlouisfed.org/series/PSAVERT" target="_blank" rel="noopener">Personal Saving Rate (PSAVERT)</a>.</li>
+                <li>Purchasing power of the dollar (about 87 percent loss since 1971): US Bureau of Labor Statistics, <a href="https://www.bls.gov/data/inflation_calculator.htm" target="_blank" rel="noopener">CPI inflation calculator</a>.</li>
+                <li>Home price to income ratio (about 3.5 in 1985, about 5.0 in 2025): Harvard <a href="https://www.jchs.harvard.edu/" target="_blank" rel="noopener">Joint Center for Housing Studies</a>.</li>
+                <li>Time preference theory: John Rae (1834); Eugen von Böhm-Bawerk, <em>Capital and Interest</em> (1884); Ludwig von Mises, <em>Human Action</em> (1949); Irving Fisher, <em>The Theory of Interest</em> (1930).</li>
+                <li>Scarcity raises discount rates: Sendhil Mullainathan and Eldar Shafir, <em>Scarcity: Why Having Too Little Means So Much</em> (2013).</li>
+                <li>Hyperbolic discounting: David Laibson, "Golden Eggs and Hyperbolic Discounting," <em>Quarterly Journal of Economics</em> (1997).</li>
+                <li>Weimar hyperinflation: Adam Fergusson, <em>When Money Dies</em> (1975).</li>
+                <li>Bitcoin issuance schedule and the 2018 and 2022 drawdowns: Bitcoin protocol; public price history.</li>
+            </ol>
         </section>
 
-        <!-- Navigation -->
         <div class="nav-buttons">
-            <a href="/deep-dives/philosophy-economics/" class="nav-btn">
-                ← Back to Philosophy &amp; Economics
-            </a>
-            <a href="/interactive-demos/time-preference-explorer/" class="nav-btn primary">
-                Try the Time Preference Explorer →
-            </a>
+            <a href="/deep-dives/austrian-economics/" class="nav-btn">← Back to Austrian Economics</a>
+            <a href="/interactive-demos/time-preference-explorer/" class="nav-btn primary">Try the Time Preference Explorer →</a>
         </div>
     </main>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>
-    <!-- Navigation Context (return-to-path functionality) -->
-    <script src="/js/navigation-context.js"></script>
     <script>
-        // Inject icons after DOM loads
         document.addEventListener('DOMContentLoaded', function() {
             if (window.IconLibrary) {
                 document.querySelectorAll('[data-icon]').forEach(function(element) {
@@ -828,17 +410,78 @@
             }
         });
     </script>
+
+    <!-- Deep-dive interactives (vanilla JS, no external data) -->
+    <script>
+    (function () {
+        // Discount-rate tool
+        var range = document.getElementById('disc-range');
+        var rateOut = document.getElementById('disc-rate');
+        var pvOut = document.getElementById('disc-pv');
+        var note = document.getElementById('disc-note');
+        function fmt(n){ return '$' + Math.round(n).toLocaleString('en-US'); }
+        function renderDisc(){
+            var r = parseInt(range.value, 10) / 100;
+            var pv = 1000 / Math.pow(1 + r, 10);
+            rateOut.textContent = range.value;
+            pvOut.textContent = fmt(pv);
+            var msg;
+            if (range.value <= 2) msg = 'A very low rate: you treat a future dollar almost like a present one.';
+            else if (range.value <= 8) msg = 'A moderate rate, in the range of long-run market returns.';
+            else if (range.value <= 15) msg = 'A high rate: the future is discounted steeply. Often sensible when the future feels uncertain.';
+            else msg = 'A very high rate: only the near term counts for much. Common under scarcity or instability.';
+            note.textContent = msg;
+        }
+        range.addEventListener('input', renderDisc);
+        renderDisc();
+
+        // Real-return tool
+        var ids = ['rt-amount','rt-return','rt-infl','rt-years'];
+        var inputs = {};
+        ids.forEach(function(id){ inputs[id] = document.getElementById(id); });
+        var rtResult = document.getElementById('rt-result');
+        function renderReal(){
+            var amt = parseFloat(inputs['rt-amount'].value);
+            var nom = parseFloat(inputs['rt-return'].value) / 100;
+            var inf = parseFloat(inputs['rt-infl'].value) / 100;
+            var yrs = parseInt(inputs['rt-years'].value, 10);
+            if (![amt,nom,inf].every(isFinite) || !isFinite(yrs) || amt < 0 || yrs < 1) {
+                rtResult.textContent = 'Enter valid numbers to see the result.';
+                return;
+            }
+            var nominalFV = amt * Math.pow(1 + nom, yrs);
+            var realRate = (1 + nom) / (1 + inf) - 1;
+            var realFV = amt * Math.pow(1 + realRate, yrs);
+            var keptPct = (realFV / amt) * 100;
+            // Build via DOM text nodes; all values are parsed Numbers, no user markup injected
+            rtResult.textContent = '';
+            var p1 = document.createElement('p');
+            p1.innerHTML = 'Nominal total after ' + yrs + ' years: <span class="readout">' + fmt(nominalFV) + '</span>';
+            var p2 = document.createElement('p');
+            p2.innerHTML = 'What it buys in today’s money: <span class="readout">' + fmt(realFV) + '</span>';
+            var p3 = document.createElement('p');
+            var realPctTxt = (realRate * 100).toFixed(2) + '% real per year';
+            p3.style.color = '#b3b3b3';
+            p3.style.fontSize = '0.92rem';
+            p3.textContent = 'Real return: ' + realPctTxt + '. Your saved amount keeps about ' + Math.round(keptPct) + '% of its starting purchasing power, before any growth, once inflation is taken out. If inflation tops your return, the real total falls below what you put in.';
+            rtResult.appendChild(p1); rtResult.appendChild(p2); rtResult.appendChild(p3);
+        }
+        ids.forEach(function(id){ inputs[id].addEventListener('input', renderReal); });
+        renderReal();
+    })();
+    </script>
+
+    <!-- Navigation Context (return-to-path functionality) -->
+    <script src="/js/navigation-context.js"></script>
     <!-- Reflect: Socratic questions after activity -->
     <div style="max-width:900px;margin:2rem auto 0;padding:0 1.5rem 2.5rem">
         <div class="reflect-widget"
-             data-topic="money"
+             data-topic="time-preference"
              data-path="principled"
              data-title="Reflect: What is time preference?">
         </div>
     </div>
     <script src="/js/reflect-widget.js"></script>
-
-
 
 <script src="/js/membership-gate.js"></script>
 

--- a/reports/austrian-economics-deepdive-audit-2026-06-17.md
+++ b/reports/austrian-economics-deepdive-audit-2026-06-17.md
@@ -1,0 +1,129 @@
+# Austrian Economics Deep-Dive Cluster — Phase 1 Audit (read-only)
+
+**Date:** 2026-06-17
+**Branch:** `feat/austrian-deepdive-rebuild` (worktree off `origin/main` @ `cb7b3f4c`)
+**Scope:** `/deep-dives/austrian-economics/` — index + 4 explainers
+**Status:** Read-only audit. No content rebuilt. Awaiting owner sign-off on direction + sequence.
+
+Pages audited (origin/main is current; PR #125 already did the coherence/de-green/overclaim-trim pass, so this is the *pedagogical-depth* layer, not a re-do):
+- `economic-calculation-problem.html` (841 lines)
+- `praxeology-human-action.html` (862 lines)
+- `sound-money-theory.html` (773 lines)
+- `time-preference-fundamentals.html` (855 lines)
+- `index.html` (198 lines) — hub card grid, fine structurally
+
+---
+
+## Deliverable 1 — Page-by-page audit (headline findings)
+
+All four pages share the **same four defects**, in descending severity:
+
+### A. Epistemic: they *convince*, they don't *inform* (the big one)
+Every page presents a **methodologically contested school** (a priori praxeology, ABCT, the gold standard) **and a partisan Bitcoin thesis as settled fact**, with **zero steelman** of the strongest opposing view, then closes in explicit advocacy. This is the direct opposite of the locked "inform, not convince" voice. Worst offenders, verbatim:
+- *"Bitcoin makes sense only through the lens of praxeology. Mainstream economics cannot explain why Bitcoin works."* (praxeology)
+- *"every sat you save in Bitcoin is a vote for sound money and a better future."* (sound-money)
+- *"By fixing the money, Bitcoin fixes the incentives... it fixes society."* + *"This is why you matter..."* (time-preference)
+- *"Bitcoin is Hayek's knowledge problem, solved with math."* (calculation)
+
+### B. Sourcing is essentially absent — and two "quotes" are fabricated
+Across ~100 hard claims, almost none carry an inline citation. Two blockquotes presented as verbatim **Mises** quotations appear to be **paraphrases dressed as quotes** (praxeology page; sound-money page). The pundit quotes (Krugman/Roubini/Rogoff) are real but unlinked and one is likely misworded (Roubini: "mother of all *bubbles*" vs "scams" — needs verification).
+
+### C. Empirical claims that are stale or wrong
+- **"Dollar lost 97% since 1971"** (sound-money) — the ~96-97% figure is measured from **1913**, not 1971. From 1971 the loss is ~87% (FRED CPIAUCSL). **Base-year error.**
+- **"$1M of gold ≈ 28 kg"** (sound-money) — **~2x stale**; at current spot it's ~15-16 kg.
+- **Stock-to-flow "60 years to double"** (sound-money) — definitional error; S2F ≈ 60 means ~60 years to *reproduce the whole stock*, not double it. Contradicts the page's own formula box.
+- **"National debt above $30 trillion"** (calculation) / **"$36T"** (sound-money) — datable, already drifting (>$36T now).
+- **"Your bitcoin maintains (or increases) purchasing power"** (time-preference) — false as stated; BTC has had multi-year drawdowns (2018, 2022).
+
+### D. No interactivity + leading Socratic questions
+All four are 100% static prose + CSS cards. The only dynamic affordance is the auto-injected Reflect widget (and on every page its `data-topic` is the generic `"money"`, not the page's actual topic). Each page has a 6-question "Socratic" block, but the questions are **rhetorical and pre-answered** (they presuppose the Austrian conclusion) rather than genuinely open. No predict→measure loop anywhere.
+
+Plus hygiene: **~17-20 em dashes per page** (violates the no-em-dash rule); red/green moral coloring on comparison cards (time-preference) conflicts with "color carries meaning."
+
+---
+
+## Deliverable 2 — Master claim ledger (priority flags)
+
+Full per-page ledgers (~100 rows total) live in the agent audit transcripts. The load-bearing items the rebuild MUST resolve:
+
+| Page | Claim | Problem | Resolution |
+|---|---|---|---|
+| sound-money | "dollar lost 97% since 1971" | wrong base year (that's 1913) | recompute live from FRED CPIAUCSL; state base year |
+| sound-money | "$1M gold ≈ 28 kg" | ~2x stale | compute from live spot (LBMA/COMEX) |
+| sound-money | S2F "60 years to double" | definitional error | fix to "reproduce existing stock"; cite |
+| sound-money | Mises "sound money..." blockquote | paraphrase as quote | relabel as paraphrase or find verbatim + cite (Mises 1912) |
+| sound-money | six properties "following Menger" | misattribution | the 6-checklist is a later synthesis (Ammous 2018), not Menger; reattribute |
+| praxeology | Mises "science of purposeful..." blockquote | not verbatim | verify against Human Action ch. I-II or relabel |
+| praxeology | "derived... through pure logic, no data" | contested method stated as fact | label a priori method as contested; add Caplan steelman |
+| praxeology | "mainstream cannot explain Bitcoin" | overclaim/convince | cut or qualify |
+| praxeology | Knightian risk vs uncertainty | credited to praxeology | credit Knight 1921 |
+| time-pref | "money directly shapes society's time preference" | contested thesis (Ammous) as fact | frame as hypothesis + steelman |
+| time-pref | "bitcoin maintains/increases purchasing power" | false (volatility) | cut/qualify |
+| time-pref | high/low TP societal-trait lists | unfalsifiable generalizations | cut or mark as illustrative |
+| time-pref | Japan miracle "Yen stable re gold" | inaccurate (Bretton Woods USD peg) | correct |
+| calculation | "rent control: shortages in *every* city" | universal overclaim | cite Diamond et al. 2019; soften |
+| calculation | Venezuela "price controls → starvation" | causal overreach, unsourced | cite ENCOVI; soften |
+| calculation | crisis "every 7-10 years like clockwork" | false precision | cite NBER; remove "clockwork" |
+
+Cross-cutting: **every** "Bitcoin fixes/solves/proves" line, and all moralizing ("HODL = delayed gratification in its purest form"), gets cut or reframed to scoped, sourced design facts.
+
+---
+
+## Deliverable 3 — Proposed structure (shared pattern + per page)
+
+**Shared rebuild pattern for all four** (keeps them deep-dives, not paths):
+1. *What the idea actually claims (and doesn't)* — define precisely, name it as one school's position, source it.
+2. *One interactive* — a predict→measure / learn-by-doing beat (see Deliverable 5).
+3. *The evidence you can check yourself* — replace asserted history/empirics with sourced, dated, learner-verifiable data.
+4. *The strongest objection (steelman)* — present the best opposing case **honestly, before any rebuttal**. This is the new required section every page lacks.
+5. *Where Bitcoin fits — and where it's still contested* — scoped design facts, no cheerleading; surface intra-Austrian disagreement where it exists (e.g. regression-theorem debate on whether Bitcoin even qualifies as money).
+6. *Reflect* — genuinely open questions (keep one that argues the other side); retopic the widget to the page's subject.
+
+Per-page steelman targets (the sharpest version of "discover, not convince"):
+- **calculation** → Lange-Lerner market socialism; Cockshott-Cottrell "big-data planning"; Walmart/Amazon as vast successful internal planners; Cybersyn.
+- **praxeology** → positivist/Popper unfalsifiability critique; Bryan Caplan, "Why I Am Not an Austrian Economist."
+- **sound-money** → mainstream case for ~2% inflation target; debt-deflation/Fisher 1933; the near-unanimous IGM economist poll against a gold standard; gold-era panics (1893, 1907).
+- **time-preference** → hyperbolic discounting/present-bias (Laibson, Thaler); Mullainathan & Shafir *Scarcity* (high discount rates track scarcity, not character — defuses the "poverty = bad character" overclaim).
+
+---
+
+## Deliverable 4 — Data sources & primary citations
+
+**Primary texts (for inline citation):** Mises, *Economic Calculation in the Socialist Commonwealth* (1920); *The Theory of Money and Credit* (1912, regression theorem); *Human Action* (1949). Hayek, "The Use of Knowledge in Society" (1945); *Prices and Production* (1931); *The Fatal Conceit* (1988). Menger, "On the Origins of Money" (1892); *Principles of Economics* (1871). Böhm-Bawerk, *Capital and Interest* (1884). Rothbard, *What Has Government Done to Our Money?* (1963); "Praxeology" (1976). Knight, *Risk, Uncertainty and Profit* (1921). Counter-sources: Caplan, "Why I Am Not an Austrian Economist"; Fisher (1933); Mullainathan & Shafir, *Scarcity* (2013); Diamond et al. (2019); Fergusson, *When Money Dies* (1975).
+
+**Live/empirical data (FRED unless noted):** CPIAUCSL (CPI/purchasing power), M2SL (money supply), GFDEBTN (federal debt), PSAVERT (personal saving rate); Case-Shiller / Census (home-price-to-income); World Gold Council + USGS (gold/silver stock & flow); Bitcoin protocol + mempool.space (supply, halving, S2F); measuringworth.com (long-run price index); IGM Booth poll (economist consensus on gold standard); OECD/BOJ (Japan saving rate).
+
+Site already has `js/bitcoin-data-reliable.js` (`data-btc-live`) for BTC values; FRED/CPI would be a **new** live-data source to add (or compute-once-and-date-stamp if we avoid a new fetch dependency — a decision flagged below).
+
+---
+
+## Deliverable 5 — Interactive opportunities (one per page minimum)
+
+- **calculation → "Plan an economy without prices"**: allocate fixed steel/labor across goods with hidden, shifting demand; reveal how far you miss vs a price-guided run. (Steelman baked in: give the learner "big data" and show tacit/dynamic knowledge still defeats it.)
+- **praxeology → "Try to deny that humans act"**: a form whose very submission is a purposeful action — teaches the a priori claim by performative contradiction. Plus a diamond-water marginal-utility slider.
+- **sound-money → live purchasing-power + debasement widgets**: "$1 in 1971 buys ___ today" (predict, then reveal from CPI); "$1M of gold weighs ___ kg" (live spot); M2-vs-CPI indexed-to-1971 chart. These directly replace the three stale/wrong hardcoded figures.
+- **time-preference → discount-rate sandbox**: learner sets their *own* discount rate, sees present value of a future sum — discovers they already have a time preference; resolves the opening hook with a measured number. Plus a "scarcity vs character" framing toggle (the steelman as interaction).
+
+These reuse existing patterns (the site already has a `/interactive-demos/stock-to-flow/` and `/interactive-demos/time-preference-explorer/` we can port from rather than build cold).
+
+---
+
+## Deliverable 6 — Recommended implementation order
+
+Sequenced by impact and by getting the pattern right once before replicating:
+
+1. **`sound-money-theory.html` first (pilot).** Highest density of *factually wrong/stale* claims (base-year error, gold weight, S2F error) → highest correctness payoff, and its interactives (live CPI/gold/M2) are the most concrete. Proving the shared 6-part pattern + sourcing + one live interactive + steelman here sets the template.
+2. **`time-preference-fundamentals.html`** — most cheerleading/moralizing to defuse; the scarcity-vs-character steelman is the most valuable single addition on the site.
+3. **`economic-calculation-problem.html`** — strongest, most teachable interactive ("plan without prices"); steelman is genuinely interesting (computational planning).
+4. **`praxeology-human-action.html`** — most abstract; benefits from going last once the pattern is proven.
+5. **`index.html`** — light pass: update card blurbs to match the rebuilt, less-triumphalist tone; no structural change.
+
+Each page ships as its **own small PR** off this branch (or sequential commits), verified in-browser (contrast AA, interactive works, no em dashes, Reflect retopiced) before the next. Em-dash sweep + Reflect-retopic happen inline per page.
+
+---
+
+## Open decisions for owner (need a call before code)
+
+1. **Editorial shift — confirm:** the rebuild makes these pages genuinely *two-sided* (a real steelman of mainstream economics / the case against the gold standard, presented fairly). This is faithful to "inform, not convince" / "discover, not convince," but it means the pages will no longer read as advocacy. Confirm that's the intent.
+2. **Live FRED data vs dated-and-sourced static:** do we add a live CPI/M2 fetch (new data dependency, always-current, more build) or compute-once and stamp "as of <date>, source FRED" (simpler, no new runtime dependency, but goes stale)? Recommend **live for BTC** (already wired) + **dated-and-sourced for FRED** in v1, upgrade to live FRED later.
+3. **Sequence/scope:** approve the 4-page order above, or pilot **sound-money only**, review, then decide on the rest.


### PR DESCRIPTION
Rebuilds the four Austrian economics deep-dives plus the hub from advocacy essays into first-principles **research labs**, per the `deep-dive-design-and-upgrade` method (research question → current system → failure mode → mechanism → tradeoffs → interactive → evidence → steelman → reflection). Owner-approved direction: **inform, not convince** (genuine steelman, no advocacy spine); dated + sourced data now (BTC live, FRED-live later); pilot sound-money, then all four.

Phase 1 read-only audit: `reports/austrian-economics-deepdive-audit-2026-06-17.md`.

## What changed, per page
- **Sound money** — interactive 8-property × 7-instrument matrix (gold / fiat cash / bank deposit / Bitcoin / stablecoin / CBDC / other crypto) that teaches the tradeoff (the winning money changes with what you weight); "what does 'backed by' mean?" module; stock-to-flow + issuance-through-halvings charts; four-point steelman (the 2% inflation / debt-deflation case, the 0-of-40 IGM economist poll, gold-era panics, "no intrinsic value"); purchasing-power predictor + gold-portability calculator.
- **Time preference** — discount-rate tool (reveal your own) + real-return calculator (shows saving can lose purchasing power); the scarcity-vs-character + hyperbolic-discounting steelman that ends the moralizing; sourced savings/inflation/affordability data with no-mono-causality caveat.
- **Economic calculation** — "plan without prices" allocation simulator + price-signal predictor; systems comparison table; the fully developed "can computers plan?" steelman (Lange, Walmart/Amazon, Cybersyn) with the honest three-gap response; "I, Pencil" → Bitcoin coordination-by-rule.
- **Praxeology** — "is this human action?" classifier + subjective-value lab; fair Austrian-vs-mainstream table (marginalism marked as shared); the Popper/Caplan unfalsifiability steelman; the live intra-Austrian regression-theorem debate.
- **Hub** — cards reframed as research questions; "what these are, and are not" note.

## Corrections to wrong/stale facts
Dollar loss **~87% since 1971** (the 97% figure is from 1913); $1M of gold **~7.1 kg** at \$4,371/oz (was 28 kg); stock-to-flow "reproduce the stock" not "double" it; relabels a paraphrased Mises "quote"; reattributes the properties checklist to Ammous, not Menger. All figures verified and dated, with an on-page source/claim ledger on every page.

## Conventions held
Deep-dives stay classified as `deep_dive` and remain free; TBA boundary held (no funnel); inform-not-convince throughout; **zero em dashes** in page content; content-graph edges added; reflect widgets retopiced per page. Each page browser-verified (interactives compute correctly, no console errors).

## Notes
- Optional deeper sims from the brief were scoped out (fee-market simulator, rate-setting game, decision tree, opportunity-cost calculator); each page already has its headline interactive. Easy to add as a follow-up.
- The shared reflect-widget em-dash issue is fixed separately on `main`'s line (commit `010a9808`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)