### PR TITLE
Austrian deep-dives: add the four deferred interactive sims

### DIFF
--- a/deep-dives/austrian-economics/economic-calculation-problem.html
+++ b/deep-dives/austrian-economics/economic-calculation-problem.html
@@ -234,6 +234,24 @@ blocked_by_boundary: [no_direct_tba_funnel]
         </section>
 
         <section class="content-section">
+            <h2>Try it: set one interest rate for everyone</h2>
+            <p>
+                A central bank is a smaller version of the same problem. It sets one interest rate, the price of borrowing, for a whole country made of very different regions and sectors. Below, four parts of an economy each have a rate that would suit their local conditions, which you cannot see. Pick a single rate for all of them and see how well one number fits.
+            </p>
+            <div class="interactive" id="rate-tool">
+                <h4>Set the national interest rate</h4>
+                <p class="hint">One rate, four very different local economies. Set it, then reveal what each part actually needed. The wider the spread, the worse any single number does.</p>
+                <label for="rate-range">Your rate: <span class="readout" id="rate-v">4.0</span>%</label>
+                <input type="range" id="rate-range" min="0" max="10" value="4" step="0.5">
+                <button id="rate-reveal" type="button">Reveal local conditions</button>
+                <div class="reveal" id="rate-result" hidden></div>
+            </div>
+            <p>
+                There is no rate that fits all four at once. Too low, and the overheating regions get cheap credit that fuels bubbles and malinvestment. Too high, and the struggling regions are starved of the borrowing they need. This is the calculation problem in miniature: one price, set centrally, cannot carry the dispersed and conflicting information that a thousand local prices would.
+            </p>
+        </section>
+
+        <section class="content-section">
             <h2>The strongest objection: can computers plan now?</h2>
             <p>
                 The most serious challenge to Mises and Hayek is not that they were wrong in 1920, but that technology has changed since. This deserves its full strength.
@@ -256,6 +274,25 @@ blocked_by_boundary: [no_direct_tba_funnel]
             </p>
             <p>
                 Bitcoin is a smaller example of the same shape: coordination without a coordinator. Miners, node operators, wallet developers, exchanges, and self-custodians each act on local information and incentives, and the network holds together with no one in charge. Notice this is a claim about <strong>coordination design</strong>, not a claim that Bitcoin runs an economy. It coordinates one thing, the issuance and settlement of a money, by rule.
+            </p>
+        </section>
+
+        <section class="content-section">
+            <h2>Try it: the fee market as a price signal</h2>
+            <p>
+                Here is a price signal working inside Bitcoin, with no planner setting it. Each block holds only so much space, so when more transactions are waiting than will fit, users bid fees for priority. The fee is a price for block space, and it rises and falls with demand exactly as Hayek would expect, coordinating who gets in next without anyone in charge.
+            </p>
+            <div class="interactive" id="fee-tool">
+                <h4>Bid for block space</h4>
+                <p class="hint">Set how much demand is waiting (in multiples of one block of space), then set your fee bid. The market clears at whatever fee fills the next block from the highest bidders. See whether you get in.</p>
+                <label for="fee-demand">Pending demand: <span class="readout" id="fee-demand-v">3.0</span>x one block</label>
+                <input type="range" id="fee-demand" min="0.2" max="8" value="3" step="0.1">
+                <label for="fee-bid">Your fee bid: <span class="readout" id="fee-bid-v">20</span> sat/vB</label>
+                <input type="range" id="fee-bid" min="1" max="250" value="20" step="1">
+                <div class="reveal" id="fee-result" aria-live="polite" style="border-top:1px solid rgba(255,255,255,0.12);"></div>
+            </div>
+            <p>
+                Notice no one decided the clearing fee. It emerged from everyone's bids against a fixed supply of space, and it told you, in one number, how urgently to bid or whether to wait. That is a market price doing exactly the job Mises and Hayek described, inside a system with no central authority to set it.
             </p>
         </section>
 
@@ -411,6 +448,72 @@ blocked_by_boundary: [no_direct_tba_funnel]
                 signalResult.appendChild(p);
             });
         });
+    })();
+    </script>
+
+    <!-- Deep-dive interactives, part 2 -->
+    <script>
+    (function () {
+        // Central-bank rate-setting game
+        var SECTORS = [
+            { name: 'Overheating tech hub', ideal: 8.0 },
+            { name: 'Housing-bubble coast', ideal: 6.5 },
+            { name: 'Steady services region', ideal: 4.5 },
+            { name: 'Struggling manufacturing town', ideal: 1.5 }
+        ];
+        var rRange = document.getElementById('rate-range');
+        var rV = document.getElementById('rate-v');
+        var rResult = document.getElementById('rate-result');
+        rRange.addEventListener('input', function(){ rV.textContent = parseFloat(rRange.value).toFixed(1); });
+        document.getElementById('rate-reveal').addEventListener('click', function(){
+            var rate = parseFloat(rRange.value);
+            rResult.hidden = false; rResult.textContent = '';
+            var totalMiss = 0;
+            SECTORS.forEach(function(s){ totalMiss += Math.abs(rate - s.ideal); });
+            var p = document.createElement('p');
+            p.innerHTML = 'Total mismatch: <span class="readout">' + totalMiss.toFixed(1) + ' points</span> across four regions. No single rate gets this to zero.';
+            rResult.appendChild(p);
+            SECTORS.forEach(function(s){
+                var gap = rate - s.ideal;
+                var verdict = Math.abs(gap) < 0.75 ? 'about right' : (gap > 0 ? 'too tight (credit too dear for them)' : 'too loose (cheap credit fuels malinvestment)');
+                var line = document.createElement('p');
+                line.style.margin = '0.4rem 0 0.1rem'; line.style.fontSize = '0.92rem';
+                line.innerHTML = '<strong>' + s.name + '</strong> needed about ' + s.ideal.toFixed(1) + '%. Your ' + rate.toFixed(1) + '% is ' + verdict + '.';
+                rResult.appendChild(line);
+            });
+        });
+
+        // Fee-market simulator
+        var fDemand = document.getElementById('fee-demand');
+        var fBid = document.getElementById('fee-bid');
+        var fDV = document.getElementById('fee-demand-v');
+        var fBV = document.getElementById('fee-bid-v');
+        var fResult = document.getElementById('fee-result');
+        function clearingFee(demand){
+            if (demand <= 1) return 1;
+            return Math.max(1, Math.round(2 * Math.pow(demand, 2)));
+        }
+        function renderFee(){
+            var demand = parseFloat(fDemand.value);
+            var bid = parseInt(fBid.value, 10);
+            fDV.textContent = demand.toFixed(1);
+            fBV.textContent = bid;
+            var clear = clearingFee(demand);
+            fResult.textContent = '';
+            var p1 = document.createElement('p');
+            p1.innerHTML = 'Market clearing fee right now: <span class="readout">' + clear + ' sat/vB</span>, set by everyone’s bids against a fixed block, not by you.';
+            var p2 = document.createElement('p');
+            if (bid >= clear) p2.textContent = 'Your bid clears. You confirm in the next block, about ten minutes.';
+            else if (bid >= clear * 0.6) p2.textContent = 'Your bid is below clearing. You wait several blocks, until demand eases or you raise it.';
+            else p2.textContent = 'Your bid is far below clearing. You could wait hours, or sit unconfirmed until the backlog clears.';
+            var p3 = document.createElement('p');
+            p3.style.color = '#b3b3b3'; p3.style.fontSize = '0.9rem'; p3.style.marginBottom = '0';
+            p3.textContent = 'Raise demand and the clearing fee climbs; lower it and space is nearly free. The price is doing the rationing.';
+            fResult.appendChild(p1); fResult.appendChild(p2); fResult.appendChild(p3);
+        }
+        fDemand.addEventListener('input', renderFee);
+        fBid.addEventListener('input', renderFee);
+        renderFee();
     })();
     </script>
 

--- a/deep-dives/austrian-economics/praxeology-human-action.html
+++ b/deep-dives/austrian-economics/praxeology-human-action.html
@@ -190,6 +190,24 @@ blocked_by_boundary: [no_direct_tba_funnel]
         </section>
 
         <section class="content-section">
+            <h2>The anatomy of an action</h2>
+            <p>
+                Praxeology says every action has the same skeleton: a person uses <em>means</em> to pursue an <em>end</em>, accepting a <em>tradeoff</em>, under <em>uncertainty</em>, and then lives with the <em>consequence</em> and revises. Pick a real choice and walk it through the structure.
+            </p>
+            <div class="interactive" id="tree-tool">
+                <h4>Walk a choice through the structure</h4>
+                <p class="hint">Choose a decision, then step through its anatomy. The labels are the praxeological categories; the lines are how they apply to your choice.</p>
+                <div id="tree-choices">
+                    <button class="choice-btn" data-key="save" type="button">Save this month's surplus</button>
+                    <button class="choice-btn" data-key="spend" type="button">Spend it on a trip now</button>
+                    <button class="choice-btn" data-key="learn" type="button">Spend weekends learning a skill</button>
+                </div>
+                <div class="reveal" id="tree-result" hidden></div>
+                <button id="tree-next" type="button" hidden>Next step</button>
+            </div>
+        </section>
+
+        <section class="content-section">
             <h2>Subjective value: the same thing, different worth</h2>
             <p>
                 A second praxeological idea: value is not a property baked into objects, it is assigned by acting people at the margin. The classic puzzle is the diamond-water paradox: water is essential yet cheap, diamonds are useless yet dear, because what we value is the <em>next</em> unit in our actual situation, not the thing in the abstract. Pick a situation and see.
@@ -203,6 +221,24 @@ blocked_by_boundary: [no_direct_tba_funnel]
                     <button class="choice-btn" data-key="btc-skeptic" type="button">Bitcoin, to a skeptic with a stable currency</button>
                 </div>
                 <div class="reveal" id="value-result" hidden></div>
+            </div>
+        </section>
+
+        <section class="content-section">
+            <h2>Make the tradeoff visible: opportunity cost</h2>
+            <p>
+                Because means are scarce, every choice forecloses others. The real cost of anything is not its price tag but the next best thing you give up to get it. This tool only makes that visible; it gives no advice about what you should choose.
+            </p>
+            <div class="interactive" id="oc-tool">
+                <h4>What does this choice really cost?</h4>
+                <p class="hint">Enter what you are about to spend and roughly what an hour of your work is worth, then name the single best thing you would otherwise do with it. The point is clarity, not a verdict.</p>
+                <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:1rem;">
+                    <div><label for="oc-amount">Amount ($)</label><input type="number" id="oc-amount" value="500" min="0" step="10"></div>
+                    <div><label for="oc-wage">Your take-home wage ($/hr)</label><input type="number" id="oc-wage" value="25" min="0" step="1"></div>
+                </div>
+                <label for="oc-alt">The best thing you would otherwise do with it</label>
+                <input type="text" id="oc-alt" maxlength="120" placeholder="e.g. three months of saving, a course, a weekend away" style="background:var(--secondary-dark);color:var(--text-light);border:1px solid rgba(255,255,255,0.2);border-radius:6px;padding:0.5rem 0.65rem;font-size:1rem;width:100%;">
+                <div class="reveal" id="oc-result" aria-live="polite" style="border-top:1px solid rgba(255,255,255,0.12);"></div>
             </div>
         </section>
 
@@ -408,6 +444,110 @@ blocked_by_boundary: [no_direct_tba_funnel]
                 valueResult.appendChild(note);
             });
         });
+    })();
+    </script>
+
+    <!-- Deep-dive interactives, part 2 -->
+    <script>
+    (function () {
+        // Action decision-tree
+        var TREE = {
+            save: [
+                { label: 'End (the valued goal)', text: 'A more secure future you value, right now, more than the things this money could buy today.' },
+                { label: 'Means', text: 'Setting this month’s surplus aside instead of spending it.' },
+                { label: 'Tradeoff (opportunity cost)', text: 'The trip, gadget, or nights out you forgo by not spending it now.' },
+                { label: 'Uncertainty', text: 'Future returns, inflation, and your own later needs are unknown.' },
+                { label: 'Action', text: 'You move the money to savings. That act, chosen toward an end, is the praxeology.' },
+                { label: 'Consequence and revision', text: 'It may reward you or disappoint you. Either way you learn and adjust next month.' }
+            ],
+            spend: [
+                { label: 'End (the valued goal)', text: 'An experience and rest you value now, more than a larger balance later.' },
+                { label: 'Means', text: 'Spending this month’s surplus on the trip.' },
+                { label: 'Tradeoff (opportunity cost)', text: 'The future security or compounding growth you give up.' },
+                { label: 'Uncertainty', text: 'Whether the trip is worth it, and what you will later wish you had done.' },
+                { label: 'Action', text: 'You book it and pay. That is the action.' },
+                { label: 'Consequence and revision', text: 'Memories or regret; either way you revise what you value next time.' }
+            ],
+            learn: [
+                { label: 'End (the valued goal)', text: 'A skill you expect to value more than the leisure it costs you.' },
+                { label: 'Means', text: 'Spending weekends studying instead of resting.' },
+                { label: 'Tradeoff (opportunity cost)', text: 'The rest and social time you forgo.' },
+                { label: 'Uncertainty', text: 'Whether the skill pays off, and whether you will stick with it.' },
+                { label: 'Action', text: 'You sit down and practice. The action itself.' },
+                { label: 'Consequence and revision', text: 'Progress or burnout; you adjust the plan as you go.' }
+            ]
+        };
+        var treeResult = document.getElementById('tree-result');
+        var treeNext = document.getElementById('tree-next');
+        var treeSteps = null, treeIdx = 0;
+        function renderTreeStep(){
+            treeResult.hidden = false;
+            treeResult.textContent = '';
+            for (var i = 0; i <= treeIdx && i < treeSteps.length; i++){
+                var card = document.createElement('div');
+                card.style.padding = '0.6rem 0'; card.style.borderBottom = '1px solid rgba(255,255,255,0.08)';
+                var lab = document.createElement('div');
+                lab.style.color = 'var(--accent-bronze)'; lab.style.fontWeight = '700'; lab.style.fontSize = '0.85rem';
+                lab.textContent = (i + 1) + '. ' + treeSteps[i].label;
+                var txt = document.createElement('div'); txt.style.color = 'var(--text-light)'; txt.textContent = treeSteps[i].text;
+                card.appendChild(lab); card.appendChild(txt); treeResult.appendChild(card);
+            }
+            if (treeIdx >= treeSteps.length - 1){
+                treeNext.hidden = true;
+                var done = document.createElement('p');
+                done.style.marginTop = '0.75rem'; done.style.color = '#b3b3b3'; done.style.fontSize = '0.9rem'; done.style.marginBottom = '0';
+                done.textContent = 'Every choice you make has this same skeleton. That sameness is what the action axiom points at.';
+                treeResult.appendChild(done);
+            } else {
+                treeNext.hidden = false;
+            }
+        }
+        document.querySelectorAll('#tree-choices .choice-btn').forEach(function(btn){
+            btn.addEventListener('click', function(){
+                treeSteps = TREE[btn.getAttribute('data-key')];
+                treeIdx = 0; renderTreeStep();
+            });
+        });
+        treeNext.addEventListener('click', function(){
+            if (treeSteps && treeIdx < treeSteps.length - 1){ treeIdx++; renderTreeStep(); }
+        });
+
+        // Opportunity-cost calculator
+        var ocAmount = document.getElementById('oc-amount');
+        var ocWage = document.getElementById('oc-wage');
+        var ocAlt = document.getElementById('oc-alt');
+        var ocResult = document.getElementById('oc-result');
+        function renderOC(){
+            var amt = parseFloat(ocAmount.value);
+            var wage = parseFloat(ocWage.value);
+            ocResult.textContent = '';
+            if (!isFinite(amt) || amt < 0){ ocResult.textContent = 'Enter an amount to see the tradeoff.'; return; }
+            var p1 = document.createElement('p');
+            if (isFinite(wage) && wage > 0){
+                var hours = amt / wage;
+                var hrTxt = hours >= 1 ? hours.toFixed(1) + ' hours' : Math.round(hours * 60) + ' minutes';
+                p1.innerHTML = '$' + amt.toLocaleString('en-US') + ' is about <span class="readout">' + hrTxt + '</span> of your working life.';
+            } else {
+                p1.innerHTML = '$' + amt.toLocaleString('en-US') + '.';
+            }
+            ocResult.appendChild(p1);
+            var alt = (ocAlt.value || '').trim();
+            var p2 = document.createElement('p'); p2.style.marginBottom = '0';
+            if (alt){
+                p2.appendChild(document.createTextNode('Its real cost is not the number. It is what you give up: '));
+                var strong = document.createElement('strong'); strong.style.color = 'var(--accent-gold)'; strong.textContent = alt;
+                p2.appendChild(strong);
+                p2.appendChild(document.createTextNode('. That forgone option is the opportunity cost.'));
+            } else {
+                p2.style.color = '#b3b3b3'; p2.style.fontSize = '0.9rem';
+                p2.textContent = 'Now name the single best thing you would otherwise do with it. That, not the dollar figure, is the true cost.';
+            }
+            ocResult.appendChild(p2);
+        }
+        ocAmount.addEventListener('input', renderOC);
+        ocWage.addEventListener('input', renderOC);
+        ocAlt.addEventListener('input', renderOC);
+        renderOC();
     })();
     </script>
 


### PR DESCRIPTION
Follow-up to #137. Adds the optional deeper interactives that were scoped out of the cluster rebuild. Each teaches a tradeoff (not decorative), is sanitized vanilla JS with no external data, and matches the existing page patterns.

## Economic calculation problem
- **Central-bank rate-setting game** — set one national interest rate; reveal four regions with divergent ideal rates and the total mismatch. Makes the point that one centrally set price cannot fit dispersed local conditions (the calculation problem in miniature).
- **Fee-market simulator** — set pending demand and your fee bid; the market clears at a fee set by everyone's bids against a fixed block. A working price signal inside Bitcoin, with no planner setting it.

## Praxeology and human action
- **Action decision-tree** — step a real choice (save / spend / learn) through its praxeological anatomy: end, means, tradeoff, uncertainty, action, consequence.
- **Opportunity-cost calculator** — translate a spend into hours of working life and name the next-best alternative. Tradeoff visibility, no advice.

## Verification
Browser-verified: rate mismatch and fee clearing compute correctly (demand 3 → 18 sat/vB; bids below clear wait, above clear confirm), the tree steps through all six stages and closes, opportunity cost echoes both the hours and the named alternative. No console errors. **Zero em dashes** in page content. Two files changed; holds the inform-not-convince and TBA-boundary conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)