### PR TITLE
demos: em-dash sweep across interactive-demos

### DIFF
--- a/interactive-demos/account-freeze-locked-out/index.html
+++ b/interactive-demos/account-freeze-locked-out/index.html
@@ -357,15 +357,15 @@
         /* ===== ACCESSIBILITY ENHANCEMENTS (WCAG 2.1 AA) ===== */
 
         /* 1. Improved Color Contrast (WCAG 1.4.3) */
-        .header .subtitle,
-        .balance-label,
-        .timeline-time,
+        .header .subtitle
+        .balance-label
+        .timeline-time
         .choice-btn .choice-desc {
             color: #b3b3b3; /* Changed from #888888 for better contrast (4.6:1) */
         }
 
         /* 2. Touch Targets (WCAG 2.5.5) */
-        button, a, [role="button"], input[type="button"], input[type="submit"], .choice-btn {
+        button, a, [role="button"], input[type="button"], input[type="submit"] .choice-btn {
             min-height: 44px;
             min-width: 44px;
         }
@@ -376,7 +376,7 @@
             outline-offset: 2px;
         }
 
-        button:focus-visible, a:focus-visible, .choice-btn:focus-visible {
+        button:focus-visible, a:focus-visible .choice-btn:focus-visible {
             outline: 3px solid var(--primary-orange, #FF7A00);
             outline-offset: 4px;
             box-shadow: 0 0 0 4px rgba(255, 122, 0, 0.2);
@@ -605,7 +605,7 @@
                     <div class="dialogue">
                         <span class="speaker">Alex:</span>
                         "Just keep $1,000 in Bitcoin. Not as an investment. As insurance. The day your bank
-                        freezes your account — and it will happen to someone you know — you'll understand why
+                        freezes your account, and it will happen to someone you know, you'll understand why
                         'get your Bitcoin off exchanges' isn't paranoia. It's reality."
                     </div>
                     <p class="story-text">
@@ -662,8 +662,7 @@
                         </div>
                     </div>
                     <p class="story-text">
-                        Your bank account stays frozen for 11 days. But you keep working, paying bills, living life —
-                        because you now have a financial system that doesn't need permission.
+                        Your bank account stays frozen for 11 days. But you keep working, paying bills, living life, because you now have a financial system that doesn't need permission.
                     </p>
                     <div class="dialogue">
                         <span class="speaker">You (one month later):</span>
@@ -676,7 +675,7 @@
                     "Automated fraud detection algorithms make mistakes with no human oversight",
                     "Your deposits are technically bank liabilities, not your property",
                     "Once you broadcast a transaction from your own wallet, no bank can freeze or reverse it",
-                    "Self-custody means true ownership — no one can deny you access",
+                    "Self-custody means true ownership, no one can deny you access",
                     "Financial sovereignty isn't paranoia; it's protection against systemic failure",
                     "The question isn't IF your bank will fail you, but WHEN"
                 ]
@@ -796,21 +795,19 @@
                     </p>
                     <div class="dialogue">
                         <span class="speaker">Manager:</span>
-                        "Our fraud prevention system flagged unusual activity. I can't lift this restriction —
-                        only the compliance department can. They're backlogged 5-7 business days. I'm sorry,
+                        "Our fraud prevention system flagged unusual activity. I can't lift this restriction, only the compliance department can. They're backlogged 5-7 business days. I'm sorry,
                         but there's nothing I can do."
                     </div>
                     <p class="story-text">
-                        You're standing <strong>inside the bank, looking at employees, surrounded by infrastructure</strong> —
-                        and your money is still locked behind an algorithm no human can override.
+                        You're standing <strong>inside the bank, looking at employees, surrounded by infrastructure</strong>, and your money is still locked behind an algorithm no human can override.
                     </p>
                 `,
                 learning: [
-                    "Physical branches are theater — real control is algorithmic",
+                    "Physical branches are theater, real control is algorithmic",
                     "Employees are powerless against automated compliance systems",
                     "The friendly teller can't help you; they don't control your access",
                     "Modern banking is centralized software with branch-shaped decorations",
-                    "Bitcoin has no customer service because it needs none — code is the only gatekeeper"
+                    "Bitcoin has no customer service because it needs none, code is the only gatekeeper"
                 ]
             },
 
@@ -830,7 +827,7 @@
                         You check ChexSystems. Your frozen account was reported as "suspicious activity under review."
                     </p>
                     <p class="story-text">
-                        <strong>You're now flagged across the entire banking system</strong> — not because you did anything wrong,
+                        <strong>You're now flagged across the entire banking system</strong>, not because you did anything wrong,
                         but because one bank's algorithm said so.
                     </p>
                     <div class="dialogue">
@@ -888,7 +885,7 @@
                 learning: [
                     "Relying on others' Bitcoin is not the same as having your own",
                     "In emergencies, dependency on anyone (banks OR friends) is risk",
-                    "Bitcoin's value isn't price appreciation — it's 24/7 uncensorable access",
+                    "Bitcoin's value isn't price appreciation, it's 24/7 uncensorable access",
                     "Self-custody means never being locked out",
                     "The best time to set up Bitcoin was before the emergency; second best is now",
                     "Financial sovereignty requires preparation, not panic"

--- a/interactive-demos/address-format-explorer/index.html
+++ b/interactive-demos/address-format-explorer/index.html
@@ -559,7 +559,7 @@
                 <div class="takeaway-card">
                     <div class="icon" data-icon="money"></div>
                     <h3>Fees Matter</h3>
-                    <p>Taproot saves up to 52% vs Legacy. Over years, this adds up to significant savings—hundreds or thousands of dollars!</p>
+                    <p>Taproot saves up to 52% vs Legacy. Over years, this adds up to significant savings, hundreds or thousands of dollars!</p>
                 </div>
 
                 <div class="takeaway-card">

--- a/interactive-demos/bitcoin-dca-time-machine/index.html
+++ b/interactive-demos/bitcoin-dca-time-machine/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="What dollar-cost averaging actually does to your money — drawdowns, regrets, and all. A truth-telling DCA simulator using real historical Bitcoin prices.">
+    <meta name="description" content="What dollar-cost averaging actually does to your money, drawdowns, regrets, and all. A truth-telling DCA simulator using real historical Bitcoin prices.">
     <title>DCA Reality Check | Bitcoin Sovereign Academy</title>
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="DCA Reality Check — what dollar-cost averaging actually does">
+    <meta property="og:title" content="DCA Reality Check, what dollar-cost averaging actually does">
     <meta property="og:description" content="Drawdowns, lump-sum benchmarks, survivorship bias. The honest version of a DCA calculator.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://bitcoinsovereign.academy/interactive-demos/bitcoin-dca-time-machine/">
@@ -102,7 +102,7 @@
             margin-bottom: 0.5rem;
         }
 
-        .input-group input, .input-group select {
+        .input-group input .input-group select {
             padding: 1rem;
             background: #242424;
             border: 2px solid #333;
@@ -113,7 +113,7 @@
             font-family: inherit;
         }
 
-        .input-group input:focus, .input-group select:focus {
+        .input-group input:focus .input-group select:focus {
             outline: none;
             border-color: #FF7A00;
         }
@@ -462,7 +462,7 @@
             line-height: 1.7;
         }
         .gaps-panel li::before {
-            content: '— ';
+            content: ', ';
             color: #555;
         }
 
@@ -559,7 +559,7 @@
         <header class="header">
             <h1>DCA Reality Check</h1>
             <p class="subtitle">
-                What dollar-cost averaging actually does — drawdowns, regrets, and all. Not a "how rich would I be" calculator.
+                What dollar-cost averaging actually does, drawdowns, regrets, and all. Not a "how rich would I be" calculator.
             </p>
             <details class="why-this-exists">
                 <summary>Why this exists</summary>
@@ -692,14 +692,14 @@
                     <li>Taxes (capital gains, income reporting)</li>
                     <li>Exchange failure or KYC freezes (FTX, Mt. Gox style events)</li>
                     <li>Lost keys, forgotten seeds, hardware failure</li>
-                    <li>That picking a start year ≥ 2014 is itself a survivor's choice — assets that died don't show up here</li>
+                    <li>That picking a start year ≥ 2014 is itself a survivor's choice, assets that died don't show up here</li>
                     <li>Whether you would have actually held through the drawdown shown above</li>
                 </ul>
             </div>
 
             <div class="cta-section">
                 <h3>Want to do this for real, with the smaller risks managed?</h3>
-                <p>Self-custody, KYC trade-offs, exchange selection — covered in the Curious path.</p>
+                <p>Self-custody, KYC trade-offs, exchange selection, covered in the Curious path.</p>
                 <a href="/start/" class="cta-btn">Learn how to buy Bitcoin safely →</a>
             </div>
 
@@ -790,7 +790,7 @@
                 // Merge + dedupe
                 const seen = new Set();
                 const merged = [];
-                for (const row of [...older, ...recent]) {
+                for (const row of [...older ...recent]) {
                     if (seen.has(row[0])) continue;
                     seen.add(row[0]);
                     merged.push(row);
@@ -799,7 +799,7 @@
 
                 try {
                     localStorage.setItem(CACHE_KEY, JSON.stringify({ fetchedAt: Date.now(), prices: merged }));
-                } catch (_) { /* private mode etc — ignore */ }
+                } catch (_) { /* private mode etc, ignore */ }
 
                 priceData = merged;
                 livePrice = merged[merged.length - 1][1];
@@ -838,7 +838,7 @@
         }
 
         function labelForYear(y) {
-            // Compute observed price range that year — neutral, no regret-tinted descriptors
+            // Compute observed price range that year, neutral, no regret-tinted descriptors
             const start = Date.UTC(y, 0, 1);
             const end = Date.UTC(y + 1, 0, 1);
             let lo = Infinity, hi = -Infinity;
@@ -999,12 +999,12 @@
                 });
             }
 
-            // Priority 2: significant drawdown — would you have actually held?
+            // Priority 2: significant drawdown, would you have actually held?
             if (dd <= -0.4) {
                 out.push({
                     kind: 'warn',
                     title: 'The bumpy ride',
-                    body: `Your stack was down ${fmtPct(dd)} from peak at one point — from $${fmtUsd(ddPeak.stackValue)} (${fmtDate(ddPeak.ts)}) to $${fmtUsd(ddTrough.stackValue)} (${fmtDate(ddTrough.ts)}). Most people stop buying or sell during drops like this. DCA only works if you don't.`
+                    body: `Your stack was down ${fmtPct(dd)} from peak at one point, from $${fmtUsd(ddPeak.stackValue)} (${fmtDate(ddPeak.ts)}) to $${fmtUsd(ddTrough.stackValue)} (${fmtDate(ddTrough.ts)}). Most people stop buying or sell during drops like this. DCA only works if you don't.`
                 });
             }
 
@@ -1013,7 +1013,7 @@
                 out.push({
                     kind: 'flag',
                     title: 'Don\'t read this as expected return',
-                    body: `${(r.roi * 100).toFixed(0)}% sounds great, but you picked an asset that survived. Many tokens, stocks, and currencies that traded in ${r.startYear} are gone or worthless now. This is survivorship bias — the data you can\'t see (failed assets) is exactly what you\'d need to estimate "expected" returns.`
+                    body: `${(r.roi * 100).toFixed(0)}% sounds great, but you picked an asset that survived. Many tokens, stocks, and currencies that traded in ${r.startYear} are gone or worthless now. This is survivorship bias, the data you can\'t see (failed assets) is exactly what you\'d need to estimate "expected" returns.`
                 });
             }
 
@@ -1023,13 +1023,13 @@
                     out.push({
                         kind: 'info',
                         title: 'Lump-sum would have beaten DCA here',
-                        body: `Putting the full $${fmtUsd(r.totalInvested)} in at the start would have grown to $${fmtUsd(r.lumpSum.value)} — that\'s ${fmtPct(-r.lumpSum.delta)} more than DCA. DCA\'s job isn\'t maximum returns. It\'s reducing the cost of being wrong about timing.`
+                        body: `Putting the full $${fmtUsd(r.totalInvested)} in at the start would have grown to $${fmtUsd(r.lumpSum.value)}, that\'s ${fmtPct(-r.lumpSum.delta)} more than DCA. DCA\'s job isn\'t maximum returns. It\'s reducing the cost of being wrong about timing.`
                     });
                 } else {
                     out.push({
                         kind: 'info',
                         title: 'DCA beat lump-sum here',
-                        body: `DCA outperformed lump-sum by ${fmtPct(r.lumpSum.delta)}. You bought through dips instead of buying everything at the top. This is the regime where DCA shines — and the one most people remember.`
+                        body: `DCA outperformed lump-sum by ${fmtPct(r.lumpSum.delta)}. You bought through dips instead of buying everything at the top. This is the regime where DCA shines, and the one most people remember.`
                     });
                 }
             }
@@ -1039,7 +1039,7 @@
                 out.push({
                     kind: 'warn',
                     title: 'Underwater',
-                    body: `You're down ${fmtPct(r.roi)}. DCA on a falling asset doesn\'t save you — it just makes you wrong slower. Worth sitting with: at this point, would you keep buying, stop, or sell?`
+                    body: `You're down ${fmtPct(r.roi)}. DCA on a falling asset doesn\'t save you, it just makes you wrong slower. Worth sitting with: at this point, would you keep buying, stop, or sell?`
                 });
             }
 
@@ -1270,9 +1270,9 @@
                 document.getElementById('guess-actual').textContent = '$' + fmtUsd(r.finalValue);
                 const ratio = r.finalValue / guess;
                 let comment;
-                if (ratio > 2) comment = `Actual stack is ${ratio.toFixed(1)}× your guess — most people underestimate compounding through volatility.`;
-                else if (ratio < 0.5) comment = `Actual stack is ${(1 / ratio).toFixed(1)}× smaller than your guess — most people overestimate Bitcoin returns from any single starting point.`;
-                else if (ratio >= 0.85 && ratio <= 1.15) comment = `Within ±15% — that\'s a calibrated guess.`;
+                if (ratio > 2) comment = `Actual stack is ${ratio.toFixed(1)}× your guess, most people underestimate compounding through volatility.`;
+                else if (ratio < 0.5) comment = `Actual stack is ${(1 / ratio).toFixed(1)}× smaller than your guess, most people overestimate Bitcoin returns from any single starting point.`;
+                else if (ratio >= 0.85 && ratio <= 1.15) comment = `Within ±15%, that\'s a calibrated guess.`;
                 else comment = `Off by ${Math.abs((ratio - 1) * 100).toFixed(0)}%. Closer than most.`;
                 document.getElementById('guess-comment').textContent = comment;
                 guessPanel.classList.add('visible');
@@ -1305,7 +1305,7 @@
             results.classList.add('visible');
             results.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
-            // Redraw chart on resize (debounced) — bind once
+            // Redraw chart on resize (debounced), bind once
             if (!renderResults._resizeBound) {
                 let timer;
                 window.addEventListener('resize', () => {
@@ -1358,7 +1358,7 @@
          data-demo-id="bitcoin-dca-time-machine"
          data-heading="What to do this week"
          data-sub="Pick the track that fits you. Each one is a single concrete action."
-         data-tracks='[{"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit — checklists so your stack actually lives in your own custody","href":"/products/self-custody-starter-kit/"},{"audience":"beginner","time":"10 min","action":"See how a real wallet is set up in the Wallet Workshop","href":"/interactive-demos/wallet-workshop/"}]'>
+         data-tracks='[{"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit, checklists so your stack actually lives in your own custody","href":"/products/self-custody-starter-kit/"},{"audience":"beginner","time":"10 min","action":"See how a real wallet is set up in the Wallet Workshop","href":"/interactive-demos/wallet-workshop/"}]'>
     </div>
     <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
     <div id="tip-page" data-tip-cta="compact"></div>

--- a/interactive-demos/bitcoin-genesis-timeline/index.html
+++ b/interactive-demos/bitcoin-genesis-timeline/index.html
@@ -347,7 +347,7 @@
             font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);
         }
 
-        .demo-output input,
+        .demo-output input
         .demo-output select {
             width: 100%;
             padding: 0.5rem;
@@ -449,13 +449,13 @@
             --text-dim: #b3b3b3;
         }
 
-        .subtitle, .card-description, small, p[style*="color: var(--text-dim)"] {
+        .subtitle .card-description, small, p[style*="color: var(--text-dim)"] {
             color: #b3b3b3 !important;
         }
 
         /* Touch Targets - Minimum 44x44px */
-        button, a, [role="button"], input[type="button"], input[type="submit"],
-        .back-button, .control-button, .demo-button, .wallet-btn, .connection-node {
+        button, a, [role="button"], input[type="button"], input[type="submit"]
+        .back-button .control-button .demo-button .wallet-btn .connection-node {
             min-height: 44px;
             min-width: 44px;
         }
@@ -466,8 +466,8 @@
             outline-offset: 2px;
         }
 
-        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible,
-        .timeline-card:focus-visible, .connection-node:focus-visible {
+        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
+        .timeline-card:focus-visible .connection-node:focus-visible {
             outline: 3px solid var(--primary-orange, #FF7A00);
             outline-offset: 4px;
             box-shadow: 0 0 0 4px rgba(255, 122, 0, 0.2);
@@ -503,7 +503,7 @@
                 left: 20px;
             }
 
-            .timeline-card.left,
+            .timeline-card.left
             .timeline-card.right {
                 margin-left: 60px;
                 margin-right: 0;
@@ -511,7 +511,7 @@
                 padding-right: 0;
             }
 
-            .timeline-card.left .timeline-dot,
+            .timeline-card.left .timeline-dot
             .timeline-card.right .timeline-dot {
                 left: -40px;
                 right: auto;
@@ -605,7 +605,7 @@
             font-weight: 600;
         }
 
-        .demoWrap textarea,
+        .demoWrap textarea
         .demoWrap input {
             width: 100%;
             padding: 0.75rem;
@@ -617,7 +617,7 @@
             font-size: 1rem;
         }
 
-        .demoWrap textarea:focus,
+        .demoWrap textarea:focus
         .demoWrap input:focus {
             outline: none;
             border-color: var(--primary-orange);
@@ -773,8 +773,8 @@
                             <div class="card-year num-fade">1977</div>
                             <div class="card-title">RSA Makes It Real</div>
                             <div class="card-description">
-                                Rivest, Shamir &amp; Adleman publish RSA—a practical method for <strong>both encryption and digital signatures</strong>.
-                                A signature <strong>proves who signed a message</strong>. It does not hide the message—it makes tampering obvious.
+                                Rivest, Shamir &amp; Adleman publish RSA, a practical method for <strong>both encryption and digital signatures</strong>.
+                                A signature <strong>proves who signed a message</strong>. It does not hide the message, it makes tampering obvious.
                                 <strong>If one character changes, verification fails. That is the point.</strong>
                             </div>
                             <button class="demo-button shell-outline-btn" onclick="event.stopPropagation(); openSignaturesDemo()">✍️ Try the Signatures Demo</button>
@@ -1746,7 +1746,7 @@
 
 <div style="margin: 1.5rem 0; padding: 1rem; background: rgba(0, 0, 0, 0.5); border-left: 3px solid var(--primary-orange); font-style: italic; line-height: 1.8;">
     "A purely peer-to-peer version of electronic cash would allow online payments to be sent directly from one party to another without going through a financial institution... We propose a solution to the double-spending problem using a peer-to-peer network. The network timestamps transactions by hashing them into an ongoing chain of hash-based proof-of-work..."
-    <div style="text-align: right; margin-top: 0.5rem; font-style: normal; color: var(--text-dim);">— Satoshi Nakamoto, October 31, 2008</div>
+    <div style="text-align: right; margin-top: 0.5rem; font-style: normal; color: var(--text-dim);">, Satoshi Nakamoto, October 31, 2008</div>
 </div>
 
 <div style="padding: 0.75rem; background: rgba(255, 122, 0, 0.1); border-left: 3px solid var(--primary-orange); font-size: 0.9rem;">
@@ -1784,7 +1784,7 @@
 
 <div style="padding: 0.75rem; background: rgba(33, 150, 243, 0.1); border-left: 3px solid var(--accent-blue); font-size: 0.9rem; margin-top: 1rem;">
     <strong>🔢 What's a <span class="term-tooltip" data-definition="Number used once. The winning lottery ticket number found after trying millions of guesses.">Nonce</span>?</strong><br>
-    The "nonce" is the winning lottery ticket number Satoshi found after trying millions of guesses. When combined with the block data, it produces a <span class="term-tooltip" data-definition="A unique fingerprint for data. Change one letter, the entire fingerprint changes completely.">hash</span> starting with many zeros—proof that real computational work was done.
+    The "nonce" is the winning lottery ticket number Satoshi found after trying millions of guesses. When combined with the block data, it produces a <span class="term-tooltip" data-definition="A unique fingerprint for data. Change one letter, the entire fingerprint changes completely.">hash</span> starting with many zeros, proof that real computational work was done.
 </div>
             `;
             output.classList.add('visible');
@@ -1969,7 +1969,7 @@
                 const ok = await verifySig(keys.publicKey, msgEl.value, signature);
 
                 if (ok) {
-                    statusEl.innerHTML = '<span class="status-valid">✅ VALID SIGNATURE</span><br>Message matches what was signed. Verification is public—anyone with the public key can verify this.';
+                    statusEl.innerHTML = '<span class="status-valid">✅ VALID SIGNATURE</span><br>Message matches what was signed. Verification is public, anyone with the public key can verify this.';
                 } else {
                     statusEl.innerHTML = '<span class="status-invalid">❌ INVALID SIGNATURE</span><br>Message was changed! This proves tampering. The signature no longer matches.';
                 }

--- a/interactive-demos/bitcoin-ira-decision-tool.html
+++ b/interactive-demos/bitcoin-ira-decision-tool.html
@@ -25,7 +25,7 @@
         }
 
         /* ===== ACCESSIBILITY ENHANCEMENTS (WCAG 2.1 AA) ===== */
-        button, a, [role="button"], input[type="button"], input[type="submit"], .choice {
+        button, a, [role="button"], input[type="button"], input[type="submit"] .choice {
             min-height: 44px;
             min-width: 44px;
         }
@@ -485,7 +485,7 @@
             border-collapse: collapse;
         }
 
-        .provider-table th,
+        .provider-table th
         .provider-table td {
             padding: 1rem;
             text-align: left;
@@ -718,19 +718,19 @@
                 <div class="checkbox-group">
                     <div class="checkbox-item">
                         <input type="checkbox" id="motivationTax" data-question="iraMotivation">
-                        <label for="motivationTax"><strong>Tax advantages</strong> — I want tax-deferred or tax-free growth</label>
+                        <label for="motivationTax"><strong>Tax advantages</strong>: I want tax-deferred or tax-free growth</label>
                     </div>
                     <div class="checkbox-item">
                         <input type="checkbox" id="motivationExisting" data-question="iraMotivation">
-                        <label for="motivationExisting"><strong>I already have most wealth in retirement accounts</strong> — My funds are already in 401(k)/IRA structures</label>
+                        <label for="motivationExisting"><strong>I already have most wealth in retirement accounts</strong>: My funds are already in 401(k)/IRA structures</label>
                     </div>
                     <div class="checkbox-item">
                         <input type="checkbox" id="motivationAdviser" data-question="iraMotivation">
-                        <label for="motivationAdviser"><strong>My adviser suggested it</strong> — Professional recommendation</label>
+                        <label for="motivationAdviser"><strong>My adviser suggested it</strong>: Professional recommendation</label>
                     </div>
                     <div class="checkbox-item">
                         <input type="checkbox" id="motivationUnsure" data-question="iraMotivation">
-                        <label for="motivationUnsure"><strong>I am not sure</strong> — Still exploring options</label>
+                        <label for="motivationUnsure"><strong>I am not sure</strong>: Still exploring options</label>
                     </div>
                 </div>
             </div>
@@ -756,19 +756,19 @@
                 <div class="checkbox-group">
                     <div class="checkbox-item">
                         <input type="checkbox" id="goalHedge" data-question="primaryGoal">
-                        <label for="goalHedge"><strong>Hedge against money printing</strong> — Protection from inflation and currency debasement</label>
+                        <label for="goalHedge"><strong>Hedge against money printing</strong>: Protection from inflation and currency debasement</label>
                     </div>
                     <div class="checkbox-item">
                         <input type="checkbox" id="goalGrowth" data-question="primaryGoal">
-                        <label for="goalGrowth"><strong>High growth part of my portfolio</strong> — Seeking significant appreciation potential</label>
+                        <label for="goalGrowth"><strong>High growth part of my portfolio</strong>: Seeking significant appreciation potential</label>
                     </div>
                     <div class="checkbox-item">
                         <input type="checkbox" id="goalWealth" data-question="primaryGoal">
-                        <label for="goalWealth"><strong>Way to pass wealth to family</strong> — Intergenerational wealth preservation</label>
+                        <label for="goalWealth"><strong>Way to pass wealth to family</strong>: Intergenerational wealth preservation</label>
                     </div>
                     <div class="checkbox-item">
                         <input type="checkbox" id="goalExperiment" data-question="primaryGoal">
-                        <label for="goalExperiment"><strong>Just a small experiment</strong> — Testing the waters with limited exposure</label>
+                        <label for="goalExperiment"><strong>Just a small experiment</strong>: Testing the waters with limited exposure</label>
                     </div>
                 </div>
             </div>
@@ -1262,15 +1262,15 @@
                 <div class="checkbox-group">
                     <div class="checkbox-item">
                         <input type="checkbox" id="emergencyNonRetirement" data-question="emergencyCash">
-                        <label for="emergencyNonRetirement"><strong>Tap non-retirement Bitcoin first</strong> — Keep IRA untouched, use other holdings</label>
+                        <label for="emergencyNonRetirement"><strong>Tap non-retirement Bitcoin first</strong>: Keep IRA untouched, use other holdings</label>
                     </div>
                     <div class="checkbox-item">
                         <input type="checkbox" id="emergencySavings" data-question="emergencyCash">
-                        <label for="emergencySavings"><strong>Tap cash savings</strong> — Use traditional emergency fund</label>
+                        <label for="emergencySavings"><strong>Tap cash savings</strong>: Use traditional emergency fund</label>
                     </div>
                     <div class="checkbox-item">
                         <input type="checkbox" id="emergencyIRA" data-question="emergencyCash">
-                        <label for="emergencyIRA"><strong>Tap the IRA even with penalty</strong> — Would accept penalty if necessary</label>
+                        <label for="emergencyIRA"><strong>Tap the IRA even with penalty</strong>: Would accept penalty if necessary</label>
                     </div>
                 </div>
             </div>

--- a/interactive-demos/bitcoin-key-generator-visual/index.html
+++ b/interactive-demos/bitcoin-key-generator-visual/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Bitcoin Key Generator — Visual Learning</title>
+<title>Bitcoin Key Generator, Visual Learning</title>
 <link rel="stylesheet" href="/css/brand.css">
 <style>
 /* ── base ── */
@@ -24,21 +24,21 @@ body{font-family:var(--font-sans, 'Inter', system-ui, sans-serif);
      background:var(--dark);color:var(--text);min-height:100vh;line-height:1.6}
 .wrap{max-width:1100px;margin:0 auto;padding:1.5rem}
 a{color:var(--orange);text-decoration:none}
-code,pre,.mono{font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace)}
+code,pre.mono{font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace)}
 button:focus-visible,a:focus-visible{outline:3px solid var(--orange);outline-offset:2px}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.01ms!important;transition-duration:.01ms!important}}
 
 /* ── header ── */
-.hdr{text-align:center;padding:1.5rem 1rem 1rem;background:linear-gradient(135deg,rgba(255, 122, 0,.12),rgba(255, 122, 0,.12));border-radius:14px;margin-bottom:1.5rem}
+.hdr{text-align:center;padding:1.5rem 1rem 1rem;background:linear-gradient(135deg,rgba(255, 122, 0.12),rgba(255, 122, 0.12));border-radius:14px;margin-bottom:1.5rem}
 .hdr h1{color:var(--orange);font-size:clamp(1.5rem,4vw,2.2rem);margin-bottom:.4rem}
 .hdr p{color:var(--dim);font-size:.95rem}
 
 /* ── FLOW DIAGRAM ── */
-.flow-panel{background:var(--surf);border:2px solid rgba(255, 122, 0,.4);border-radius:14px;padding:1.5rem;margin-bottom:1.5rem}
+.flow-panel{background:var(--surf);border:2px solid rgba(255, 122, 0.4);border-radius:14px;padding:1.5rem;margin-bottom:1.5rem}
 .flow-panel h2{color:var(--purple);font-size:1rem;text-transform:uppercase;letter-spacing:.08em;margin-bottom:1.2rem;display:flex;align-items:center;gap:.5rem}
 .flow-chain{display:flex;flex-wrap:wrap;align-items:center;gap:.4rem}
-.flow-node{background:var(--surf2);border:2px solid rgba(255, 122, 0,.5);border-radius:10px;padding:.6rem .9rem;min-width:130px;transition:border-color .3s,box-shadow .3s}
-.flow-node.active{border-color:var(--orange);box-shadow:0 0 14px rgba(255, 122, 0,.3)}
+.flow-node{background:var(--surf2);border:2px solid rgba(255, 122, 0.5);border-radius:10px;padding:.6rem .9rem;min-width:130px;transition:border-color .3s,box-shadow .3s}
+.flow-node.active{border-color:var(--orange);box-shadow:0 0 14px rgba(255, 122, 0.3)}
 .flow-node .fn-label{font-size:.68rem;color:var(--dim);text-transform:uppercase;letter-spacing:.06em}
 .flow-node .fn-value{font-size:.72rem;color:var(--text);word-break:break-all;font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);margin-top:.2rem;min-height:1rem;transition:color .4s}
 .flow-node .fn-value.changed{color:var(--orange)}
@@ -49,27 +49,27 @@ button:focus-visible,a:focus-visible{outline:3px solid var(--orange);outline-off
 /* ── spinner ── */
 .spin-wrap{text-align:center;padding:1rem;display:none}
 .spin-wrap.show{display:block}
-.spinner{display:inline-block;width:28px;height:28px;border:3px solid rgba(255, 122, 0,.2);border-top-color:var(--orange);border-radius:50%;animation:spin .7s linear infinite}
+.spinner{display:inline-block;width:28px;height:28px;border:3px solid rgba(255, 122, 0.2);border-top-color:var(--orange);border-radius:50%;animation:spin .7s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
 .spin-label{color:var(--orange);font-size:.85rem;margin-top:.5rem}
 
 /* ── accordion ── */
 .accordion{margin-bottom:1rem}
-details.step{background:var(--surf);border:2px solid rgba(255, 122, 0,.3);border-radius:12px;overflow:hidden;transition:border-color .3s}
+details.step{background:var(--surf);border:2px solid rgba(255, 122, 0.3);border-radius:12px;overflow:hidden;transition:border-color .3s}
 details.step[open]{border-color:var(--orange)}
 details.step>summary{display:flex;align-items:center;gap:.75rem;padding:1rem 1.25rem;cursor:pointer;list-style:none;user-select:none;transition:background .2s}
 details.step>summary::-webkit-details-marker{display:none}
-details.step>summary:hover{background:rgba(255, 122, 0,.06)}
+details.step>summary:hover{background:rgba(255, 122, 0.06)}
 .step-badge{background:var(--orange);color:#fff;width:32px;height:32px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:.95rem;flex-shrink:0}
 .step-title{font-size:1.05rem;font-weight:600;flex:1}
-.step-pill{font-size:.7rem;background:rgba(255, 122, 0,.2);color:var(--purple);padding:.2rem .6rem;border-radius:20px;margin-left:.5rem}
+.step-pill{font-size:.7rem;background:rgba(255, 122, 0.2);color:var(--purple);padding:.2rem .6rem;border-radius:20px;margin-left:.5rem}
 .step-chevron{color:var(--dim);font-size:1.2rem;transition:transform .3s;margin-left:auto}
 details.step[open] .step-chevron{transform:rotate(90deg)}
 .step-body{padding:0 1.25rem 1.25rem}
 
 /* ── bit grid ── */
 .bit-grid-wrap{display:flex;justify-content:center;margin:1rem 0}
-.bit-grid{display:grid;grid-template-columns:repeat(16,1fr);gap:3px;max-width:520px;width:100%;background:rgba(0,0,0,.5);padding:10px;border-radius:10px;border:2px solid rgba(255, 122, 0,.4)}
+.bit-grid{display:grid;grid-template-columns:repeat(16,1fr);gap:3px;max-width:520px;width:100%;background:rgba(0,0,0.5);padding:10px;border-radius:10px;border:2px solid rgba(255, 122, 0.4)}
 .bc{aspect-ratio:1;background:#333;border:1px solid #555;border-radius:2px;display:flex;align-items:center;justify-content:center;font-size:.55rem;font-weight:700;cursor:pointer;transition:background .15s,transform .1s;user-select:none}
 .bc.one{background:var(--orange);color:#fff;border-color:#c96f0a}
 .bc.zero{background:#222;color:#555}
@@ -79,55 +79,55 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 .entropy-slider-wrap{display:flex;align-items:center;gap:1rem;margin:1rem 0;flex-wrap:wrap}
 .entropy-slider-wrap label{font-size:.85rem;color:var(--dim);white-space:nowrap}
 #entropy-slider{flex:1;min-width:180px;accent-color:var(--orange)}
-.entropy-hex{background:rgba(0,0,0,.4);border:1.5px solid rgba(255, 122, 0,.4);border-radius:8px;padding:.7rem 1rem;font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);font-size:.75rem;word-break:break-all;margin-top:.5rem;line-height:1.6;min-height:2.5rem;transition:background .3s}
-.entropy-hex.flash{background:rgba(255, 122, 0,.12)}
+.entropy-hex{background:rgba(0,0,0.4);border:1.5px solid rgba(255, 122, 0.4);border-radius:8px;padding:.7rem 1rem;font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);font-size:.75rem;word-break:break-all;margin-top:.5rem;line-height:1.6;min-height:2.5rem;transition:background .3s}
+.entropy-hex.flash{background:rgba(255, 122, 0.12)}
 .bit-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:.75rem;margin:.75rem 0}
-.bs-box{background:rgba(255, 122, 0,.1);border:1.5px solid rgba(255, 122, 0,.3);border-radius:8px;padding:.6rem;text-align:center}
+.bs-box{background:rgba(255, 122, 0.1);border:1.5px solid rgba(255, 122, 0.3);border-radius:8px;padding:.6rem;text-align:center}
 .bs-val{color:var(--orange);font-size:1.3rem;font-weight:700}
 .bs-lbl{color:var(--dim);font-size:.7rem;margin-top:.15rem}
 
 /* ── key displays ── */
-.kd{background:rgba(0,0,0,.4);border:1.5px solid rgba(255, 122, 0,.35);border-radius:8px;padding:.9rem 1rem;margin:.6rem 0}
+.kd{background:rgba(0,0,0.4);border:1.5px solid rgba(255, 122, 0.35);border-radius:8px;padding:.9rem 1rem;margin:.6rem 0}
 .kd-label{color:var(--purple);font-size:.78rem;font-weight:600;margin-bottom:.35rem;display:flex;align-items:center;gap:.5rem}
 .kd-value{color:var(--text);font-size:.75rem;word-break:break-all;font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);line-height:1.5}
 .kd-value.hi{color:var(--orange);font-size:.85rem}
 .kd-value.placeholder{color:var(--dim);font-style:italic}
-.copy-btn{background:rgba(0,176,255,.15);color:var(--blue);border:1px solid rgba(0,176,255,.4);padding:.2rem .55rem;border-radius:4px;font-size:.72rem;cursor:pointer;transition:all .2s;margin-left:auto}
-.copy-btn:hover{background:rgba(0,176,255,.28)}
-.copy-btn.ok{background:rgba(40,199,111,.15);color:var(--green);border-color:var(--green)}
+.copy-btn{background:rgba(0,176,255.15);color:var(--blue);border:1px solid rgba(0,176,255.4);padding:.2rem .55rem;border-radius:4px;font-size:.72rem;cursor:pointer;transition:all .2s;margin-left:auto}
+.copy-btn:hover{background:rgba(0,176,255.28)}
+.copy-btn.ok{background:rgba(40,199,111.15);color:var(--green);border-color:var(--green)}
 
 /* ── mnemonic grid ── */
 .mnemonic-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(110px,1fr));gap:.6rem;margin:.75rem 0}
-.mw{background:rgba(255, 122, 0,.15);border:1.5px solid rgba(255, 122, 0,.35);border-radius:8px;padding:.65rem .5rem;text-align:center}
+.mw{background:rgba(255, 122, 0.15);border:1.5px solid rgba(255, 122, 0.35);border-radius:8px;padding:.65rem .5rem;text-align:center}
 .mw-n{color:var(--dim);font-size:.65rem}
 .mw-w{color:var(--text);font-weight:600;font-size:.9rem}
 
 /* ── HD address table ── */
 .hd-table{width:100%;border-collapse:collapse;font-size:.75rem;margin:.75rem 0}
-.hd-table th{background:rgba(255, 122, 0,.2);color:var(--purple);padding:.5rem .7rem;text-align:left;font-size:.68rem;text-transform:uppercase}
-.hd-table td{padding:.5rem .7rem;border-bottom:1px solid rgba(255,255,255,.06);word-break:break-all;font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);vertical-align:top}
-.hd-table tr:hover td{background:rgba(255, 122, 0,.05)}
+.hd-table th{background:rgba(255, 122, 0.2);color:var(--purple);padding:.5rem .7rem;text-align:left;font-size:.68rem;text-transform:uppercase}
+.hd-table td{padding:.5rem .7rem;border-bottom:1px solid rgba(255,255,255.06);word-break:break-all;font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);vertical-align:top}
+.hd-table tr:hover td{background:rgba(255, 122, 0.05)}
 .hd-table .path-col{color:var(--orange);white-space:nowrap;font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace)}
 .hd-table .addr-col{color:var(--green)}
 
 /* ── tabs ── */
 .tabs{display:flex;gap:.5rem;margin-bottom:.75rem;flex-wrap:wrap}
-.tab-btn{background:rgba(0,0,0,.3);border:1.5px solid rgba(255, 122, 0,.3);color:var(--dim);padding:.4rem 1rem;border-radius:20px;font-size:.82rem;cursor:pointer;transition:all .2s}
-.tab-btn.active{background:rgba(255, 122, 0,.2);border-color:var(--purple);color:var(--text)}
+.tab-btn{background:rgba(0,0,0.3);border:1.5px solid rgba(255, 122, 0.3);color:var(--dim);padding:.4rem 1rem;border-radius:20px;font-size:.82rem;cursor:pointer;transition:all .2s}
+.tab-btn.active{background:rgba(255, 122, 0.2);border-color:var(--purple);color:var(--text)}
 .tab-pane{display:none}
 .tab-pane.active{display:block}
 
 /* ── curve canvas ── */
 .curve-wrap{text-align:center;margin:.75rem 0}
-#curve-canvas{background:#111;border:2px solid rgba(255, 122, 0,.4);border-radius:8px;max-width:100%;height:220px}
+#curve-canvas{background:#111;border:2px solid rgba(255, 122, 0.4);border-radius:8px;max-width:100%;height:220px}
 
 /* ── info box ── */
-.info{background:rgba(255, 122, 0,.07);border-left:3px solid var(--purple);border-radius:4px;padding:.75rem 1rem;margin:.6rem 0;font-size:.85rem}
+.info{background:rgba(255, 122, 0.07);border-left:3px solid var(--purple);border-radius:4px;padding:.75rem 1rem;margin:.6rem 0;font-size:.85rem}
 .info h4{color:var(--purple);margin-bottom:.35rem}
 .info ul{margin-left:1.2rem}
-.warn{background:rgba(234,84,85,.08);border-left:3px solid var(--red);border-radius:4px;padding:.75rem 1rem;margin:.6rem 0;font-size:.85rem}
+.warn{background:rgba(234,84,85.08);border-left:3px solid var(--red);border-radius:4px;padding:.75rem 1rem;margin:.6rem 0;font-size:.85rem}
 .warn h4{color:var(--red);margin-bottom:.3rem}
-.danger-banner{background:rgba(234,84,85,.14);border:2px solid var(--red);border-radius:8px;padding:1rem 1.2rem;margin:1rem 0 1.4rem;color:var(--text)}
+.danger-banner{background:rgba(234,84,85.14);border:2px solid var(--red);border-radius:8px;padding:1rem 1.2rem;margin:1rem 0 1.4rem;color:var(--text)}
 .danger-banner strong{color:var(--red);display:block;font-size:.95rem;margin-bottom:.35rem}
 .danger-banner p{font-size:.85rem;line-height:1.5;margin:0}
 
@@ -139,18 +139,18 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 .btn-row{display:flex;flex-wrap:wrap;gap:.25rem;margin:.6rem 0}
 
 /* ── toast ── */
-.toast{position:fixed;top:18px;right:18px;background:#28c76f;color:#fff;padding:.75rem 1.25rem;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0,.4);font-size:.88rem;z-index:9999;display:none}
+.toast{position:fixed;top:18px;right:18px;background:#28c76f;color:#fff;padding:.75rem 1.25rem;border-radius:8px;box-shadow:0 4px 16px rgba(0,0,0.4);font-size:.88rem;z-index:9999;display:none}
 .toast.show{display:block;animation:fadeIn .25s ease}
 @keyframes fadeIn{from{opacity:0;transform:translateX(30px)}to{opacity:1;transform:none}}
 
 /* ── error banner ── */
-.err-bar{background:rgba(234,84,85,.15);border:1.5px solid var(--red);border-radius:8px;padding:.75rem 1rem;color:var(--red);font-size:.85rem;display:none;margin:.75rem 0}
+.err-bar{background:rgba(234,84,85.15);border:1.5px solid var(--red);border-radius:8px;padding:.75rem 1rem;color:var(--red);font-size:.85rem;display:none;margin:.75rem 0}
 .err-bar.show{display:block}
 
 /* ── hashing playground ── */
-.hash-playground{background:rgba(0,0,0,.25);border-radius:8px;padding:1rem;margin:.75rem 0}
-.hash-playground input{width:100%;padding:.6rem .8rem;background:rgba(0,0,0,.4);border:1.5px solid rgba(255, 122, 0,.4);border-radius:6px;color:var(--text);font-size:.9rem}
-.hash-result{font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);font-size:.78rem;word-break:break-all;color:var(--green);padding:.6rem;background:rgba(0,0,0,.3);border-radius:6px;margin-top:.6rem;display:none}
+.hash-playground{background:rgba(0,0,0.25);border-radius:8px;padding:1rem;margin:.75rem 0}
+.hash-playground input{width:100%;padding:.6rem .8rem;background:rgba(0,0,0.4);border:1.5px solid rgba(255, 122, 0.4);border-radius:6px;color:var(--text);font-size:.9rem}
+.hash-result{font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);font-size:.78rem;word-break:break-all;color:var(--green);padding:.6rem;background:rgba(0,0,0.3);border-radius:6px;margin-top:.6rem;display:none}
 
 /* ── responsive ── */
 @media(max-width:640px){
@@ -170,7 +170,7 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 <!-- ── HEADER ── -->
 <div class="hdr">
     <h1>🔑 Bitcoin Key Generator</h1>
-    <p>Real cryptography, live and reactive — change one bit, watch everything cascade</p>
+    <p>Real cryptography, live and reactive, change one bit, watch everything cascade</p>
 </div>
 
 <!-- ── SAFETY BANNER ── -->
@@ -184,23 +184,23 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 
 <!-- ── FLOW DIAGRAM ── -->
 <div class="flow-panel">
-    <h2>🔗 Relationship Map — how everything connects</h2>
+    <h2>🔗 Relationship Map, how everything connects</h2>
     <div class="flow-chain">
 
         <div class="flow-row">
             <div class="flow-node" id="fn-entropy">
                 <div class="fn-label">🎲 Entropy</div>
-                <div class="fn-value placeholder" id="fv-entropy">—</div>
+                <div class="fn-value placeholder" id="fv-entropy">-</div>
             </div>
             <div class="flow-arrow">→</div>
             <div class="flow-node" id="fn-priv">
                 <div class="fn-label">🔐 Private Key (hex)</div>
-                <div class="fn-value placeholder" id="fv-priv">—</div>
+                <div class="fn-value placeholder" id="fv-priv">-</div>
             </div>
             <div class="flow-arrow">→</div>
             <div class="flow-node" id="fn-mnemonic">
                 <div class="fn-label">📝 Mnemonic</div>
-                <div class="fn-value placeholder" id="fv-mnemonic">—</div>
+                <div class="fn-value placeholder" id="fv-mnemonic">-</div>
             </div>
         </div>
 
@@ -209,17 +209,17 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
         <div class="flow-row">
             <div class="flow-node" id="fn-seed">
                 <div class="fn-label">🌱 512-bit Seed</div>
-                <div class="fn-value placeholder" id="fv-seed">—</div>
+                <div class="fn-value placeholder" id="fv-seed">-</div>
             </div>
             <div class="flow-arrow">→</div>
             <div class="flow-node" id="fn-master">
                 <div class="fn-label">🔑 Master Key (BIP32)</div>
-                <div class="fn-value placeholder" id="fv-master">—</div>
+                <div class="fn-value placeholder" id="fv-master">-</div>
             </div>
             <div class="flow-arrow">→</div>
             <div class="flow-node" id="fn-pub">
                 <div class="fn-label">🔓 Public Key</div>
-                <div class="fn-value placeholder" id="fv-pub">—</div>
+                <div class="fn-value placeholder" id="fv-pub">-</div>
             </div>
         </div>
 
@@ -228,17 +228,17 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
         <div class="flow-row">
             <div class="flow-node" id="fn-h160">
                 <div class="fn-label">🔵 hash160</div>
-                <div class="fn-value placeholder" id="fv-h160">—</div>
+                <div class="fn-value placeholder" id="fv-h160">-</div>
             </div>
             <div class="flow-arrow">→</div>
             <div class="flow-node" id="fn-legacy">
                 <div class="fn-label">📮 Legacy (P2PKH)</div>
-                <div class="fn-value placeholder" id="fv-legacy">—</div>
+                <div class="fn-value placeholder" id="fv-legacy">-</div>
             </div>
             <div class="flow-arrow">&amp;</div>
             <div class="flow-node" id="fn-segwit">
                 <div class="fn-label">⚡ SegWit (bc1q…)</div>
-                <div class="fn-value placeholder" id="fv-segwit">—</div>
+                <div class="fn-value placeholder" id="fv-segwit">-</div>
             </div>
         </div>
 
@@ -247,7 +247,7 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
         <div class="flow-row">
             <div class="flow-node" id="fn-hd">
                 <div class="fn-label">🌳 HD Addresses (5 shown)</div>
-                <div class="fn-value placeholder" id="fv-hd">—</div>
+                <div class="fn-value placeholder" id="fv-hd">-</div>
             </div>
         </div>
 
@@ -261,13 +261,13 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 </div>
 
 <!-- ══════════════════════════════════════════════════════
-     STEP 1 — ENTROPY
+     STEP 1, ENTROPY
 ══════════════════════════════════════════════════════ -->
 <div class="accordion">
 <details class="step" id="step1" open>
 <summary>
     <span class="step-badge">1</span>
-    <span class="step-title">Entropy — your 256 random bits</span>
+    <span class="step-title">Entropy, your 256 random bits</span>
     <span class="step-pill">GENERATE HERE</span>
     <span class="step-chevron">›</span>
 </summary>
@@ -275,7 +275,7 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 
     <div class="info">
         <h4>What is entropy?</h4>
-        <p>A Bitcoin private key is simply a <strong>very large random number</strong> — 256 ones and zeros chosen at random.
+        <p>A Bitcoin private key is simply a <strong>very large random number</strong>, 256 ones and zeros chosen at random.
         There are 2²⁵⁶ possible combinations: more than atoms in the observable universe.
         <strong>Click any bit</strong> to flip it and watch every downstream value change instantly.</p>
     </div>
@@ -300,16 +300,16 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
     </div>
     <div class="kd">
         <div class="kd-label">
-            🔤 Private Key — Hex (64 chars = 256 bits ÷ 4)
+            🔤 Private Key, Hex (64 chars = 256 bits ÷ 4)
             <button class="copy-btn" onclick="copyEl('kd-hex',this)">Copy</button>
         </div>
-        <div class="kd-value hi placeholder" id="kd-hex">—</div>
+        <div class="kd-value hi placeholder" id="kd-hex">-</div>
     </div>
 
     <div class="warn">
         <h4>⚠️ Security: what makes entropy safe?</h4>
         <ul style="margin-left:1.2rem">
-            <li>Must be <strong>truly random</strong> — not your birthday, name, or any predictable pattern</li>
+            <li>Must be <strong>truly random</strong>, not your birthday, name, or any predictable pattern</li>
             <li>Generated by the operating system's cryptographic RNG (CSPRNG)</li>
             <li>Never stored digitally or photographed</li>
         </ul>
@@ -319,7 +319,7 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 </div>
 
 <!-- ══════════════════════════════════════════════════════
-     STEP 2 — MNEMONIC
+     STEP 2, MNEMONIC
 ══════════════════════════════════════════════════════ -->
 <div class="accordion">
 <details class="step" id="step2">
@@ -340,7 +340,7 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
             <li><strong>Step 4:</strong> Split into 12 groups of 11 bits → each picks 1 of 2,048 words</li>
         </ul>
         <p style="margin-top:.5rem">The <strong>same entropy always produces the same words</strong>.
-        Writing down 12 words is equivalent to writing down your private key — but far easier to verify.</p>
+        Writing down 12 words is equivalent to writing down your private key, but far easier to verify.</p>
     </div>
 
     <div class="mnemonic-grid" id="mnemonic-grid">
@@ -349,10 +349,10 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 
     <div class="kd">
         <div class="kd-label">
-            📋 Full phrase (copy to paper — never digital)
+            📋 Full phrase (copy to paper, never digital)
             <button class="copy-btn" onclick="copyEl('kd-phrase',this)">Copy</button>
         </div>
-        <div class="kd-value placeholder" id="kd-phrase">—</div>
+        <div class="kd-value placeholder" id="kd-phrase">-</div>
     </div>
 
     <div class="warn">
@@ -364,7 +364,7 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 </div>
 
 <!-- ══════════════════════════════════════════════════════
-     STEP 3 — SEED & MASTER KEY
+     STEP 3, SEED & MASTER KEY
 ══════════════════════════════════════════════════════ -->
 <div class="accordion">
 <details class="step" id="step3">
@@ -391,28 +391,28 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
             🌱 512-bit Seed (hex)
             <button class="copy-btn" onclick="copyEl('kd-seed',this)">Copy</button>
         </div>
-        <div class="kd-value placeholder mono" id="kd-seed" style="font-size:.68rem">—</div>
+        <div class="kd-value placeholder mono" id="kd-seed" style="font-size:.68rem">-</div>
     </div>
     <div class="kd">
         <div class="kd-label">
             🔑 Master Private Key (BIP32)
             <button class="copy-btn" onclick="copyEl('kd-master-priv',this)">Copy</button>
         </div>
-        <div class="kd-value hi placeholder" id="kd-master-priv">—</div>
+        <div class="kd-value hi placeholder" id="kd-master-priv">-</div>
     </div>
     <div class="kd">
         <div class="kd-label">
             🔗 Master Chain Code
             <button class="copy-btn" onclick="copyEl('kd-master-chain',this)">Copy</button>
         </div>
-        <div class="kd-value placeholder mono" id="kd-master-chain" style="font-size:.72rem">—</div>
+        <div class="kd-value placeholder mono" id="kd-master-chain" style="font-size:.72rem">-</div>
     </div>
 </div>
 </details>
 </div>
 
 <!-- ══════════════════════════════════════════════════════
-     STEP 4 — PUBLIC KEY
+     STEP 4, PUBLIC KEY
 ══════════════════════════════════════════════════════ -->
 <div class="accordion">
 <details class="step" id="step4">
@@ -440,7 +440,7 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 
     <div class="curve-wrap">
         <canvas id="curve-canvas" width="600" height="220"></canvas>
-        <p style="color:var(--dim);font-size:.75rem;margin-top:.4rem">y² = x³ + 7 over ℝ (conceptual — actual computation is over 𝔽ₚ with p ≈ 2²⁵⁶)</p>
+        <p style="color:var(--dim);font-size:.75rem;margin-top:.4rem">y² = x³ + 7 over ℝ (conceptual, actual computation is over 𝔽ₚ with p ≈ 2²⁵⁶)</p>
     </div>
 
     <div class="kd">
@@ -448,36 +448,36 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
             🔓 Compressed Public Key (33 bytes)
             <button class="copy-btn" onclick="copyEl('kd-pub-comp',this)">Copy</button>
         </div>
-        <div class="kd-value hi placeholder" id="kd-pub-comp">—</div>
+        <div class="kd-value hi placeholder" id="kd-pub-comp">-</div>
     </div>
     <div class="kd">
         <div class="kd-label">
             🔓 Uncompressed Public Key (65 bytes = 04 + x + y)
             <button class="copy-btn" onclick="copyEl('kd-pub-unc',this)">Copy</button>
         </div>
-        <div class="kd-value placeholder mono" id="kd-pub-unc" style="font-size:.68rem">—</div>
+        <div class="kd-value placeholder mono" id="kd-pub-unc" style="font-size:.68rem">-</div>
     </div>
     <div class="kd">
         <div class="kd-label">X coordinate</div>
-        <div class="kd-value placeholder mono" id="kd-pub-x" style="font-size:.72rem">—</div>
+        <div class="kd-value placeholder mono" id="kd-pub-x" style="font-size:.72rem">-</div>
     </div>
     <div class="kd">
         <div class="kd-label">Y coordinate</div>
-        <div class="kd-value placeholder mono" id="kd-pub-y" style="font-size:.72rem">—</div>
+        <div class="kd-value placeholder mono" id="kd-pub-y" style="font-size:.72rem">-</div>
     </div>
     <div class="kd">
         <div class="kd-label">
             🔵 hash160 = RIPEMD-160(SHA-256(pubkey))
             <button class="copy-btn" onclick="copyEl('kd-h160',this)">Copy</button>
         </div>
-        <div class="kd-value placeholder mono" id="kd-h160" style="font-size:.72rem">—</div>
+        <div class="kd-value placeholder mono" id="kd-h160" style="font-size:.72rem">-</div>
     </div>
 
     <!-- Hashing playground -->
     <details style="margin-top:1rem">
-        <summary style="cursor:pointer;color:var(--purple);font-size:.88rem;padding:.4rem 0">🎮 Hash playground — try it yourself</summary>
+        <summary style="cursor:pointer;color:var(--purple);font-size:.88rem;padding:.4rem 0">🎮 Hash playground, try it yourself</summary>
         <div class="hash-playground" style="margin-top:.6rem">
-            <p style="font-size:.83rem;margin-bottom:.5rem">Type anything and see SHA-256. Change one letter — the entire hash changes:</p>
+            <p style="font-size:.83rem;margin-bottom:.5rem">Type anything and see SHA-256. Change one letter, the entire hash changes:</p>
             <div style="display:flex;gap:.5rem">
                 <input type="text" id="hash-input" placeholder="Type something…" oninput="liveHash(this.value)">
             </div>
@@ -489,7 +489,7 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
 </div>
 
 <!-- ══════════════════════════════════════════════════════
-     STEP 5 — ADDRESSES
+     STEP 5, ADDRESSES
 ══════════════════════════════════════════════════════ -->
 <div class="accordion">
 <details class="step" id="step5">
@@ -517,23 +517,23 @@ details.step[open] .step-chevron{transform:rotate(90deg)}
             📮 Legacy P2PKH (Base58Check)
             <button class="copy-btn" onclick="copyEl('kd-addr-legacy',this)">Copy</button>
         </div>
-        <div class="kd-value hi placeholder" id="kd-addr-legacy">—</div>
+        <div class="kd-value hi placeholder" id="kd-addr-legacy">-</div>
     </div>
     <div class="kd">
         <div class="kd-label">
             ⚡ Native SegWit P2WPKH (Bech32)
             <button class="copy-btn" onclick="copyEl('kd-addr-segwit',this)">Copy</button>
         </div>
-        <div class="kd-value hi placeholder" id="kd-addr-segwit">—</div>
+        <div class="kd-value hi placeholder" id="kd-addr-segwit">-</div>
     </div>
 
     <!-- HD addresses -->
-    <h3 style="color:var(--purple);font-size:.9rem;margin:1.1rem 0 .35rem">HD Wallet — from the BIP32 master key (BIP44 &amp; BIP84):</h3>
+    <h3 style="color:var(--purple);font-size:.9rem;margin:1.1rem 0 .35rem">HD Wallet, from the BIP32 master key (BIP44 &amp; BIP84):</h3>
 
     <div class="info">
         <h4>One seed → infinite addresses</h4>
         <p>Modern wallets derive a <strong>tree of child keys</strong> from the master key using HMAC-SHA-512.
-        Each child has its own private key, public key, and address — but all are recoverable from your 12 words alone.</p>
+        Each child has its own private key, public key, and address, but all are recoverable from your 12 words alone.</p>
         <p style="margin-top:.4rem">
             BIP44 path: <code>m/44'/0'/0'/0/i</code> → Legacy<br>
             BIP84 path: <code>m/84'/0'/0'/0/i</code> → Native SegWit
@@ -734,7 +734,7 @@ function renderAll(r) {
     set('kd-h160',     r.h160Hex);
     drawCurve(r.pubKey);
 
-    // step 5 — single addresses
+    // step 5, single addresses
     set('kd-addr-legacy', r.legacySingle);
     set('kd-addr-segwit', r.segwitSingle);
 
@@ -826,7 +826,7 @@ function drawCurve(pubKey) {
     const gPx = cx + gx * scale, gPy = cy - gy * scale;
     dot(gPx, gPy, '#FF7A00', 'G', '(generator)');
 
-    // public key — pick a deterministic display position from first bytes of pubkey
+    // public key, pick a deterministic display position from first bytes of pubkey
     const xFrac = parseInt(pubKey.x.slice(0, 8), 16) / 0xFFFFFFFF;
     const pkx   = -1.5 + xFrac * 3.5;
     const pky2  = pkx**3 + 7;
@@ -875,7 +875,7 @@ function switchTab(name) {
 ────────────────────────────────────────────────── */
 function copyEl(id, btn) {
     const val = document.getElementById(id).textContent.trim();
-    if (!val || val === '—') return;
+    if (!val || val === ', ') return;
     navigator.clipboard.writeText(val).then(() => {
         showToast('Copied!');
         btn.textContent = '✓ Copied'; btn.classList.add('ok');
@@ -910,12 +910,12 @@ function resetAll() {
      'kd-pub-comp','kd-pub-unc','kd-pub-x','kd-pub-y','kd-h160',
      'kd-addr-legacy','kd-addr-segwit'].forEach(id => {
         const el = document.getElementById(id);
-        if (el) { el.textContent = '—'; el.classList.add('placeholder'); }
+        if (el) { el.textContent = ', '; el.classList.add('placeholder'); }
     });
     ['fv-entropy','fv-priv','fv-mnemonic','fv-seed','fv-master',
      'fv-pub','fv-h160','fv-legacy','fv-segwit','fv-hd'].forEach(id => {
         const el = document.getElementById(id);
-        if (el) { el.textContent = '—'; el.classList.add('placeholder'); }
+        if (el) { el.textContent = ', '; el.classList.add('placeholder'); }
     });
     document.getElementById('mnemonic-grid').innerHTML =
         '<div class="mw" style="opacity:.3;grid-column:1/-1;text-align:center;color:var(--dim)">Generate entropy first…</div>';
@@ -942,8 +942,8 @@ window.addEventListener('DOMContentLoaded', () => {
     <div class="demo-cta-footer"
          data-demo-id="bitcoin-key-generator-visual"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — a backup-and-recovery checklist so one lost seed isn't fatal", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "15 min", "action": "Drill it risk-free on testnet before touching mainnet", "href": "/interactive-demos/testnet-practice-guide/"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, a backup-and-recovery checklist so one lost seed isn't fatal", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "15 min", "action": "Drill it risk-free on testnet before touching mainnet", "href": "/interactive-demos/testnet-practice-guide/"}]'>
     </div>
     <div class="reflect-widget"
          data-topic="bitcoin-key-generator-visual"

--- a/interactive-demos/bitcoin-layers-map/index.html
+++ b/interactive-demos/bitcoin-layers-map/index.html
@@ -551,7 +551,7 @@
             font-size: 0.9rem;
         }
 
-        .comparison-metric:hover,
+        .comparison-metric:hover
         .comparison-metric.active {
             border-color: var(--primary-orange);
             background: rgba(255, 122, 0, 0.1);
@@ -569,7 +569,7 @@
             border-collapse: collapse;
         }
 
-        .comparison-table th,
+        .comparison-table th
         .comparison-table td {
             padding: 0.75rem;
             text-align: left;
@@ -638,7 +638,7 @@
                 grid-template-columns: 1fr;
             }
 
-            .level-btn,
+            .level-btn
             .comparison-metric {
                 padding: 0.5rem 1rem;
                 font-size: 0.85rem;
@@ -653,7 +653,7 @@
         }
 
         /* 2. Touch Targets (WCAG 2.5.5) */
-        button, a, [role="button"], input[type="button"], input[type="submit"], .layer-card, .protocol-card {
+        button, a, [role="button"], input[type="button"], input[type="submit"] .layer-card .protocol-card {
             min-height: 44px;
             min-width: 44px;
         }
@@ -664,7 +664,7 @@
             outline-offset: 2px;
         }
 
-        button:focus-visible, a:focus-visible, .layer-card:focus-visible {
+        button:focus-visible, a:focus-visible .layer-card:focus-visible {
             outline: 3px solid var(--primary-orange, #FF7A00);
             outline-offset: 4px;
             box-shadow: 0 0 0 4px rgba(255, 122, 0, 0.2);
@@ -729,7 +729,7 @@
     <div class="header">
         <h1><span data-icon="institution"></span> Bitcoin Layers Map</h1>
         <p class="beginner-only">
-            Bitcoin isn't just one thing—it's a layered system! Each layer solves different problems while keeping Bitcoin's core principles intact.
+            Bitcoin isn't just one thing, it's a layered system! Each layer solves different problems while keeping Bitcoin's core principles intact.
         </p>
         <p class="intermediate-only">
             Explore Bitcoin's evolving layer ecosystem. Each layer makes specific tradeoffs to extend Bitcoin's capabilities for different use cases.
@@ -821,7 +821,7 @@
                     <div class="layer-status status-live">✅ Live</div>
                 </div>
                 <div class="layer-description beginner-only">
-                    Instant Bitcoin payments! Like opening a tab at your favorite coffee shop—pay instantly, settle on Bitcoin later.
+                    Instant Bitcoin payments! Like opening a tab at your favorite coffee shop, pay instantly, settle on Bitcoin later.
                 </div>
                 <div class="layer-description intermediate-only">
                     Bidirectional payment channels enabling instant, low-cost transactions via multi-hop routing with HTLCs.
@@ -1016,7 +1016,7 @@
             base: {
                 title: '🏛️ Bitcoin Base Layer',
                 beginner: {
-                    purpose: 'The foundation that everything else builds on. Like bedrock—slow to move, but totally solid.',
+                    purpose: 'The foundation that everything else builds on. Like bedrock, slow to move, but totally solid.',
                     how: 'Every 10 minutes, miners bundle transactions into blocks. Everyone can verify these blocks independently.',
                     pros: ['Maximum security', 'Nobody can cheat', 'Globally verified by thousands of nodes'],
                     cons: ['Only ~7 transactions per second', 'Takes 10+ minutes for confirmation', 'Fees rise when busy'],
@@ -1107,7 +1107,7 @@
                     how: 'Join a Fedimint (maybe your family or local Bitcoin group). Deposit Bitcoin. Use eCash for private, instant payments within the community.',
                     pros: ['Super private (eCash is anonymous)', 'Easy to use', 'Great for communities who trust each other'],
                     cons: ['Your Fedimint could steal your money', 'Only as good as the people running it', 'Smaller networks'],
-                    question: 'If you trust your local credit union more than big banks, could Fedimint be like that—but for Bitcoin?'
+                    question: 'If you trust your local credit union more than big banks, could Fedimint be like that, but for Bitcoin?'
                 },
                 intermediate: {
                     purpose: 'Community custody with Chaumian eCash for privacy. Optimized for local trust networks.',

--- a/interactive-demos/bitcoin-unit-converter/index.html
+++ b/interactive-demos/bitcoin-unit-converter/index.html
@@ -385,14 +385,14 @@
         /* ===== ACCESSIBILITY ENHANCEMENTS (WCAG 2.1 AA) ===== */
 
         /* 1. Improved Color Contrast (WCAG 1.4.3) */
-        .header p,
-        .result-label,
+        .header p
+        .result-label
         .result-subtext {
             color: #b3b3b3; /* Changed from #888888 for better contrast (4.6:1) */
         }
 
         /* 2. Touch Targets (WCAG 2.5.5) */
-        button, a, [role="button"], input[type="button"], input[type="submit"], .quick-btn, select {
+        button, a, [role="button"], input[type="button"], input[type="submit"] .quick-btn, select {
             min-height: 44px;
             min-width: 44px;
         }
@@ -476,7 +476,7 @@
                 A <strong style="color: var(--primary-orange);">satoshi (sat)</strong> is the smallest unit of Bitcoin, named after Bitcoin's creator, Satoshi Nakamoto. Think of sats as the "pennies" of Bitcoin.
             </p>
             <p style="margin-bottom: 0; line-height: 1.8; font-size: 1.05rem;">
-                Since Bitcoin can be worth a lot in dollars, most people don't need to buy a whole Bitcoin. You can buy any fraction you want—even just a few thousand satoshis to start. <strong style="color: var(--text-light);">Try the converter below to see how different amounts compare!</strong>
+                Since Bitcoin can be worth a lot in dollars, most people don't need to buy a whole Bitcoin. You can buy any fraction you want, even just a few thousand satoshis to start. <strong style="color: var(--text-light);">Try the converter below to see how different amounts compare!</strong>
             </p>
         </div>
 

--- a/interactive-demos/bitcoin-vs-banking/index.html
+++ b/interactive-demos/bitcoin-vs-banking/index.html
@@ -151,7 +151,7 @@
             font-weight: 600;
         }
         
-        .form-group input, .form-group select {
+        .form-group input .form-group select {
             width: 100%;
             padding: 0.75rem;
             background: #242424;
@@ -161,7 +161,7 @@
             font-size: 1rem;
         }
         
-        .form-group input:focus, .form-group select:focus {
+        .form-group input:focus .form-group select:focus {
             outline: none;
             border-color: #FF7A00;
         }
@@ -173,7 +173,7 @@
             margin: 2rem 0;
         }
         
-        .pros-list, .cons-list {
+        .pros-list .cons-list {
             background: #242424;
             padding: 1.5rem;
             border-radius: 8px;
@@ -187,7 +187,7 @@
             border-left: 3px solid #ff1744;
         }
         
-        .pros-list h4, .cons-list h4 {
+        .pros-list h4 .cons-list h4 {
             margin-bottom: 1rem;
             color: #FF7A00;
         }
@@ -290,7 +290,7 @@
         }
 
         @media (max-width: 968px) {
-            .comparison-grid, .pros-cons {
+            .comparison-grid .pros-cons {
                 grid-template-columns: 1fr;
             }
 
@@ -302,14 +302,14 @@
         /* ===== ACCESSIBILITY ENHANCEMENTS (WCAG 2.1 AA) ===== */
 
         /* 1. Improved Color Contrast (WCAG 1.4.3) */
-        .metric-label,
+        .metric-label
         .level-info span:first-child,
         #level-description {
             color: #b3b3b3; /* Changed from #b0b0b0 for better contrast (4.6:1) */
         }
 
         /* 2. Touch Targets (WCAG 2.5.5) */
-        button, a, [role="button"], input[type="button"], input[type="submit"], select, .level-btn {
+        button, a, [role="button"], input[type="button"], input[type="submit"], select .level-btn {
             min-height: 44px;
             min-width: 44px;
         }
@@ -786,7 +786,7 @@
         <div class="reflect-widget"
              data-topic="money"
              data-path="curious"
-             data-title="Reflect: Banking vs Bitcoin — what&#39;s truly different?">
+             data-title="Reflect: Banking vs Bitcoin, what&#39;s truly different?">
         </div>
     </div>
     <script src="/js/reflect-widget.js"></script>

--- a/interactive-demos/coinjoin-simulator/index.html
+++ b/interactive-demos/coinjoin-simulator/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="/css/interactive-demos.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
     <link rel="stylesheet" href="/css/demo-shell.css">
-<link rel="canonical" href="https://bitcoinsovereign.academy/interactive-demos/coinjoin-simulator/"><meta property="og:title" content="CoinJoin: how it works, what it doesn't fix"><meta property="og:description" content="A practical look at Bitcoin transaction privacy — for holders, HNW, families, and advisors."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/interactive-demos/coinjoin-simulator/"><meta property="og:type" content="website"><script type="application/ld+json">{
+<link rel="canonical" href="https://bitcoinsovereign.academy/interactive-demos/coinjoin-simulator/"><meta property="og:title" content="CoinJoin: how it works, what it doesn't fix"><meta property="og:description" content="A practical look at Bitcoin transaction privacy, for holders, HNW, families, and advisors."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/interactive-demos/coinjoin-simulator/"><meta property="og:type" content="website"><script type="application/ld+json">{
   "@context": "https://schema.org",
   "@type": "EducationalOrganization",
   "name": "Bitcoin Sovereign Academy",
@@ -59,18 +59,18 @@
             <section class="demo-step active" id="step-1" aria-labelledby="step-1-heading">
                 <div class="explanation-box">
                     <h2 id="step-1-heading">Why this matters more than you think</h2>
-                    <p>Bitcoin's blockchain is <strong>permanently public</strong>. Once an address is linked to you, every transaction touching it — past and future — is visible to anyone with a chain-analysis subscription. That isn't a hypothetical surveillance risk; it's the default state of every coin you hold.</p>
+                    <p>Bitcoin's blockchain is <strong>permanently public</strong>. Once an address is linked to you, every transaction touching it, past and future, is visible to anyone with a chain-analysis subscription. That isn't a hypothetical surveillance risk; it's the default state of every coin you hold.</p>
 
                     <p>Whether that matters depends on who you are. Three concrete scenarios:</p>
 
                     <div class="privacy-scenarios">
                         <div class="scenario-card">
                             <h3>The holder</h3>
-                            <p>You buy a coffee with sats. The merchant's terminal — and anyone watching the chain — now sees your wallet's full balance. The bigger your stack, the bigger the targeting risk.</p>
+                            <p>You buy a coffee with sats. The merchant's terminal, and anyone watching the chain, now sees your wallet's full balance. The bigger your stack, the bigger the targeting risk.</p>
                         </div>
                         <div class="scenario-card">
                             <h3>The HNW individual</h3>
-                            <p>Your KYC exchange knows your full name and address. Every withdrawal it ever made is on a public ledger. A determined adversary doesn't need to hack you — they need a subpoena and a map.</p>
+                            <p>Your KYC exchange knows your full name and address. Every withdrawal it ever made is on a public ledger. A determined adversary doesn't need to hack you, they need a subpoena and a map.</p>
                         </div>
                         <div class="scenario-card">
                             <h3>The family</h3>
@@ -90,7 +90,7 @@
             <section class="demo-step" id="step-2" aria-labelledby="step-2-heading">
                 <div class="explanation-box">
                     <h2 id="step-2-heading">How chain analysis actually works</h2>
-                    <p>Chain-analysis firms don't break Bitcoin's cryptography. They use <strong>heuristics</strong> — patterns that probabilistically link addresses to the same owner. A few addresses get tagged at a regulated exchange, and the graph spreads from there.</p>
+                    <p>Chain-analysis firms don't break Bitcoin's cryptography. They use <strong>heuristics</strong>, patterns that probabilistically link addresses to the same owner. A few addresses get tagged at a regulated exchange, and the graph spreads from there.</p>
                 </div>
 
                 <div class="tracking-demo">
@@ -202,7 +202,7 @@
 
                     <div class="key-concept">
                         <h3>Anonymity set</h3>
-                        <p>In a CoinJoin with 5 participants, each output has an <strong>anonymity set of 5</strong> — it could plausibly belong to any of them. Larger rounds give larger sets. Multiple sequential rounds compound the effect.</p>
+                        <p>In a CoinJoin with 5 participants, each output has an <strong>anonymity set of 5</strong>, it could plausibly belong to any of them. Larger rounds give larger sets. Multiple sequential rounds compound the effect.</p>
                     </div>
 
                     <div class="key-concept" style="border-left-color: var(--color-warning, #ff9800);">
@@ -214,7 +214,7 @@
                             <li><strong>Timing patterns.</strong> Spending an hour after a round, every round, builds a behavioral fingerprint that survives any single mix.</li>
                             <li><strong>Network metadata.</strong> If you submit your CoinJoin from your home IP, the coordinator (and anyone watching the network) can link the round to you regardless of what happens on-chain. Tor matters.</li>
                         </ul>
-                        <p>One round of CoinJoin isn't a privacy guarantee — it's a privacy <em>improvement</em>, with conditions.</p>
+                        <p>One round of CoinJoin isn't a privacy guarantee, it's a privacy <em>improvement</em>, with conditions.</p>
                     </div>
                 </div>
 
@@ -308,7 +308,7 @@
                             </div>
                             <div class="insight-card">
                                 <h4>More rounds, more privacy, more cost</h4>
-                                <p>Anonymity sets compound across rounds, but so do fees and time. Plan for 3–5 rounds, not one — and budget the fee impact in advance.</p>
+                                <p>Anonymity sets compound across rounds, but so do fees and time. Plan for 3–5 rounds, not one, and budget the fee impact in advance.</p>
                             </div>
                         </div>
                     </div>
@@ -355,7 +355,7 @@
                             <div class="tool-card">
                                 <h4>Wasabi 2.x</h4>
                                 <p class="tool-type">Desktop · choose your coordinator</p>
-                                <p>Mainstream UX. Ships without a default coordinator since the June 2024 shutdown — you point it at one yourself (e.g. Kruw, others listed on wabisabi.io). The coordinator you pick can deny you service; vet before use.</p>
+                                <p>Mainstream UX. Ships without a default coordinator since the June 2024 shutdown, you point it at one yourself (e.g. Kruw, others listed on wabisabi.io). The coordinator you pick can deny you service; vet before use.</p>
                                 <a href="https://wasabiwallet.io" target="_blank" rel="noopener" class="tool-link">wasabiwallet.io →</a>
                             </div>
                             <div class="tool-card">
@@ -367,7 +367,7 @@
                             <div class="tool-card">
                                 <h4>Sparrow Wallet (no Whirlpool)</h4>
                                 <p class="tool-type">Desktop · manual privacy</p>
-                                <p>Strong UTXO labeling and coin control. Has had no built-in CoinJoin since Sparrow 1.9.0 — the value here is <em>manual</em> privacy hygiene (labeling, coin control, fee-bumping), not mixing.</p>
+                                <p>Strong UTXO labeling and coin control. Has had no built-in CoinJoin since Sparrow 1.9.0, the value here is <em>manual</em> privacy hygiene (labeling, coin control, fee-bumping), not mixing.</p>
                                 <a href="https://sparrowwallet.com" target="_blank" rel="noopener" class="tool-link">sparrowwallet.com →</a>
                             </div>
                         </div>

--- a/interactive-demos/consensus-game/index.html
+++ b/interactive-demos/consensus-game/index.html
@@ -526,7 +526,7 @@
                     </p>
                     <p style="margin-top: 0.5rem;">
                         <strong>Proof of Work solves this</strong> by making each "vote" (block) expensive to create. An attacker would need to
-                        acquire massive amounts of physical mining hardware and electricity—not just create virtual nodes. This makes attacks
+                        acquire massive amounts of physical mining hardware and electricity, not just create virtual nodes. This makes attacks
                         economically impractical because:
                     </p>
                     <ul style="margin-left: 1.5rem; margin-top: 0.5rem;">
@@ -594,8 +594,7 @@
                     </ul>
                     <p style="margin-top: 1rem;">
                         <strong>Why?</strong> Because every full node independently validates every block according to Bitcoin's consensus rules.
-                        If a miner creates a block that breaks the rules (invalid signatures, wrong supply, etc.), <strong>every node will reject it</strong>—
-                        even if it's on the longest chain!
+                        If a miner creates a block that breaks the rules (invalid signatures, wrong supply, etc.), <strong>every node will reject it</strong>, even if it's on the longest chain!
                     </p>
                     <p style="margin-top: 0.5rem;">
                         <strong>Key takeaway:</strong> Miners propose blocks, but full nodes enforce the rules. This separation of powers is crucial to Bitcoin's security.
@@ -608,8 +607,7 @@
                 <button class="reveal-btn" onclick="toggleAnswer('consensus-answer4')">Reveal Answer</button>
                 <div class="answer" id="consensus-answer4" style="display: none; margin-top: 1rem; padding: 1rem; background: rgba(76, 175, 80, 0.1); border-left: 4px solid var(--success-green); border-radius: 8px; line-height: 1.6;">
                     <p>
-                        The probability is approximately <strong>40%</strong> for any single block. This is because mining is a probabilistic process—
-                        each miner's chance of finding the next block is directly proportional to their hashrate.
+                        The probability is approximately <strong>40%</strong> for any single block. This is because mining is a probabilistic process, each miner's chance of finding the next block is directly proportional to their hashrate.
                     </p>
                     <p style="margin-top: 1rem;"><strong>The Math:</strong></p>
                     <ul style="margin-left: 1.5rem; margin-top: 0.5rem;">
@@ -633,7 +631,7 @@
                     </ul>
                     <p style="margin-top: 1rem;">
                         <strong>Example attack scenario:</strong> Per Nakamoto whitepaper §11 (Poisson race formula), a 40%-hashrate attacker
-                        has roughly a <strong>~50% chance</strong> of successfully reorganizing a chain 6 blocks deep — NOT vanishingly small.
+                        has roughly a <strong>~50% chance</strong> of successfully reorganizing a chain 6 blocks deep, NOT vanishingly small.
                         For that, attacker share must be well below 50%: a 10% attacker catches a 6-deep chain only ~0.02% of the time,
                         and a 30% attacker only ~13% of the time. This is why Bitcoin's security assumes attackers control well under half the hashrate.
                     </p>

--- a/interactive-demos/difficulty-calculator/index.html
+++ b/interactive-demos/difficulty-calculator/index.html
@@ -120,7 +120,7 @@
             margin-bottom: 0.5rem;
         }
 
-        .input-group input, .input-group select {
+        .input-group input .input-group select {
             width: 100%;
             padding: 0.75rem;
             background: rgba(0, 0, 0, 0.4);
@@ -131,7 +131,7 @@
             transition: border-color 0.3s;
         }
 
-        .input-group input:focus, .input-group select:focus {
+        .input-group input:focus .input-group select:focus {
             outline: none;
             border-color: var(--primary-orange);
         }
@@ -393,7 +393,7 @@
             <div style="color: var(--text-light); line-height: 1.8;">
                 <p style="margin-bottom: 1rem;">
                     In January 2025, Bitcoin's network hashrate surpassed <strong>1 ZH/s (zettahash per second)</strong> for the first time in history.
-                    This represents <strong>1,000,000,000,000,000,000,000 hashes per second</strong> — a quintillion computational operations every single second.
+                    This represents <strong>1,000,000,000,000,000,000,000 hashes per second</strong>, a quintillion computational operations every single second.
                 </p>
                 <p style="margin-bottom: 1rem;">
                     <strong>What this means:</strong>
@@ -409,7 +409,7 @@
                     </li>
                     <li style="padding-left: 1.5rem; margin-bottom: 0.75rem; position: relative;">
                         <span style="position: absolute; left: 0;">📈</span>
-                        <strong>Network Growth</strong>: From ~10 TH/s in 2013 to over 1 ZH/s in 2025 — a 100 million-fold increase
+                        <strong>Network Growth</strong>: From ~10 TH/s in 2013 to over 1 ZH/s in 2025, a 100 million-fold increase
                     </li>
                     <li style="padding-left: 1.5rem; margin-bottom: 0.75rem; position: relative;">
                         <span style="position: absolute; left: 0;">⚡</span>

--- a/interactive-demos/digital-signatures-demo/index.html
+++ b/interactive-demos/digital-signatures-demo/index.html
@@ -206,7 +206,7 @@
                 That's what a <strong>digital signature</strong> does! It's cryptographic proof that says "I own this" without revealing your secret.<br><br>
                 Bitcoin has two ways to do this:<br>
                 • <strong style="color: var(--primary-orange);">ECDSA</strong> (the original way, since 2009)<br>
-                • <strong style="color: #C8922A;">✨ Schnorr</strong> (the new way, since 2021) — smaller, faster, more private!
+                • <strong style="color: #C8922A;">✨ Schnorr</strong> (the new way, since 2021), smaller, faster, more private!
             </p>
             <p class="intermediate-only">
                 Bitcoin uses elliptic curve cryptography (secp256k1) for digital signatures. Private keys sign transactions, public keys verify signatures. The mathematical relationship is one-way: easy to derive public from private, impossible to reverse.<br><br>
@@ -252,7 +252,7 @@
 
             <div style="background: rgba(255, 122, 0, 0.1); border: 2px dashed rgba(255, 122, 0, 0.3); border-radius: 8px; padding: 1rem; margin-top: 1rem;">
                 <h4 style="color: var(--accent-purple); margin-bottom: 0.75rem; font-size: 1rem;">🎮 Step 3: The Verification Game</h4>
-                <p class="beginner-only" style="font-size: 0.95rem; margin-bottom: 0.75rem;">Now anyone can check that YOU really signed it. Try to break it — it's impossible!</p>
+                <p class="beginner-only" style="font-size: 0.95rem; margin-bottom: 0.75rem;">Now anyone can check that YOU really signed it. Try to break it, it's impossible!</p>
                 <p class="intermediate-only advanced-only" style="font-size: 0.9rem; margin-bottom: 0.75rem; color: var(--text-dim);">Test signature verification - try changing the message or tampering with the signature!</p>
 
                 <div style="margin-bottom: 0.75rem;">
@@ -289,7 +289,7 @@
             <!-- BEGINNER LEVEL -->
             <div class="beginner-only">
                 <div style="background: rgba(200, 146, 42, 0.1); border-left: 4px solid #C8922A; border-radius: 8px; padding: 1.25rem; margin-bottom: 1rem;">
-                    <p style="font-size: 1.05rem; margin-bottom: 1rem;">You just tried <strong>ECDSA</strong> (the original way). Now let's try <strong style="color: #C8922A;">Schnorr</strong> — the 2021 upgrade that made Bitcoin better!</p>
+                    <p style="font-size: 1.05rem; margin-bottom: 1rem;">You just tried <strong>ECDSA</strong> (the original way). Now let's try <strong style="color: #C8922A;">Schnorr</strong>, the 2021 upgrade that made Bitcoin better!</p>
                     <p style="font-size: 0.95rem;">What makes Schnorr special? It's <strong>smaller, faster, and has a powerful feature</strong>: multiple people can sign together and it looks like just one person signed!</p>
                 </div>
 
@@ -362,7 +362,7 @@
 
                 <div style="background: rgba(76, 175, 80, 0.1); border: 2px solid #4CAF50; border-radius: 8px; padding: 1rem; margin-top: 1rem;">
                     <strong style="color: #4CAF50;">💡 Key Advantage: Linearity</strong>
-                    <p style="margin-top: 0.5rem;">Schnorr's linearity property allows <strong>signature aggregation</strong>: Multiple parties can combine their signatures into a single signature. This makes complex multisig setups look identical to single-key spends on-chain — massive privacy and efficiency gains!</p>
+                    <p style="margin-top: 0.5rem;">Schnorr's linearity property allows <strong>signature aggregation</strong>: Multiple parties can combine their signatures into a single signature. This makes complex multisig setups look identical to single-key spends on-chain, massive privacy and efficiency gains!</p>
                 </div>
             </div>
 
@@ -613,7 +613,7 @@
                         <strong>🔒 Old vs New:</strong>
                         <ul style="margin-left: 1.25rem; margin-top: 0.5rem;">
                             <li><strong>ECDSA</strong> (2009-now): Original signatures, work great but bigger</li>
-                            <li><strong>Schnorr + Taproot</strong> (2021-now): Newer, smaller, more private — multisig looks like single-sig!</li>
+                            <li><strong>Schnorr + Taproot</strong> (2021-now): Newer, smaller, more private, multisig looks like single-sig!</li>
                         </ul>
                     </div>
                 </div>

--- a/interactive-demos/double-spending-demo/index.html
+++ b/interactive-demos/double-spending-demo/index.html
@@ -474,7 +474,7 @@
                 You're running a coffee shop accepting DigiDollars - a digital currency without a shared ledger.
                 In early digital payment systems, every merchant had their own copy of the ledger. Messages could
                 arrive out of order or at the same time. If two payments using the same coin ID reached different
-                servers before they could talk to each other, both might appear valid — at least for a few moments.
+                servers before they could talk to each other, both might appear valid, at least for a few moments.
             </p>
             <p class="advanced-only">
                 You're operating a merchant node in a distributed payment network without Byzantine Fault Tolerance.
@@ -582,7 +582,7 @@
                 <li><strong>UTXO Model:</strong> Each coin can only be spent once; outputs become inputs</li>
                 <li><strong>Mempool Validation:</strong> Nodes reject conflicting transactions immediately</li>
                 <li><strong>Longest Chain Rule:</strong> Miners extend the chain with most accumulated work</li>
-                <li><strong>Probabilistic Finality:</strong> Reorg probability falls with confirmations n, but depends on attacker hashrate share q — not a fixed 0.5<sup>n</sup>. See Nakamoto whitepaper §11 Poisson race formula.</li>
+                <li><strong>Probabilistic Finality:</strong> Reorg probability falls with confirmations n, but depends on attacker hashrate share q, not a fixed 0.5<sup>n</sup>. See Nakamoto whitepaper §11 Poisson race formula.</li>
                 <li><strong>Economic Security:</strong> 51% attack cost &gt;&gt; value of reversed transactions</li>
             </ul>
             <p style="margin-top: 1rem; padding: 1rem; background: #16181c; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 8px;">
@@ -766,7 +766,7 @@
                             <strong>first payment was valid</strong>. The rest were rejected as double-spends.
                         </p>
                         <p style="margin-top: 1rem; font-size: 1.15rem; line-height: 1.8; padding: 1rem; background: rgba(220, 53, 69, 0.2); border-radius: 8px;"><span data-icon="lightbulb"></span> <strong>Why This Happened:</strong> This timing gap is what allowed Alice's scam to work.
-                            It's not that she teleported — it's that the networks didn't agree fast enough. Without instant
+                            It's not that she teleported, it's that the networks didn't agree fast enough. Without instant
                             global consensus, each merchant only knew what their own system told them.
                         </p>
                         <p style="margin-top: 1rem; font-size: 1.2rem; color: var(--accent-red);">

--- a/interactive-demos/emergency-fifty-scenario/index.html
+++ b/interactive-demos/emergency-fifty-scenario/index.html
@@ -418,7 +418,7 @@
                     <div class="dialogue">
                         <span class="speaker">Maria:</span>
                         "I need your help. Emma has a fever of 104°F and the doctor prescribed emergency antibiotics.
-                        The pharmacy closes at 8 PM and I'm $50 short. My card was declined — I think the bank
+                        The pharmacy closes at 8 PM and I'm $50 short. My card was declined, I think the bank
                         flagged it for 'suspicious activity' because I bought gas in a different state yesterday.
                         Can you send me $50? Please?"
                     </div>
@@ -727,7 +727,7 @@
                     "Bitcoin transactions settle in minutes, not days",
                     "No business hours, weekends, or bank holidays",
                     "Minimal fees ($2) vs bank wires ($25+)",
-                    "No permission needed — no account holds or flags",
+                    "No permission needed, no account holds or flags",
                     "Instant conversion to local currency via modern apps",
                     "True 24/7/365 financial access anywhere in the world"
                 ]
@@ -764,7 +764,7 @@
                 learning: [
                     "Traditional systems have gatekeepers that can arbitrarily deny access",
                     "When seconds matter, waiting on hold or for business hours isn't an option",
-                    "Bitcoin works when other systems fail — but works even better when used first",
+                    "Bitcoin works when other systems fail, but works even better when used first",
                     "Financial emergencies don't wait for bank approvals"
                 ]
             },
@@ -793,7 +793,7 @@
                     </div>
                     <p class="story-text">
                         Emma spent Friday night in the ER. She's fine now, but Maria is now $425 deeper in debt.
-                        The $75 you sent arrives Monday — three days too late.
+                        The $75 you sent arrives Monday, three days too late.
                     </p>
                 `,
                 learning: [
@@ -829,7 +829,7 @@
                         </div>
                     </div>
                     <p class="story-text">
-                        Your payment clears 36 hours later — Sunday morning. Far too late.
+                        Your payment clears 36 hours later, Sunday morning. Far too late.
                         Maria had to take Emma to the ER Friday night.
                     </p>
                     <div class="dialogue">

--- a/interactive-demos/energy-bucket/index.html
+++ b/interactive-demos/energy-bucket/index.html
@@ -559,7 +559,7 @@
                     <button class="work-btn" id="inflationBtn" style="background: #dc3545; display: none;"><span data-icon="money-flow"></span> Inflation ON</button>
                 </div>
 
-                <div class="tooltip" style="font-size: 0.9rem; padding: 10px;"><span data-icon="chat"></span> Money should hold your stored energy — but what if it leaks?
+                <div class="tooltip" style="font-size: 0.9rem; padding: 10px;"><span data-icon="chat"></span> Money should hold your stored energy, but what if it leaks?
                 </div>
 
                 <div class="frame-nav">

--- a/interactive-demos/fee-master-tool/index.html
+++ b/interactive-demos/fee-master-tool/index.html
@@ -161,7 +161,7 @@
             font-weight: 600;
         }
         
-        .form-group input, .form-group select {
+        .form-group input .form-group select {
             width: 100%;
             padding: 0.75rem;
             background: #242424;
@@ -171,7 +171,7 @@
             font-size: 1rem;
         }
         
-        .form-group input:focus, .form-group select:focus {
+        .form-group input:focus .form-group select:focus {
             outline: none;
             border-color: #FF7A00;
         }
@@ -512,7 +512,7 @@
     <script>
         // Global state
         const apiHandler = new BitcoinAPIHandler({ enableLogging: false });
-        let currentBTCPrice = 95000; // fallback only — API populates this on init
+        let currentBTCPrice = 95000; // fallback only, API populates this on init
         let currentFees = { fastest: 10, halfHour: 7, hour: 5, economy: 3 };
         let mempoolSize = 0;
         let mempoolData = {};
@@ -908,8 +908,8 @@
     <div class="demo-cta-footer"
          data-demo-id="fee-master-tool"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — fee, send, and backup checklists so a careless transaction never costs you", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Watch a real mempool fill and clear before you set a fee for real", "href": "/interactive-demos/mempool-visualizer/"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, fee, send, and backup checklists so a careless transaction never costs you", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Watch a real mempool fill and clear before you set a fee for real", "href": "/interactive-demos/mempool-visualizer/"}]'>
     </div>
         <div class="reflect-widget"
              data-topic="transactions"

--- a/interactive-demos/index.html
+++ b/interactive-demos/index.html
@@ -449,7 +449,7 @@
               <span class="time-badge">15 min</span>
             </div>
             <p class="learn-outcome">Learn to: Assess security trade-offs</p>
-            <p>Branching what-if scenario: make 8 security decisions and watch the consequences play out — phone theft, exchange hack, inheritance — on a live risk dashboard. (The Training Lab is hands-on stations; this is decision-and-consequence.)</p>
+            <p>Branching what-if scenario: make 8 security decisions and watch the consequences play out, phone theft, exchange hack, inheritance, on a live risk dashboard. (The Training Lab is hands-on stations; this is decision-and-consequence.)</p>
             <span class="chip">Tool</span>
           </a>
           <a class="card" href="/emergency-kit.html">
@@ -890,7 +890,7 @@
         }
       }
 
-      // All demos are live — preview locking removed.
+      // All demos are live, preview locking removed.
       // Keeping this block as a no-op for any code that may reference it.
       (function() {
         // Previously locked; all demos now available.
@@ -928,7 +928,7 @@
           'energy-bucket',
           'bitcoin-vs-banking',
           'debt-crisis'
-        ]; // lockedDemos_DISABLED — not used
+        ]; // lockedDemos_DISABLED, not used
 
         // All demos are now live. No locking applied.
         document.querySelectorAll('.card').forEach(card => {
@@ -1001,7 +1001,7 @@
          data-demo-id="interactive-demos-index"
          data-heading="Want these for your team?"
          data-sub="Pick the track that fits you."
-         data-tracks='[{"audience":"advisor","time":"15 min","action":"License these demos for your practice or institution","href":"/institutional"},{"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit — turn the demos into a checklist you actually follow","href":"/products/self-custody-starter-kit/"}]'>
+         data-tracks='[{"audience":"advisor","time":"15 min","action":"License these demos for your practice or institution","href":"/institutional"},{"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit, turn the demos into a checklist you actually follow","href":"/products/self-custody-starter-kit/"}]'>
     </div>
     <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
     <div id="tip-page" data-tip-cta="compact"></div>

--- a/interactive-demos/kyc-best-practices/index.html
+++ b/interactive-demos/kyc-best-practices/index.html
@@ -2,7 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>KYC, no-KYC, or hybrid: which fits your situation? | Bitcoin Sovereign Academy</title>
-    <meta name="description" content="A short decision aid for buying Bitcoin. Pick by jurisdiction, amount, and privacy preference — get a recommendation with specific platforms verified for April 2026.">
+    <meta name="description" content="A short decision aid for buying Bitcoin. Pick by jurisdiction, amount, and privacy preference, get a recommendation with specific platforms verified for April 2026.">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/interactive-demos.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
@@ -122,7 +122,7 @@
             margin-top: 0.5rem;
             transition: transform 0.15s ease, box-shadow 0.15s ease;
         }
-        .kyc-decider__btn:hover,
+        .kyc-decider__btn:hover
         .kyc-decider__btn:focus-visible {
             transform: translateY(-1px);
             box-shadow: 0 4px 12px rgba(255, 122, 0, 0.4);
@@ -272,7 +272,7 @@
     <div class="resource-container" id="main-content">
         <div class="resource-header">
             <h1>KYC, no-KYC, or hybrid: which fits your situation?</h1>
-            <p class="subtitle">What you're agreeing to — and what you're not — when you buy Bitcoin through a regulated exchange.</p>
+            <p class="subtitle">What you're agreeing to, and what you're not, when you buy Bitcoin through a regulated exchange.</p>
             <span class="verified-stamp">Recommendations verified 2026-04-27</span>
         </div>
 
@@ -346,7 +346,7 @@
                 </ul>
                 <div class="what-it-means">
                     <strong>What this means in 2026</strong>
-                    Hodl Hodl, RoboSats, and Bisq remain the durable global options. RoboSats over Tor is the lowest-friction path for small amounts. Expect to pay a few percent above spot — it's the cost of not building a permanent identity-to-coin link.
+                    Hodl Hodl, RoboSats, and Bisq remain the durable global options. RoboSats over Tor is the lowest-friction path for small amounts. Expect to pay a few percent above spot, it's the cost of not building a permanent identity-to-coin link.
                 </div>
             </div>
         </div>
@@ -369,7 +369,7 @@
              data-heading="What to do this week"
              data-sub="Pick the track for your jurisdiction."
              data-tracks='[
-               {"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit — the checklist that turns \"which exchange\" into \"safely off the exchange\"","href":"/products/self-custody-starter-kit/"},
+               {"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit, the checklist that turns \"which exchange\" into \"safely off the exchange\"","href":"/products/self-custody-starter-kit/"},
                {"audience":"us-buyer","time":"10 min","action":"Open the On-Ramp Chooser to compare regulated US options","href":"/interactive-demos/onramp-chooser/?region=us"},
                {"audience":"eu-buyer","time":"10 min","action":"Open the On-Ramp Chooser with EU filter","href":"/interactive-demos/onramp-chooser/?region=eu"},
                {"audience":"colombia","time":"15 min","action":"Practice on testnet first, then pick a Colombian exchange","href":"/interactive-demos/testnet-practice-guide/"}
@@ -413,7 +413,7 @@
         if (amount === 'small') {
           return {
             title: 'No-KYC P2P',
-            body: '<p>Use ' + P2P_GLOBAL.slice(0, 2).join(' or ') + '. Expect a 2–5% premium over spot — that\'s the cost of not building a permanent identity-to-coin link.</p>' +
+            body: '<p>Use ' + P2P_GLOBAL.slice(0, 2).join(' or ') + '. Expect a 2–5% premium over spot, that\'s the cost of not building a permanent identity-to-coin link.</p>' +
                   '<p>For amounts under $200/month, the privacy cost of KYC outweighs the convenience benefit. Start here.</p>'
           };
         }
@@ -421,7 +421,7 @@
           return {
             title: 'Hybrid',
             body: '<p><strong>Half no-KYC, half regulated.</strong> Use ' + P2P_GLOBAL[0] + ' or ' + P2P_GLOBAL[1] + ' for some buys; use ' + regulatedList + ' for the rest.</p>' +
-                  '<p>This builds two unlinked Bitcoin pools. Not perfect privacy — but materially better than 100% KYC, without the liquidity pain of going fully no-KYC at this volume.</p>'
+                  '<p>This builds two unlinked Bitcoin pools. Not perfect privacy, but materially better than 100% KYC, without the liquidity pain of going fully no-KYC at this volume.</p>'
           };
         }
         // amount === 'large'
@@ -486,7 +486,7 @@
         <div class="reflect-widget"
              data-topic="privacy"
              data-path="curious"
-             data-title="Reflect: what does KYC reveal — and to whom?">
+             data-title="Reflect: what does KYC reveal, and to whom?">
         </div>
     </div>
     <script src="/js/reflect-widget.js"></script>

--- a/interactive-demos/ledger-keeper-dilemma/index.html
+++ b/interactive-demos/ledger-keeper-dilemma/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Ledger Keeper's Dilemma 2.0 — Interactive Comparison</title>
+    <title>The Ledger Keeper's Dilemma 2.0, Interactive Comparison</title>
     <meta name="description" content="Compare payment systems: CBDCs, state rails, Bitcoin, and more. Interactive table shows speed, control, privacy trade-offs.">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/interactive-demos.css">
@@ -348,7 +348,7 @@
             transition: all 0.3s ease;
         }
 
-        .scenario-btn:hover, .scenario-btn.active {
+        .scenario-btn:hover .scenario-btn.active {
             background: var(--primary-orange);
             color: white;
             transform: translateY(-2px);
@@ -479,7 +479,7 @@
         <!-- Hero -->
         <div class="hero">
             <h1>The Ledger Keeper's Dilemma 2.0</h1>
-            <p>Every payment system decides who can change the ledger—and who can see it.</p>
+            <p>Every payment system decides who can change the ledger, and who can see it.</p>
             <div class="tagline">
                 The question isn't whether we trust; it's <strong>how we verify.</strong>
             </div>
@@ -547,7 +547,7 @@
         <div class="highlight-box" style="font-size: 1.3rem; padding: 2rem;">
             <strong style="color: var(--primary-orange); font-size: 1.5rem;">"Speed is easy. Freedom is fragile."</strong><br><br>
             Centralized rails keep getting faster.<br>
-            Bitcoin's revolution was <strong>independence</strong>—rules without a referee change the game.
+            Bitcoin's revolution was <strong>independence</strong>, rules without a referee change the game.
         </div>
 
         <!-- CTA -->
@@ -596,7 +596,7 @@
                 examples: { label: "Pix, Bre-B" },
                 promise: "24/7 instant payments, national integration, free/low-cost, open API access.",
                 tradeoff: "Central bank sees all flows, KYC gating, policy risk, not new money (just faster movement), surveillance infrastructure.",
-                realExample: "Pix (Brazil): 140M+ users, 10-second settlement, free for individuals. Central Bank of Brazil sees every transaction. Bre-B (Colombia): Launched Oct 2025, currently facing withholding-tax proposal disincentivizing usage—clear policy risk.",
+                realExample: "Pix (Brazil): 140M+ users, 10-second settlement, free for individuals. Central Bank of Brazil sees every transaction. Bre-B (Colombia): Launched Oct 2025, currently facing withholding-tax proposal disincentivizing usage, clear policy risk.",
                 whenUse: "Fast domestic payments, banking integration, convenience, low cost.",
                 whenAvoid: "Privacy concerns, state surveillance, policy risk, potential censorship."
             },
@@ -626,7 +626,7 @@
                 examples: { label: "USDC, USDT" },
                 promise: "Global 24/7 operation, dollar stability (1:1 peg), fast and borderless, programmable, DeFi integration.",
                 tradeoff: "Issuer can freeze addresses, redeemability subject to KYC, reserve/issuer risk, centralized control, regulatory capture.",
-                realExample: "USDC Freezes (2023): Circle froze USDC in Tornado Cash-connected wallets. Tether Opacity: $100B+ circulation, repeatedly failed to prove 1:1 backing—systemic failure risk if reserves are fractional.",
+                realExample: "USDC Freezes (2023): Circle froze USDC in Tornado Cash-connected wallets. Tether Opacity: $100B+ circulation, repeatedly failed to prove 1:1 backing, systemic failure risk if reserves are fractional.",
                 whenUse: "Dollar exposure, DeFi access, global transfers, blockchain benefits.",
                 whenAvoid: "Censorship, regulatory capture, reserve audits, counterparty risk."
             },
@@ -656,7 +656,7 @@
                 examples: { label: "Lightning" },
                 promise: "Permissionless, censorship-resistant, fully auditable, immutable supply (21M), consensus robustness.",
                 tradeoff: "UX complexity, volatility, self-responsibility (lost keys = lost funds), Lightning requires liquidity/routing.",
-                realExample: "Bitcoin (2009+): 99.98% uptime since 2009, no transaction ever blocked, hard cap enforced by math. Lightning Network: Instant Bitcoin payments, cheap and private, but requires channel management. Fedimint: Community custody with privacy—balance between self-custody and UX.",
+                realExample: "Bitcoin (2009+): 99.98% uptime since 2009, no transaction ever blocked, hard cap enforced by math. Lightning Network: Instant Bitcoin payments, cheap and private, but requires channel management. Fedimint: Community custody with privacy, balance between self-custody and UX.",
                 whenUse: "Sovereignty, censorship resistance, predictable monetary policy, independence from institutions.",
                 whenAvoid: "Price volatility, technical complexity, self-custody burden, regulatory uncertainty."
             }

--- a/interactive-demos/mining-economics-demo/index.html
+++ b/interactive-demos/mining-economics-demo/index.html
@@ -423,7 +423,7 @@
             });
         });
 
-        // Live data — populated from window.bitcoinData when available; fallbacks if API unreachable
+        // Live data, populated from window.bitcoinData when available; fallbacks if API unreachable
         let liveBtcPrice = 95000;
         let liveNetworkHashrateThs = 700000000; // 700 EH/s = 700,000,000 TH/s (late-2026 estimate)
 
@@ -460,7 +460,7 @@
             const powerConsumption = parseFloat(document.getElementById('power-consumption').value) || 3250;
             const poolFee = currentLevel === 'advanced' ? (parseFloat(document.getElementById('pool-fee').value) || 2) : 2;
 
-            // Network stats — wired to live data via bitcoin-data-reliable.js (fallbacks above)
+            // Network stats, wired to live data via bitcoin-data-reliable.js (fallbacks above)
             const networkHashrate = liveNetworkHashrateThs;
             const blockReward = 3.125;
             const fees = 0.15;
@@ -614,7 +614,7 @@
         <div class="reflect-widget"
              data-topic="mining"
              data-path="curious"
-             data-title="Reflect: Is mining profitable — and for whom?">
+             data-title="Reflect: Is mining profitable, and for whom?">
         </div>
     </div>
     <script src="/js/reflect-widget.js"></script>

--- a/interactive-demos/multisig-setup-wizard/index.html
+++ b/interactive-demos/multisig-setup-wizard/index.html
@@ -623,7 +623,7 @@
         <div class="warning-banner">
             <h3>⚠️ Real Money, Real Consequences</h3>
             <p style="color: var(--text-light); line-height: 1.8;">
-                <strong>$650+ million in Bitcoin has been lost due to poor key management.</strong> This demo shows real cases where multisig saved—or failed to save—people's Bitcoin. Every decision you make has consequences backed by real incidents.
+                <strong>$650+ million in Bitcoin has been lost due to poor key management.</strong> This demo shows real cases where multisig saved, or failed to save, people's Bitcoin. Every decision you make has consequences backed by real incidents.
             </p>
         </div>
 
@@ -1059,8 +1059,8 @@
     <div class="demo-cta-footer"
          data-demo-id="multisig-setup-wizard"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — set up your own-key multisig (you hold every key) without a wrong step", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Build the muscle first: assemble a transaction by hand", "href": "/interactive-demos/transaction-builder/"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, set up your own-key multisig (you hold every key) without a wrong step", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Build the muscle first: assemble a transaction by hand", "href": "/interactive-demos/transaction-builder/"}]'>
     </div>
         <div class="reflect-widget"
              data-topic="custody"

--- a/interactive-demos/network-consensus-demo/index.html
+++ b/interactive-demos/network-consensus-demo/index.html
@@ -318,7 +318,7 @@
                 <li><strong>Sybil Resistance:</strong> One-CPU-one-vote → One-hash-one-vote (computational proof replaces identity)</li>
                 <li><strong>Incentive Compatibility:</strong> Block rewards make honest mining more profitable than attacks</li>
                 <li><strong>Chain Selection:</strong> Longest chain = most accumulated PoW = majority decision</li>
-                <li><strong>Finality Model:</strong> Probabilistic finality — attacker catch-up probability depends on both confirmations z and attacker hashrate share q (Nakamoto whitepaper §11 Poisson race). It is NOT a simple 2<sup>z</sup> ratio: a 10% attacker catches a 6-deep chain ~0.02% of the time, but a 40% attacker catches it ~50% of the time.</li>
+                <li><strong>Finality Model:</strong> Probabilistic finality, attacker catch-up probability depends on both confirmations z and attacker hashrate share q (Nakamoto whitepaper §11 Poisson race). It is NOT a simple 2<sup>z</sup> ratio: a 10% attacker catches a 6-deep chain ~0.02% of the time, but a 40% attacker catches it ~50% of the time.</li>
                 <li><strong>Attack Vector Analysis:</strong> 51% attack requires majority hashrate + willingness to destroy network value</li>
             </ul>
             <p style="margin-top: 1rem;">

--- a/interactive-demos/network-growth-demo/index.html
+++ b/interactive-demos/network-growth-demo/index.html
@@ -295,7 +295,7 @@
             font-size: 1.3rem;
         }
 
-        .advanced-only, .intermediate-only, .beginner-only {
+        .advanced-only .intermediate-only .beginner-only {
             display: block;
         }
 
@@ -470,7 +470,7 @@
                 <div class="formula">
                     Network Value ≈ n² (where n = number of users)
                 </div>
-                <p>The value of a network grows exponentially with the number of users. A network with 10,000 users is not 10x more valuable than one with 1,000 users—it's approximately 100x more valuable.</p>
+                <p>The value of a network grows exponentially with the number of users. A network with 10,000 users is not 10x more valuable than one with 1,000 users, it's approximately 100x more valuable.</p>
 
                 <p style="margin-top: 1.5rem;"><strong>Applied to Bitcoin:</strong></p>
                 <ul>
@@ -674,7 +674,7 @@
             updateSecurityIndicator(metrics.hashrate);
 
             // Store data point
-            dataPoints.push({ year, ...metrics });
+            dataPoints.push({ year ...metrics });
             if (dataPoints.length > 50) {
                 dataPoints.shift();
             }
@@ -779,11 +779,11 @@
             // Draw legend
             ctx.font = 'bold 16px sans-serif';
             ctx.fillStyle = '#FF7A00';
-            ctx.fillText('— Users', 20, 30);
+            ctx.fillText(', Users', 20, 30);
 
             if (currentLevel === 'advanced' || currentLevel === 'intermediate') {
                 ctx.fillStyle = '#4CAF50';
-                ctx.fillText('— Hashrate', 120, 30);
+                ctx.fillText(', Hashrate', 120, 30);
             }
         }
 

--- a/interactive-demos/node-setup-sandbox/index.html
+++ b/interactive-demos/node-setup-sandbox/index.html
@@ -322,7 +322,7 @@
             color: var(--text-light);
         }
 
-        .config-option input,
+        .config-option input
         .config-option select {
             width: 100%;
             padding: 0.75rem;
@@ -469,7 +469,7 @@
         }
 
         /* Checkbox and Radio Styles */
-        .checkbox-option,
+        .checkbox-option
         .radio-option {
             background: var(--primary-dark);
             border: 2px solid var(--border-color);
@@ -480,19 +480,19 @@
             transition: all 0.2s;
         }
 
-        .checkbox-option:hover,
+        .checkbox-option:hover
         .radio-option:hover {
             border-color: var(--primary-orange);
             transform: translateY(-2px);
             box-shadow: 0 4px 12px rgba(255, 122, 0, 0.2);
         }
 
-        .checkbox-option input,
+        .checkbox-option input
         .radio-option input {
             margin-right: 0.75rem;
         }
 
-        .checkbox-option.selected,
+        .checkbox-option.selected
         .radio-option.selected {
             border-color: var(--accent-green);
             background: #16181c;
@@ -552,7 +552,7 @@
         @media (max-width: 768px) {
             h1 { font-size: 2rem; }
             .section { padding: 1.5rem; }
-            .hardware-grid,
+            .hardware-grid
             .scenario-grid {
                 grid-template-columns: 1fr;
             }
@@ -565,8 +565,8 @@
         }
 
         /* Level-specific content visibility */
-        .beginner-only,
-        .intermediate-only,
+        .beginner-only
+        .intermediate-only
         .advanced-only {
             display: block;
         }
@@ -1958,7 +1958,7 @@ rpcallowip=127.0.0.1
   "verificationprogress": 0.9999,
   "chainwork": "000000000000000000000000000000000000000000000000708b6e8e8e8e8e8e"
 }</div>`,
-                    'getpeerinfo': '<div class="terminal-line terminal-output">[ { "id": 1, "addr": "203.0.113.5:8333", "version": 70016 }, ... ]</div>',
+                    'getpeerinfo': '<div class="terminal-line terminal-output">[ { "id": 1, "addr": "203.0.113.5:8333", "version": 70016 } ... ]</div>',
                     'getnetworkinfo': '<div class="terminal-line terminal-output">{ "version": 270000, "subversion": "/Satoshi:27.0.0/", "protocolversion": 70016, "connections": 8 }</div>',
                     'getnewaddress': '<div class="terminal-line terminal-output">bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh</div>',
                     'getwalletinfo': '<div class="terminal-line terminal-output">{ "walletname": "default", "balance": 0.00000000, "txcount": 0 }</div>'
@@ -2046,8 +2046,8 @@ rpcallowip=127.0.0.1
     <div class="demo-cta-footer"
          data-demo-id="node-setup-sandbox"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — verify your own node and stop trusting someone else's", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "See why a node matters: explore the mempool yourself", "href": "/interactive-demos/mempool-visualizer/"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, verify your own node and stop trusting someone else's", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "See why a node matters: explore the mempool yourself", "href": "/interactive-demos/mempool-visualizer/"}]'>
     </div>
         <div class="reflect-widget"
              data-topic="blockchain"

--- a/interactive-demos/onramp-chooser/index.html
+++ b/interactive-demos/onramp-chooser/index.html
@@ -714,8 +714,8 @@
                 font-size: 1rem;
             }
 
-            .start-screen,
-            .question-screen,
+            .start-screen
+            .question-screen
             .results-screen {
                 padding: 1.5rem;
             }
@@ -850,7 +850,7 @@
          data-demo-id="onramp-chooser"
          data-heading="What to do this week"
          data-sub="Pick the track that fits you. Each one is a single concrete action."
-         data-tracks='[{"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit — move from exchange to your own keys with a checklist","href":"/products/self-custody-starter-kit/"},{"audience":"beginner","time":"10 min","action":"Practice a safe first withdrawal on testnet","href":"/interactive-demos/testnet-practice-guide/"}]'>
+         data-tracks='[{"audience":"holder","time":"this week","action":"Get the Self-Custody Starter Kit, move from exchange to your own keys with a checklist","href":"/products/self-custody-starter-kit/"},{"audience":"beginner","time":"10 min","action":"Practice a safe first withdrawal on testnet","href":"/interactive-demos/testnet-practice-guide/"}]'>
     </div>
     <div id="email-capture-page" data-email-capture="page-footer" data-title="📬 Stay Updated" data-subtitle="Get Bitcoin insights and new content announcements. No spam, ever."></div>
     <div id="tip-page" data-tip-cta="compact"></div>

--- a/interactive-demos/sat-stacking-calculator/index.html
+++ b/interactive-demos/sat-stacking-calculator/index.html
@@ -92,7 +92,7 @@
             margin: 2rem 0;
         }
         
-        .input-section, .results-section {
+        .input-section .results-section {
             background: #1a1a1a;
             border-radius: 2px;
             padding: 2rem;
@@ -113,7 +113,7 @@
             font-weight: 500;
         }
         
-        .form-group input, .form-group select {
+        .form-group input .form-group select {
             width: 100%;
             padding: 0.75rem;
             background: #242424;
@@ -123,7 +123,7 @@
             font-size: 1rem;
         }
         
-        .form-group input:focus, .form-group select:focus {
+        .form-group input:focus .form-group select:focus {
             outline: none;
             border-color: #FF7A00;
         }
@@ -750,9 +750,9 @@
                 // Legend
                 ctx.font = '14px sans-serif';
                 ctx.fillStyle = '#FF7A00';
-                ctx.fillText('— Amount Invested', width - 200, 30);
+                ctx.fillText(', Amount Invested', width - 200, 30);
                 ctx.fillStyle = '#00c853';
-                ctx.fillText('— Portfolio Value', width - 200, 50);
+                ctx.fillText(', Portfolio Value', width - 200, 50);
             } catch (error) {
                 console.error('Chart drawing error:', error);
                 // Don't fail silently - chart is optional

--- a/interactive-demos/savings-disappear-scenario/index.html
+++ b/interactive-demos/savings-disappear-scenario/index.html
@@ -546,7 +546,7 @@
                         <strong>Five years later (2025)...</strong>
                     </p>
                     <p class="story-text">
-                        Your savings account statement arrives. You've been diligent — adding $200 every month from your paycheck.
+                        Your savings account statement arrives. You've been diligent, adding $200 every month from your paycheck.
                     </p>
                     <div class="savings-display">
                         <div class="savings-label">Your Savings Account Balance</div>
@@ -811,8 +811,7 @@
                     <div class="dialogue">
                         <span class="speaker">You (to your own child in 2030):</span>
                         "Grandma gave me $50,000 in 2020. The government printed so much money that year,
-                        I knew the dollar was doomed. I chose differently. This is your inheritance —
-                        but it's not just money. It's freedom."
+                        I knew the dollar was doomed. I chose differently. This is your inheritance, but it's not just money. It's freedom."
                     </div>
                 `,
                 learning: [
@@ -821,7 +820,7 @@
                     "Volatility is the price of opting out of fiat currency debasement",
                     "Those who understand monetary history recognize inflation as policy, not accident",
                     "Saving in a deflationary asset (Bitcoin) rewards patience instead of punishing it",
-                    "Your grandmother's mistake wasn't saving — it was saving in a currency designed to lose value"
+                    "Your grandmother's mistake wasn't saving, it was saving in a currency designed to lose value"
                 ]
             },
 
@@ -849,7 +848,7 @@
                 `,
                 learning: [
                     "Taking profits feels good, but understanding the asset is crucial",
-                    "Bitcoin isn't just an investment — it's opting out of fiat debasement",
+                    "Bitcoin isn't just an investment, it's opting out of fiat debasement",
                     "The hardest part isn't buying Bitcoin. It's holding it.",
                     "Short-term thinking (5 years) vs long-term (10+ years) creates 5x difference in outcomes"
                 ]

--- a/interactive-demos/security-dojo-enhanced/index.html
+++ b/interactive-demos/security-dojo-enhanced/index.html
@@ -872,7 +872,7 @@
       box-shadow: 0 0 20px rgba(255, 122, 0, 0.4);
     }
 
-    .beginner-only, .intermediate-only, .advanced-only {
+    .beginner-only .intermediate-only .advanced-only {
       display: block;
     }
 
@@ -955,8 +955,7 @@
 
     <p>
       Stop reading about security. Start practicing it.<br>
-      Answer a few quick questions so we can match you with the right training stations —
-      then work through hands-on scenarios, real attack simulations, and practical exercises.
+      Answer a few quick questions so we can match you with the right training stations, then work through hands-on scenarios, real attack simulations, and practical exercises.
     </p>
 
     <div class="warning-banner">
@@ -2037,7 +2036,7 @@ Failure to verify within 24 hours will result in permanent account closure.<br/>
         multisig: `
           <div class="modal-header">
             <h2><span data-icon="lock"></span> Multi-Sig Workshop</h2>
-            <p>Learn collaborative security with The Bitcoin Adviser — one option designed to reduce single points of failure.</p>
+            <p>Learn collaborative security with The Bitcoin Adviser, one option designed to reduce single points of failure.</p>
           </div>
 
           <div class="modal-section">
@@ -2371,7 +2370,7 @@ Failure to verify within 24 hours will result in permanent account closure.<br/>
                 <li>When in doubt, seek guidance from trusted Bitcoin communities</li>
               </ul>
               <p style="margin-top: 0.75rem; font-style: italic; color: var(--color-muted);">
-                The Bitcoin security landscape changes constantly. Never trust blindly—verify everything.
+                The Bitcoin security landscape changes constantly. Never trust blindly, verify everything.
               </p>
             </div>
 
@@ -2841,8 +2840,8 @@ Failure to verify within 24 hours will result in permanent account closure.<br/>
     <div class="demo-cta-footer"
          data-demo-id="security-dojo-enhanced"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — checklists so the threats you just trained against can't reach you", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Map your real risk surface first", "href": "/interactive-demos/security-risk-simulator.html"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, checklists so the threats you just trained against can't reach you", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Map your real risk surface first", "href": "/interactive-demos/security-risk-simulator.html"}]'>
     </div>
         <div class="reflect-widget"
              data-topic="custody"

--- a/interactive-demos/security-risk-simulator.html
+++ b/interactive-demos/security-risk-simulator.html
@@ -1679,8 +1679,8 @@
     <div class="demo-cta-footer"
          data-demo-id="security-risk-simulator"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — turn 'what could go wrong' into a checklist that prevents it", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "15 min", "action": "Train the reflexes: run the Security Dojo", "href": "/interactive-demos/security-dojo-enhanced/"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, turn 'what could go wrong' into a checklist that prevents it", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "15 min", "action": "Train the reflexes: run the Security Dojo", "href": "/interactive-demos/security-dojo-enhanced/"}]'>
     </div>
 <script src="/js/membership-gate.js"></script>
 

--- a/interactive-demos/sovereign-vault/index.html
+++ b/interactive-demos/sovereign-vault/index.html
@@ -127,7 +127,7 @@
                             <li>Plan for inheritance and emergencies</li>
                             <li>Monitor your overall custody resilience</li>
                         </ul>
-                        <p>Think of it as a secure, encrypted "map" of your custody setup—not the treasure itself.</p>
+                        <p>Think of it as a secure, encrypted "map" of your custody setup, not the treasure itself.</p>
                     </div>
                 </details>
             </div>
@@ -775,7 +775,7 @@
                         <option value="nunchuk">Nunchuk</option>
                         <option value="bluewallet">BlueWallet</option>
                         <option value="core">Bitcoin Core</option>
-                        <option value="caravan">Caravan (archived — historical)</option>
+                        <option value="caravan">Caravan (archived, historical)</option>
                         <option value="other">Other</option>
                     </select>
                 </div>
@@ -804,7 +804,7 @@
                 <div class="form-group">
                     <label for="backup-alias">Location Alias *</label>
                     <input type="text" id="backup-alias" placeholder="e.g., Location Alpha, Home Safe" required="">
-                    <span class="help-text">Use an alias—don't enter the actual address</span>
+                    <span class="help-text">Use an alias, don't enter the actual address</span>
                 </div>
 
                 <div class="form-group">
@@ -1002,11 +1002,11 @@
     <!-- Closing CTA: free vault tool -> paid prevention (Family Bitcoin Recovery Kit). funnel: family-education -->
     <div style="margin-bottom:2rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#f7931a);border-radius:8px;background:rgba(247,147,26,0.06);">
         <h3 style="margin:0 0 .5rem;">Built your vault here? Make it survivable.</h3>
-        <p style="margin:0 0 1.25rem;color:var(--text-dim,#9aa0aa);">A vault only protects your family if they can actually recover it. The <strong>Family Bitcoin Recovery Kit</strong> turns what you just set up into a structured, family-readable recovery plan — tested backups, a clear sequence, and not a single exposed key.</p>
+        <p style="margin:0 0 1.25rem;color:var(--text-dim,#9aa0aa);">A vault only protects your family if they can actually recover it. The <strong>Family Bitcoin Recovery Kit</strong> turns what you just set up into a structured, family-readable recovery plan, tested backups, a clear sequence, and not a single exposed key.</p>
         <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#f7931a);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
-        <p style="margin:1rem 0 0;color:var(--text-dim,#9aa0aa);font-size:.9rem;">Want the bigger picture first? <a href="/deep-dives/jurisdictional-exposure-audit/audit/" style="color:var(--color-brand,#f7931a);">Map your jurisdictional exposure</a> — a free, no-login audit covering custody, family, documents, banking, and jurisdiction.</p>
+        <p style="margin:1rem 0 0;color:var(--text-dim,#9aa0aa);font-size:.9rem;">Want the bigger picture first? <a href="/deep-dives/jurisdictional-exposure-audit/audit/" style="color:var(--color-brand,#f7931a);">Map your jurisdictional exposure</a>, a free, no-login audit covering custody, family, documents, banking, and jurisdiction.</p>
     </div>
-    <div id="email-capture-page" data-email-capture="family-education-vault" data-title="🔐 Protect your family's Bitcoin" data-subtitle="Get our custody &amp; inheritance guides and new content announcements — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
+    <div id="email-capture-page" data-email-capture="family-education-vault" data-title="🔐 Protect your family's Bitcoin" data-subtitle="Get our custody &amp; inheritance guides and new content announcements, for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
     <div id="tip-page" data-tip-cta="compact"></div>
 </div>
 <script src="/js/analytics.js" defer></script>

--- a/interactive-demos/stock-to-flow/index.html
+++ b/interactive-demos/stock-to-flow/index.html
@@ -378,14 +378,14 @@
             --text-dim: #b3b3b3;
         }
 
-        .subtitle, .stat-label, .value-display, .block-time, .formula-box p,
-        .faucet-steps, .coin-age, .address-display small, .timeline-date {
+        .subtitle .stat-label .value-display .block-time .formula-box p
+        .faucet-steps .coin-age .address-display small .timeline-date {
             color: #b3b3b3;
         }
 
         /* Touch Targets - Minimum 44x44px */
-        button, a, [role="button"], input[type="button"], input[type="submit"],
-        .back-btn, .demo-button, .wallet-btn, .control-button, .level-btn {
+        button, a, [role="button"], input[type="button"], input[type="submit"]
+        .back-btn .demo-button .wallet-btn .control-button .level-btn {
             min-height: 44px;
             min-width: 44px;
         }
@@ -458,7 +458,7 @@
                 font-size: 0.85rem;
             }
 
-            .comparison-table th,
+            .comparison-table th
             .comparison-table td {
                 padding: 0.5rem;
             }
@@ -506,7 +506,7 @@
         </header>
 
         <div class="intro-section">
-            <h2>S2F is two things — keep them separate</h2>
+            <h2>S2F is two things, keep them separate</h2>
             <p>
                 <strong>(a) The S2F ratio.</strong> Stock divided by new annual production. Pure math, applies to any commodity.
                 Bitcoin's ratio is well-defined, public, and doubles every halving. Nothing wrong with it.
@@ -520,20 +520,19 @@
             <br>
             <p>
                 Most demos teach (b) without ever flagging that it broke. We'll do (a) properly, then look at
-                (b) honestly — alongside a different model that's still holding up. The point isn't to pick a winner.
+                (b) honestly, alongside a different model that's still holding up. The point isn't to pick a winner.
                 It's to learn how to evaluate models that look convincing.
             </p>
         </div>
 
-        <h2 style="color: var(--primary-orange); margin: 2rem 0 1rem;">Layer 1 — the ratio (math)</h2>
+        <h2 style="color: var(--primary-orange); margin: 2rem 0 1rem;">Layer 1, the ratio (math)</h2>
 
         <div class="concept-grid">
             <div class="concept-card">
                 <span class="concept-icon">📦</span>
                 <h3>Stock</h3>
                 <p>
-                    The total existing supply of an asset. For Bitcoin, this is all BTC mined so far —
-                    currently <strong data-btc-live="supply">~19.86 million BTC</strong>.
+                    The total existing supply of an asset. For Bitcoin, this is all BTC mined so far, currently <strong data-btc-live="supply">~19.86 million BTC</strong>.
                 </p>
             </div>
 
@@ -606,11 +605,11 @@
         </div>
 
         <div class="intro-section">
-            <h2><span data-icon="clock"></span> Halving timeline — the math and the history, kept apart</h2>
+            <h2><span data-icon="clock"></span> Halving timeline, the math and the history, kept apart</h2>
             <p style="color: var(--text-dim); margin-bottom: 1rem; font-size: 0.95rem;">
                 Each row shows the S2F ratio at that halving (a math fact) and what Bitcoin's price did in that
                 era (a history fact). They are not the same thing. Halving schedules have been public since 2009,
-                so any halving-driven move on the announcement date itself is at most a partial surprise — the
+                so any halving-driven move on the announcement date itself is at most a partial surprise, the
                 schedule is already in everyone's spreadsheet.
             </p>
             <div class="halving-timeline">
@@ -652,7 +651,7 @@
             </div>
         </div>
 
-        <h2 style="color: var(--primary-orange); margin: 2rem 0 1rem;">Layer 2 — the price model (and how it broke)</h2>
+        <h2 style="color: var(--primary-orange); margin: 2rem 0 1rem;">Layer 2, the price model (and how it broke)</h2>
 
         <div class="intro-section">
             <h2>Two models, two fates</h2>
@@ -669,7 +668,7 @@
             </p>
             <br>
             <p>
-                Both fit the data through 2020. The chart below shows how each one has done since — against actual price.
+                Both fit the data through 2020. The chart below shows how each one has done since, against actual price.
             </p>
         </div>
 
@@ -695,7 +694,7 @@
             <p style="margin-bottom: 0.5rem;"><strong style="color: var(--primary-orange);">PlanB's S2F model assumes scarcity drives price.</strong> But:</p>
             <ul style="margin-left: 1.5rem; line-height: 1.9; color: var(--text-light);">
                 <li><strong>It's a one-variable model of a multi-driver system.</strong> Bitcoin's price is also moved by interest rates, ETF flows, regulatory regime, narrative cycles, and global liquidity. A single supply-side variable can't capture that.</li>
-                <li><strong>It was fit to ~10 years of history and projected as a law.</strong> No out-of-sample validation. When BitMEX Research reproduced it in 2020, they showed the apparent strength of the fit was driven by the shared upward trend of both variables — a known statistical pitfall (<a href="https://blog.bitmex.com/falsifying-stock-to-flow-as-a-model-of-bitcoin-value/" target="_blank" rel="noopener" style="color: var(--primary-orange);">Falsifying Stock-to-Flow</a>).</li>
+                <li><strong>It was fit to ~10 years of history and projected as a law.</strong> No out-of-sample validation. When BitMEX Research reproduced it in 2020, they showed the apparent strength of the fit was driven by the shared upward trend of both variables, a known statistical pitfall (<a href="https://blog.bitmex.com/falsifying-stock-to-flow-as-a-model-of-bitcoin-value/" target="_blank" rel="noopener" style="color: var(--primary-orange);">Falsifying Stock-to-Flow</a>).</li>
                 <li><strong>Halving schedules have been public since 2009.</strong> Markets price in known information. Post-halving "rallies" are at most partial surprises around an expectations-resolution event, not pure scarcity-driven moves.</li>
             </ul>
             <br>
@@ -703,7 +702,7 @@
             <ul style="margin-left: 1.5rem; line-height: 1.9; color: var(--text-light);">
                 <li><strong>It allows a corridor</strong>, not a single line. Bitcoin spends roughly equal time above and below the central trend, within a factor of ~2–3.</li>
                 <li><strong>It survived 2022.</strong> S2F predicted ~$100k–$288k by end-2021 and didn't recover. The Power Law sat much lower and stayed inside its band.</li>
-                <li><strong>It still might break.</strong> The next halving cycle is its real test. The point isn't that this model is right — it's that as of today, evidence hasn't broken it.</li>
+                <li><strong>It still might break.</strong> The next halving cycle is its real test. The point isn't that this model is right, it's that as of today, evidence hasn't broken it.</li>
             </ul>
             <br>
             <p style="color: var(--text-dim); font-size: 0.9rem;">
@@ -713,10 +712,10 @@
         </div>
 
         <div class="intro-section">
-            <h2><span data-icon="trending-up"></span> Comparing to other assets — six properties, no winners</h2>
+            <h2><span data-icon="trending-up"></span> Comparing to other assets, six properties, no winners</h2>
             <p style="color: var(--text-dim); font-size: 0.9rem; margin-bottom: 1rem;">
                 "Hardness" is too vague to be useful. Below are six concrete properties of money. Different assets win
-                on different ones; no asset wins on all of them. There's no overall verdict — that depends on what you're
+                on different ones; no asset wins on all of them. There's no overall verdict, that depends on what you're
                 using money <em>for</em>.
             </p>
             <div style="overflow-x: auto;">
@@ -740,7 +739,7 @@
                     </tr>
                     <tr>
                         <td><strong>Verifiability</strong><br><small style="color: var(--text-dim);">Can you check it's real, yourself?</small></td>
-                        <td>High<br><small style="color: var(--text-dim);">Run a node — verify supply, signatures, history at zero cost</small></td>
+                        <td>High<br><small style="color: var(--text-dim);">Run a node, verify supply, signatures, history at zero cost</small></td>
                         <td>Moderate<br><small style="color: var(--text-dim);">Density / acid test in hand; tungsten counterfeits exist</small></td>
                         <td>Moderate<br><small style="color: var(--text-dim);">Same as gold; less commonly counterfeited</small></td>
                         <td>Moderate<br><small style="color: var(--text-dim);">Watermarks/UV for cash; bank balance = trust the bank</small></td>
@@ -779,7 +778,7 @@
             <p style="color: var(--text-dim); font-size: 0.85rem; margin-top: 1rem;">
                 Honest read: gold beats Bitcoin on durability and 5,000-year track record. Bitcoin beats gold on
                 portability, divisibility, and verifiability. Fiat beats both on day-to-day liquidity at the cost of
-                supply discipline. There's no asset that wins on every property — that's why money has always been
+                supply discipline. There's no asset that wins on every property, that's why money has always been
                 a portfolio question.
             </p>
         </div>
@@ -789,7 +788,7 @@
             <ul style="margin-left: 1.5rem; line-height: 2;">
                 <li><strong>The S2F ratio is well-defined math.</strong> Bitcoin's S2F doubles at every halving. Nothing controversial.</li>
                 <li><strong>The S2F price model (PlanB) has not tracked since ~2022.</strong> Currently predicts ~10× higher than actual price.</li>
-                <li><strong>The Power Law (Burger) is still inside its corridor</strong> as of April 2026 — but that's not a guarantee about the future.</li>
+                <li><strong>The Power Law (Burger) is still inside its corridor</strong> as of April 2026, but that's not a guarantee about the future.</li>
                 <li><strong>One simple variable rarely explains a multi-driver system.</strong> Both models use one variable; one survived, one didn't. That's information about <em>which variable</em>, not proof either is correct.</li>
                 <li><strong>Halving schedules are public.</strong> Markets price in known events; treat post-halving rallies as expectations-resolution, not pure scarcity miracles.</li>
                 <li><strong>"Hardest money ever" is a slogan, not a measurement.</strong> Bitcoin and gold each win on different concrete properties.</li>
@@ -1109,7 +1108,7 @@
         const PRICE_CACHE_KEY = 'bsa_btc_daily_v2';
         const PRICE_CACHE_TTL = 24 * 60 * 60 * 1000;
         const CC_URL = 'https://min-api.cryptocompare.com/data/v2/histoday?fsym=BTC&tsym=USD&limit=2000';
-        const GENESIS_TS = Date.UTC(2009, 0, 3); // 2009-01-03 — Bitcoin genesis block
+        const GENESIS_TS = Date.UTC(2009, 0, 3); // 2009-01-03, Bitcoin genesis block
         const MS_PER_DAY = 86400000;
         const MS_PER_WEEK = 7 * MS_PER_DAY;
 
@@ -1161,7 +1160,7 @@
             let older = [];
             try { older = await fetchCryptoCompareChunk(earliestSec); } catch (_) {}
             const seen = new Set(); const merged = [];
-            for (const r of [...older, ...recent]) {
+            for (const r of [...older ...recent]) {
                 if (seen.has(r[0])) continue;
                 seen.add(r[0]); merged.push(r);
             }
@@ -1271,7 +1270,7 @@
                 return d;
             };
 
-            // PlanB (purple, dashed) — drawn first so it's behind
+            // PlanB (purple, dashed), drawn first so it's behind
             const planbPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
             planbPath.setAttribute('d', pathFor('planb'));
             planbPath.setAttribute('fill', 'none');
@@ -1289,7 +1288,7 @@
             powerPath.setAttribute('stroke-dasharray', '6,4');
             svg.appendChild(powerPath);
 
-            // Actual (orange, solid) — on top
+            // Actual (orange, solid), on top
             const actualPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
             actualPath.setAttribute('d', pathFor('actual'));
             actualPath.setAttribute('fill', 'none');
@@ -1340,8 +1339,8 @@
                 <p style="margin-bottom: 0.5rem;"><strong>As of ${dateStr}:</strong></p>
                 <ul style="margin-left: 1.5rem;">
                     <li><strong style="color: #FF7A00;">Actual price:</strong> $${fmtUsdRound(latest.actual)}</li>
-                    <li><strong style="color: #e5534b;">PlanB S2F predicts:</strong> $${fmtUsdRound(latest.planb)} (${planbDelta >= 0 ? '+' : ''}${planbDelta.toFixed(0)}% vs actual — ~${planbRatio.toFixed(1)}× off)</li>
-                    <li><strong style="color: #4caf50;">Power Law predicts:</strong> $${fmtUsdRound(latest.powerLaw)} (${powerDelta >= 0 ? '+' : ''}${powerDelta.toFixed(0)}% vs actual — ~${powerRatio.toFixed(1)}× off)</li>
+                    <li><strong style="color: #e5534b;">PlanB S2F predicts:</strong> $${fmtUsdRound(latest.planb)} (${planbDelta >= 0 ? '+' : ''}${planbDelta.toFixed(0)}% vs actual, ~${planbRatio.toFixed(1)}× off)</li>
+                    <li><strong style="color: #4caf50;">Power Law predicts:</strong> $${fmtUsdRound(latest.powerLaw)} (${powerDelta >= 0 ? '+' : ''}${powerDelta.toFixed(0)}% vs actual, ~${powerRatio.toFixed(1)}× off)</li>
                 </ul>
                 <p style="margin-top: 0.75rem; color: var(--text-dim); font-size: 0.9rem;">
                     The Power Law's "off" multiplier sits inside its historical corridor (~factor of 2–3 above or below central).
@@ -1359,7 +1358,7 @@
                 status.style.display = 'none';
             } catch (e) {
                 console.error('Model chart load failed', e);
-                status.textContent = 'Couldn\'t load historical price data from CryptoCompare. The chart needs real data — try refreshing in a minute.';
+                status.textContent = 'Couldn\'t load historical price data from CryptoCompare. The chart needs real data, try refreshing in a minute.';
                 status.style.color = '#ff6b6b';
             }
         }

--- a/interactive-demos/testnet-practice-guide/index.html
+++ b/interactive-demos/testnet-practice-guide/index.html
@@ -244,7 +244,7 @@
             margin: 1rem 0;
         }
 
-        .advanced-only, .intermediate-only, .beginner-only {
+        .advanced-only .intermediate-only .beginner-only {
             display: block;
         }
 
@@ -270,13 +270,13 @@
             --text-dim: #b3b3b3;
         }
 
-        .subtitle, .faucet-steps, small, .step-description {
+        .subtitle .faucet-steps, small .step-description {
             color: #b3b3b3;
         }
 
         /* Touch Targets - Minimum 44x44px */
-        button, a, [role="button"], input[type="button"], input[type="submit"],
-        .wallet-btn, .level-btn, .primary-faucet-btn {
+        button, a, [role="button"], input[type="button"], input[type="submit"]
+        .wallet-btn .level-btn .primary-faucet-btn {
             min-height: 44px;
             min-width: 44px;
         }
@@ -1062,8 +1062,8 @@ bitcoin-cli -testnet estimatesmartfee 6
     <div class="demo-cta-footer"
          data-demo-id="testnet-practice-guide"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — take these drills to mainnet with a checklist at your side", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "First, generate and inspect a key step by step", "href": "/interactive-demos/bitcoin-key-generator-visual/"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, take these drills to mainnet with a checklist at your side", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "First, generate and inspect a key step by step", "href": "/interactive-demos/bitcoin-key-generator-visual/"}]'>
     </div>
         <div class="reflect-widget"
              data-topic="wallets"

--- a/interactive-demos/time-chain-explorer/index.html
+++ b/interactive-demos/time-chain-explorer/index.html
@@ -220,7 +220,7 @@
             --text-dim: #b3b3b3;
         }
 
-        .header p, .countdown-subtitle, .stat-label, .block-time,
+        .header p .countdown-subtitle .stat-label .block-time
         .education-content, small {
             color: #b3b3b3;
         }
@@ -415,7 +415,7 @@
     </div>
 
     <script>
-        // Simulated block data — currentBlockHeight is overwritten with real chain tip on load (fallback if API fails)
+        // Simulated block data, currentBlockHeight is overwritten with real chain tip on load (fallback if API fails)
         let blocks = [];
         let currentBlockHeight = 880000;
         let lastBlockTime = Date.now();

--- a/interactive-demos/time-preference-explorer/index.html
+++ b/interactive-demos/time-preference-explorer/index.html
@@ -420,7 +420,7 @@
             font-size: 0.95rem;
         }
 
-        .input-field input,
+        .input-field input
         .input-field select {
             padding: 0.875rem 1rem;
             background: var(--primary-dark);
@@ -431,7 +431,7 @@
             font-family: inherit;
         }
 
-        .input-field input:focus,
+        .input-field input:focus
         .input-field select:focus {
             outline: none;
             border-color: var(--primary-orange);
@@ -592,8 +592,8 @@
                 text-align: center;
             }
 
-            .choices-grid,
-            .asset-results,
+            .choices-grid
+            .asset-results
             .profile-grid {
                 grid-template-columns: 1fr;
             }
@@ -1401,7 +1401,7 @@
                     <div class="timeline-item">
                         <div class="timeline-year">Now</div>
                         <div class="timeline-event">${outcomes.immediate}</div>
-                        <div class="timeline-value neutral">—</div>
+                        <div class="timeline-value neutral">-</div>
                     </div>
                 `;
             }
@@ -1422,7 +1422,7 @@
                         <div class="timeline-year">10 Years</div>
                         <div class="timeline-event">${outcomes.year10}</div>
                         <div class="timeline-value ${outcomes.financialValue > 5000 ? 'positive' : 'neutral'}">
-                            ${outcomes.financialValue > 0 ? '$' + outcomes.financialValue.toLocaleString() : '—'}
+                            ${outcomes.financialValue > 0 ? '$' + outcomes.financialValue.toLocaleString() : ', '}
                         </div>
                     </div>
                 `;
@@ -1433,7 +1433,7 @@
                         <div class="timeline-year">20 Years</div>
                         <div class="timeline-event">${outcomes.year20}</div>
                         <div class="timeline-value positive">
-                            ${typeof outcomes.financialValue === 'number' && outcomes.financialValue > 10000 ? '$' + (outcomes.financialValue * 2.5).toLocaleString() : '—'}
+                            ${typeof outcomes.financialValue === 'number' && outcomes.financialValue > 10000 ? '$' + (outcomes.financialValue * 2.5).toLocaleString() : ', '}
                         </div>
                     </div>
                 `;

--- a/interactive-demos/transaction-builder/index.html
+++ b/interactive-demos/transaction-builder/index.html
@@ -87,7 +87,7 @@
             font-size: 1.3rem;
         }
 
-        .utxo-input, .output {
+        .utxo-input .output {
             background: rgba(0, 0, 0, 0.3);
             border: 1px solid rgba(255, 122, 0, 0.2);
             border-radius: 10px;
@@ -97,19 +97,19 @@
             color: var(--text-light);
         }
 
-        .utxo-input strong, .output strong {
+        .utxo-input strong .output strong {
             color: var(--text-light);
         }
 
-        .utxo-input small, .output small {
+        .utxo-input small .output small {
             color: var(--text-dim);
         }
 
-        .utxo-input label, .output label {
+        .utxo-input label .output label {
             color: var(--text-light);
         }
 
-        .utxo-input:hover, .output:hover {
+        .utxo-input:hover .output:hover {
             border-color: var(--primary-orange);
         }
 
@@ -118,7 +118,7 @@
             background: rgba(76, 175, 80, 0.1);
         }
 
-        .amount-input, .address-input {
+        .amount-input .address-input {
             width: 100%;
             padding: 0.8rem;
             background: rgba(0, 0, 0, 0.5);
@@ -221,13 +221,13 @@
         /* ===== ACCESSIBILITY ENHANCEMENTS (WCAG 2.1 AA) ===== */
 
         /* Color Contrast - Change dim text from #999 to #b3b3b3 for 4.6:1 ratio */
-        .utxo-input small, .output small {
+        .utxo-input small .output small {
             color: #b3b3b3;
         }
 
         /* Touch Targets - Minimum 44x44px */
-        button, a, [role="button"], input[type="button"], input[type="submit"],
-        .back-btn, .add-output-btn, .build-tx-btn, .utxo-input, .output {
+        button, a, [role="button"], input[type="button"], input[type="submit"]
+        .back-btn .add-output-btn .build-tx-btn .utxo-input .output {
             min-height: 44px;
             min-width: 44px;
         }
@@ -629,8 +629,8 @@ In a real Bitcoin wallet, this would:
     <div class="demo-cta-footer"
          data-demo-id="transaction-builder"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — checklists so every send is a deliberate one", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Map where your coins actually live in the UTXO visualizer", "href": "/interactive-demos/utxo-visualizer-enhanced/"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, checklists so every send is a deliberate one", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Map where your coins actually live in the UTXO visualizer", "href": "/interactive-demos/utxo-visualizer-enhanced/"}]'>
     </div>
         <div class="reflect-widget"
              data-topic="transactions"

--- a/interactive-demos/utxo-visualizer-enhanced/index.html
+++ b/interactive-demos/utxo-visualizer-enhanced/index.html
@@ -413,7 +413,7 @@
             font-weight: 600;
         }
 
-        .control-group input,
+        .control-group input
         .control-group select {
             width: 100%;
             padding: 0.75rem;
@@ -755,13 +755,13 @@
             --text-dim: #b3b3b3;
         }
 
-        .header p, .scenario-description, .objective, small {
+        .header p .scenario-description .objective, small {
             color: #b3b3b3;
         }
 
         /* Touch Targets - Minimum 44x44px */
-        button, a, [role="button"], input[type="button"], input[type="submit"],
-        .back-btn, .utxo-box, .challenge-card {
+        button, a, [role="button"], input[type="button"], input[type="submit"]
+        .back-btn .utxo-box .challenge-card {
             min-height: 44px;
             min-width: 44px;
         }
@@ -1917,8 +1917,8 @@ Fee Calculation:
     <div class="demo-cta-footer"
          data-demo-id="utxo-visualizer-enhanced"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — coin-control and labeling checklists for real wallets", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Practice fee selection on live network data", "href": "/interactive-demos/fee-master-tool/"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, coin-control and labeling checklists for real wallets", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "10 min", "action": "Practice fee selection on live network data", "href": "/interactive-demos/fee-master-tool/"}]'>
     </div>
         <div class="reflect-widget"
              data-topic="transactions"

--- a/interactive-demos/wallet-security-workshop/index.html
+++ b/interactive-demos/wallet-security-workshop/index.html
@@ -263,7 +263,7 @@
             color: var(--text-light);
         }
 
-        .input-group input,
+        .input-group input
         .input-group select {
             width: 100%;
             padding: 0.75rem;
@@ -274,7 +274,7 @@
             font-size: 1rem;
         }
 
-        .input-group input:focus,
+        .input-group input:focus
         .input-group select:focus {
             outline: none;
             border-color: var(--primary-orange);
@@ -438,13 +438,13 @@
             --text-dim: #b3b3b3;
         }
 
-        .header p, small, .node-value, .node-path {
+        .header p, small .node-value .node-path {
             color: #b3b3b3;
         }
 
         /* Touch Targets - Minimum 44x44px */
-        button, a, [role="button"], input[type="button"], input[type="submit"],
-        .btn, .level-btn, .tab, .backup-word {
+        button, a, [role="button"], input[type="button"], input[type="submit"]
+        .btn .level-btn .tab .backup-word {
             min-height: 44px;
             min-width: 44px;
         }
@@ -455,8 +455,8 @@
             outline-offset: 2px;
         }
 
-        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible,
-        .tab:focus-visible, .backup-word:focus-visible {
+        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
+        .tab:focus-visible .backup-word:focus-visible {
             outline: 3px solid var(--primary-orange, #FF7A00);
             outline-offset: 4px;
             box-shadow: 0 0 0 4px rgba(255, 122, 0, 0.2);
@@ -519,15 +519,15 @@
         color: var(--text-dim); text-transform: uppercase;
         letter-spacing: 0.06em; margin-bottom: 0.3rem;
     }
-    .rp-field select,
-    .rp-field input[type="text"],
+    .rp-field select
+    .rp-field input[type="text"]
     .rp-field input[type="date"] {
         width: 100%; padding: 0.6rem 0.85rem;
         border: 1.5px solid var(--border-color); border-radius: 8px;
         background: rgba(0,0,0,0.35); color: var(--text-light);
         font-size: 0.92rem; transition: border-color 0.2s;
     }
-    .rp-field select:focus,
+    .rp-field select:focus
     .rp-field input:focus { outline: none; border-color: var(--primary-orange); }
 
     .rp-grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.85rem; }
@@ -703,7 +703,7 @@
         <header class="header">
             <h1><span data-icon="lock"></span> Bitcoin Wallet Security Workshop</h1>
             <div class="tip-box" style="margin: 1rem auto 1.5rem; max-width: 800px; background: rgba(255, 122, 0, 0.1); border-left-color: var(--primary-orange);">
-                <strong>🎯 Mission:</strong> This workshop teaches you how one Bitcoin wallet works and how to back it up correctly. Learn seed generation, backup verification, and address derivation—the foundation of self-custody.
+                <strong>🎯 Mission:</strong> This workshop teaches you how one Bitcoin wallet works and how to back it up correctly. Learn seed generation, backup verification, and address derivation, the foundation of self-custody.
             </div>
             <p class="beginner-only">Learn how Bitcoin wallets work and practice security in a safe environment</p>
             <p class="intermediate-only">Master seed phrases, derivation paths, and wallet security best practices</p>
@@ -955,7 +955,7 @@
                     <div class="security-dropdown-content" id="essentials-content" style="display: none;">
                         <ul style="line-height: 2; margin: 1rem 0 1rem 1.5rem;">
                             <li>✅ <strong>Store seed phrases offline</strong> on paper or metal backups</li>
-                            <li>✅ <strong>Never share your seed phrase</strong> with anyone—not even "support"</li>
+                            <li>✅ <strong>Never share your seed phrase</strong> with anyone, not even "support"</li>
                             <li>✅ <strong>Use hardware wallets</strong> for amounts you can't afford to lose</li>
                             <li>✅ <strong>Verify addresses</strong> character-by-character before sending funds</li>
                             <li>✅ <strong>Test backups with small amounts</strong> first before large transfers</li>
@@ -1020,8 +1020,8 @@
                     <p>To crack a 12-word seed by brute force would take billions of years with current technology.</p>
 
                     <div class="tip-box" style="margin-top:1.25rem;">
-                        <strong>🔑 The Passphrase (25th Word) — What it actually does</strong><br><br>
-                        A BIP39 passphrase is not just extra security — it creates an <em>entirely different wallet</em>. The same seed phrase with two different passphrases produces two completely different sets of addresses with separate balances.<br><br>
+                        <strong>🔑 The Passphrase (25th Word), What it actually does</strong><br><br>
+                        A BIP39 passphrase is not just extra security, it creates an <em>entirely different wallet</em>. The same seed phrase with two different passphrases produces two completely different sets of addresses with separate balances.<br><br>
                         <strong>Practical uses:</strong>
                         <ul style="margin:0.5rem 0 0 1.5rem; line-height:1.8;">
                             <li><strong>Plausible deniability:</strong> Keep a small "decoy" balance on the seed alone. Hide the real funds behind the passphrase wallet.</li>
@@ -1031,8 +1031,8 @@
                     </div>
 
                     <div class="tip-box" style="margin-top:1rem; background:rgba(255,152,0,0.1); border-left-color:#ff9800;">
-                        <strong>⚠️ UTXO Hygiene — Why it matters for privacy</strong><br><br>
-                        A UTXO (Unspent Transaction Output) is like a bill in your wallet. When you spend, your wallet combines UTXOs to meet the amount — and this can link addresses together on the public blockchain.<br><br>
+                        <strong>⚠️ UTXO Hygiene, Why it matters for privacy</strong><br><br>
+                        A UTXO (Unspent Transaction Output) is like a bill in your wallet. When you spend, your wallet combines UTXOs to meet the amount, and this can link addresses together on the public blockchain.<br><br>
                         <strong>Coin control</strong> lets you choose which UTXOs to spend, preventing unintended address linking. Available in Sparrow, Electrum, and advanced mobile wallets.<br><br>
                         <em>Example:</em> If you received Bitcoin from an exchange and from a private sale, spending both together reveals to chain analysis that the same person controls both addresses.
                     </div>
@@ -1058,7 +1058,7 @@
 
                 <!-- Derivation Paths Deep Dive -->
                 <h3>🗂️ Understanding Derivation Paths</h3>
-                <p style="margin-bottom: 1rem;">Derivation paths are not advanced Bitcoin trivia—they are the <strong>index system of your money</strong>. Understanding them prevents recovery panic.</p>
+                <p style="margin-bottom: 1rem;">Derivation paths are not advanced Bitcoin trivia, they are the <strong>index system of your money</strong>. Understanding them prevents recovery panic.</p>
 
                 <div class="security-dropdown" style="margin-bottom: 1rem;">
                     <button class="security-dropdown-header" onclick="toggleSecurityDropdown('path-evolution')">
@@ -1070,24 +1070,24 @@
                         
                         <div style="margin: 1.5rem 0;">
                             <div style="padding: 1rem; background: rgba(255,255,255,0.05); border-radius: 0.5rem; margin-bottom: 0.75rem; border-left: 3px solid #9e9e9e;">
-                                <strong>Legacy (m/44')</strong> — Addresses start with <code>1</code><br>
+                                <strong>Legacy (m/44')</strong>: Addresses start with <code>1</code><br>
                                 <span style="color: var(--text-dim);">Oldest style. Works everywhere but higher fees, less efficient.</span>
                             </div>
                             <div style="padding: 1rem; background: rgba(255,255,255,0.05); border-radius: 0.5rem; margin-bottom: 0.75rem; border-left: 3px solid #2196F3;">
-                                <strong>SegWit Wrapped (m/49')</strong> — Addresses start with <code>3</code><br>
+                                <strong>SegWit Wrapped (m/49')</strong>: Addresses start with <code>3</code><br>
                                 <span style="color: var(--text-dim);">Transition step. Better fees, backward compatible.</span>
                             </div>
                             <div style="padding: 1rem; background: rgba(255,255,255,0.05); border-radius: 0.5rem; margin-bottom: 0.75rem; border-left: 3px solid var(--accent-green);">
-                                <strong>Native SegWit (m/84')</strong> — Addresses start with <code>bc1q</code><br>
+                                <strong>Native SegWit (m/84')</strong>: Addresses start with <code>bc1q</code><br>
                                 <span style="color: var(--text-dim);">Lower fees, cleaner design. Today's most common default.</span>
                             </div>
                             <div style="padding: 1rem; background: rgba(255,255,255,0.05); border-radius: 0.5rem; border-left: 3px solid var(--primary-orange);">
-                                <strong>Taproot (m/86')</strong> — Addresses start with <code>bc1p</code><br>
+                                <strong>Taproot (m/86')</strong>: Addresses start with <code>bc1p</code><br>
                                 <span style="color: var(--text-dim);">More privacy and flexibility. Still newer, not all tools support it fully.</span>
                             </div>
                         </div>
                         
-                        <p style="font-style: italic; color: var(--text-dim);">Wallets did not "change their minds"—they adopted new standards as Bitcoin evolved. That's why an older wallet, a newer wallet, and a multisig coordinator may all use different paths by default.</p>
+                        <p style="font-style: italic; color: var(--text-dim);">Wallets did not "change their minds", they adopted new standards as Bitcoin evolved. That's why an older wallet, a newer wallet, and a multisig coordinator may all use different paths by default.</p>
                     </div>
                 </div>
 
@@ -1148,7 +1148,7 @@
                             Same key material. Different location.</p>
                         </div>
                         
-                        <p style="margin-top: 1rem;">That's why multisig setups always document: script type, derivation paths, and policy rules. This is not paranoia—it's coordination.</p>
+                        <p style="margin-top: 1rem;">That's why multisig setups always document: script type, derivation paths, and policy rules. This is not paranoia, it's coordination.</p>
                     </div>
                 </div>
 
@@ -1224,23 +1224,23 @@ Multisig: 2-of-3</pre>
                         <li>Lose the seed → funds are <strong>gone forever</strong></li>
                         <li>Lose the path → funds are <strong>hidden but recoverable</strong></li>
                     </ul>
-                    <p style="margin-top: 1rem;">Only one is irreversible. Bitcoin does not forget—wallets just need to know where to look.</p>
+                    <p style="margin-top: 1rem;">Only one is irreversible. Bitcoin does not forget, wallets just need to know where to look.</p>
                 </div>
 
                 <!-- Configuration Files Deep Dive -->
                 <h3>📄 Configuration Files &amp; Wallet Backups</h3>
-                <p style="margin-bottom:1rem;">Beyond the seed phrase, wallets produce several configuration files that are critical for recovery — especially for multisig. Knowing what they are and where to store them is as important as knowing your derivation path.</p>
+                <p style="margin-bottom:1rem;">Beyond the seed phrase, wallets produce several configuration files that are critical for recovery, especially for multisig. Knowing what they are and where to store them is as important as knowing your derivation path.</p>
 
                 <div class="security-dropdown" style="margin-bottom:1rem;">
                     <button class="security-dropdown-header" onclick="toggleSecurityDropdown('cfg-descriptor')">
                         <span class="dropdown-icon" id="cfg-descriptor-icon">▶</span>
-                        <strong>Output Descriptors — The Most Important Config</strong>
+                        <strong>Output Descriptors, The Most Important Config</strong>
                     </button>
                     <div class="security-dropdown-content" id="cfg-descriptor-content" style="display:none;">
                         <p>An <strong>output descriptor</strong> is a compact string that completely describes your wallet: script type, derivation path, and public key fingerprint. For multisig, it includes all co-signers' keys. Without it, recovering a multisig wallet from seeds alone is extremely difficult.</p>
 
                         <p style="margin:1rem 0 0.5rem;"><strong>Single-signature native SegWit:</strong></p>
-                        <div class="config-block"><span class="cfg-c"># Wallet descriptor — safe to store, does NOT expose funds</span>
+                        <div class="config-block"><span class="cfg-c"># Wallet descriptor, safe to store, does NOT expose funds</span>
 <span class="cfg-k">wpkh</span>([<span class="cfg-v">a1b2c3d4</span>/84h/0h/0h]<span class="cfg-v">xpub6C...abc</span>/0/*)</div>
                         <p style="font-size:0.88rem; color:var(--text-dim);">Components: <code>wpkh</code> = script type · <code>a1b2c3d4</code> = master key fingerprint · <code>/84h/0h/0h</code> = derivation path · <code>xpub...</code> = extended public key</p>
 
@@ -1261,10 +1261,10 @@ Multisig: 2-of-3</pre>
                 <div class="security-dropdown" style="margin-bottom:1rem;">
                     <button class="security-dropdown-header" onclick="toggleSecurityDropdown('cfg-sparrow')">
                         <span class="dropdown-icon" id="cfg-sparrow-icon">▶</span>
-                        <strong>Sparrow Wallet Files — What to Back Up</strong>
+                        <strong>Sparrow Wallet Files, What to Back Up</strong>
                     </button>
                     <div class="security-dropdown-content" id="cfg-sparrow-content" style="display:none;">
-                        <p>Sparrow saves a <code>.json</code> wallet file that contains the descriptor, address labels, and transaction history — but <strong>never your seed phrase or private keys</strong>.</p>
+                        <p>Sparrow saves a <code>.json</code> wallet file that contains the descriptor, address labels, and transaction history, but <strong>never your seed phrase or private keys</strong>.</p>
                         <div class="config-block"><span class="cfg-c"># Sparrow wallet file structure (simplified)</span>
 {
   <span class="cfg-k">"name"</span>: <span class="cfg-v">"My Cold Storage"</span>,
@@ -1284,7 +1284,7 @@ Multisig: 2-of-3</pre>
                 <div class="security-dropdown" style="margin-bottom:1rem;">
                     <button class="security-dropdown-header" onclick="toggleSecurityDropdown('cfg-xpub')">
                         <span class="dropdown-icon" id="cfg-xpub-icon">▶</span>
-                        <strong>xpub / ypub / zpub — What the Prefix Means</strong>
+                        <strong>xpub / ypub / zpub, What the Prefix Means</strong>
                     </button>
                     <div class="security-dropdown-content" id="cfg-xpub-content" style="display:none;">
                         <p>Extended public keys (xpubs) contain the same underlying key data. The prefix only signals the <em>intended script type</em> to wallet software. This causes frequent confusion during recovery.</p>
@@ -1307,7 +1307,7 @@ Multisig: 2-of-3</pre>
                             </div>
                         </div>
                         <div class="tip-box" style="background:rgba(255,152,0,0.1); border-left-color:#ff9800;">
-                            <strong>⚠️ Wallet software may reject an xpub expecting a zpub.</strong> Tools like Sparrow let you convert between formats. If recovery fails with "unrecognized key format," this is usually the cause — the key is fine, the prefix needs changing.
+                            <strong>⚠️ Wallet software may reject an xpub expecting a zpub.</strong> Tools like Sparrow let you convert between formats. If recovery fails with "unrecognized key format," this is usually the cause, the key is fine, the prefix needs changing.
                         </div>
                     </div>
                 </div>
@@ -1315,12 +1315,12 @@ Multisig: 2-of-3</pre>
                 <div class="security-dropdown" style="margin-bottom:1.5rem;">
                     <button class="security-dropdown-header" onclick="toggleSecurityDropdown('cfg-node')">
                         <span class="dropdown-icon" id="cfg-node-icon">▶</span>
-                        <strong>bitcoin.conf — Running Your Own Node</strong>
+                        <strong>bitcoin.conf, Running Your Own Node</strong>
                         <span class="advanced-only" style="margin-left:auto; font-size:0.75rem; background:rgba(255, 122, 0,0.2); color:#FF7A00; padding:0.2rem 0.5rem; border-radius:10px; border:1px solid #FF7A00; font-weight:600;">Advanced</span>
                     </button>
                     <div class="security-dropdown-content" id="cfg-node-content" style="display:none;">
                         <p>Running Bitcoin Core gives you full sovereignty: you verify every transaction yourself instead of trusting someone else's server. The <code>bitcoin.conf</code> file controls how your node behaves.</p>
-                        <div class="config-block"><span class="cfg-c"># bitcoin.conf — stored in your Bitcoin data directory</span>
+                        <div class="config-block"><span class="cfg-c"># bitcoin.conf, stored in your Bitcoin data directory</span>
 <span class="cfg-c"># Location: ~/.bitcoin/bitcoin.conf  (Linux/Mac)</span>
 <span class="cfg-c">#           %APPDATA%\Bitcoin\bitcoin.conf  (Windows)</span>
 
@@ -1328,7 +1328,7 @@ Multisig: 2-of-3</pre>
 <span class="cfg-k">server</span>=<span class="cfg-v">1</span>           <span class="cfg-c"># Enable RPC server so wallets can connect</span>
 <span class="cfg-k">rpcbind</span>=<span class="cfg-v">127.0.0.1</span> <span class="cfg-c"># Only listen on localhost (never expose to internet)</span>
 <span class="cfg-k">rpcuser</span>=<span class="cfg-v">youruser</span>  <span class="cfg-c"># Set a unique RPC username</span>
-<span class="cfg-k">rpcpassword</span>=<span class="cfg-v">...</span>   <span class="cfg-c"># Strong random password — keep this secret</span>
+<span class="cfg-k">rpcpassword</span>=<span class="cfg-v">...</span>   <span class="cfg-c"># Strong random password, keep this secret</span>
 
 <span class="cfg-c"># Optional: prune to save disk space (cannot use txindex with prune)</span>
 <span class="cfg-c"># prune=550</span>
@@ -1355,7 +1355,7 @@ Multisig: 2-of-3</pre>
         <div id="recovery-plan" class="tab-content">
             <div class="card">
                 <h2>🛡️ Recovery &amp; Inheritance Plan</h2>
-                <p style="color: var(--text-dim); margin-bottom: 1.5rem; line-height: 1.7;">Map every wallet, exchange, and key location so you — or a trusted person — can recover your Bitcoin under any circumstances. Fill in locations only. Never record seed words or private keys in this tool.</p>
+                <p style="color: var(--text-dim); margin-bottom: 1.5rem; line-height: 1.7;">Map every wallet, exchange, and key location so you, or a trusted person, can recover your Bitcoin under any circumstances. Fill in locations only. Never record seed words or private keys in this tool.</p>
 
                 <!-- Progress Bar -->
                 <div class="rp-progress-wrap">
@@ -1388,7 +1388,7 @@ Multisig: 2-of-3</pre>
                         <span style="margin-left:auto; font-size:0.75rem; color:var(--text-dim); font-weight:400;">Blue Wallet · Muun · Sparrow · etc.</span>
                     </button>
                     <div class="security-dropdown-content" id="rp-software-content" style="display:none;">
-                        <p style="font-size:0.88rem; color:var(--text-dim); margin-bottom:1rem;">Each entry should fully describe how to recreate that wallet from scratch — seed location, script type, derivation path.</p>
+                        <p style="font-size:0.88rem; color:var(--text-dim); margin-bottom:1rem;">Each entry should fully describe how to recreate that wallet from scratch, seed location, script type, derivation path.</p>
                         <div id="software-entries"></div>
                         <button class="btn-add-entry" onclick="addRpEntry('software')">+ Add Software Wallet</button>
                     </div>
@@ -1420,7 +1420,7 @@ Multisig: 2-of-3</pre>
                             <div class="rp-field">
                                 <label>Multisig Policy</label>
                                 <select onchange="rpUpdateProgress()">
-                                    <option value="">— select —</option>
+                                    <option value="">Select</option>
                                     <option value="2of3">2-of-3</option>
                                     <option value="3of5">3-of-5</option>
                                     <option value="2of2">2-of-2</option>
@@ -1431,7 +1431,7 @@ Multisig: 2-of-3</pre>
                             <div class="rp-field">
                                 <label>Coordinator Software</label>
                                 <select onchange="rpUpdateProgress()">
-                                    <option value="">— select —</option>
+                                    <option value="">Select</option>
                                     <option value="sparrow">Sparrow Wallet</option>
                                     <option value="nunchuk">Nunchuk</option>
                                     <option value="specter">Specter Desktop</option>
@@ -1447,7 +1447,7 @@ Multisig: 2-of-3</pre>
                         <div class="rp-field" style="margin-top:0.25rem;">
                             <label>Collaborative Security Provider</label>
                             <select onchange="rpShowConditionalSelect(this,'rp-collab-detail')">
-                                <option value="">None — fully self-custody</option>
+                                <option value="">None, fully self-custody</option>
                                 <option value="unchained">Unchained Capital</option>
                                 <option value="theya">Theya</option>
                                 <option value="casa">Casa</option>
@@ -1483,17 +1483,17 @@ Multisig: 2-of-3</pre>
                     <div class="security-dropdown-content" id="rp-seeds-content" style="display:none;">
                         <p style="font-size:0.88rem; color:var(--text-dim); margin-bottom:1rem;">Record <strong style="color:var(--text-light);">locations only</strong>. Never enter actual seed words anywhere digitally.</p>
                         <div class="rp-grid-2">
-                            <div class="rp-field"><label>Seed / Key 1 — Label</label><input type="text" placeholder="e.g. Coldcard main seed" oninput="rpUpdateProgress()" /></div>
-                            <div class="rp-field"><label>Seed / Key 1 — Physical Location</label><input type="text" placeholder="e.g. Home safe, top shelf" oninput="rpUpdateProgress()" /></div>
-                            <div class="rp-field"><label>Seed / Key 2 — Label</label><input type="text" placeholder="e.g. Trezor backup" oninput="rpUpdateProgress()" /></div>
-                            <div class="rp-field"><label>Seed / Key 2 — Physical Location</label><input type="text" placeholder="e.g. Safety deposit box, Bank A" oninput="rpUpdateProgress()" /></div>
-                            <div class="rp-field"><label>Seed / Key 3 — Label</label><input type="text" placeholder="e.g. Cosigner C" oninput="rpUpdateProgress()" /></div>
-                            <div class="rp-field"><label>Seed / Key 3 — Physical Location</label><input type="text" placeholder="e.g. Attorney office" oninput="rpUpdateProgress()" /></div>
+                            <div class="rp-field"><label>Seed / Key 1, Label</label><input type="text" placeholder="e.g. Coldcard main seed" oninput="rpUpdateProgress()" /></div>
+                            <div class="rp-field"><label>Seed / Key 1, Physical Location</label><input type="text" placeholder="e.g. Home safe, top shelf" oninput="rpUpdateProgress()" /></div>
+                            <div class="rp-field"><label>Seed / Key 2, Label</label><input type="text" placeholder="e.g. Trezor backup" oninput="rpUpdateProgress()" /></div>
+                            <div class="rp-field"><label>Seed / Key 2, Physical Location</label><input type="text" placeholder="e.g. Safety deposit box, Bank A" oninput="rpUpdateProgress()" /></div>
+                            <div class="rp-field"><label>Seed / Key 3, Label</label><input type="text" placeholder="e.g. Cosigner C" oninput="rpUpdateProgress()" /></div>
+                            <div class="rp-field"><label>Seed / Key 3, Physical Location</label><input type="text" placeholder="e.g. Attorney office" oninput="rpUpdateProgress()" /></div>
                         </div>
                         <div class="rp-field" style="margin-top:0.25rem;">
                             <label>Seed Backup Format</label>
                             <select onchange="rpUpdateProgress()">
-                                <option value="">— select all that apply in notes —</option>
+                                <option value="">Select all that apply in notes</option>
                                 <option value="paper">Paper (hand-written)</option>
                                 <option value="metal">Metal plate / stamped steel</option>
                                 <option value="cryptosteel">Cryptosteel / Bilodeau</option>
@@ -1503,7 +1503,7 @@ Multisig: 2-of-3</pre>
                             </select>
                         </div>
                         <p style="font-size:0.85rem; font-weight:700; margin:1rem 0 0.5rem; text-transform:uppercase; letter-spacing:0.05em;">Physical Security Checklist</p>
-                        <label class="rp-check"><input type="checkbox" onchange="rpUpdateProgress()" /><span>Metal backup present — fire and water resistant</span></label>
+                        <label class="rp-check"><input type="checkbox" onchange="rpUpdateProgress()" /><span>Metal backup present, fire and water resistant</span></label>
                         <label class="rp-check"><input type="checkbox" onchange="rpUpdateProgress()" /><span>Fire-resistant storage location confirmed</span></label>
                         <label class="rp-check"><input type="checkbox" onchange="rpUpdateProgress()" /><span>Seeds stored in geographically separate locations</span></label>
                         <label class="rp-check"><input type="checkbox" onchange="rpUpdateProgress()" /><span>Tamper-evident packaging used</span></label>
@@ -1568,10 +1568,10 @@ Multisig: 2-of-3</pre>
                         </div>
 
                         <div style="margin-top:1rem; padding:1rem 1.25rem; background:rgba(0,0,0,0.35); border:2px solid var(--accent-red); border-radius:8px;">
-                            <strong style="color:var(--accent-red);">⚠️ Critical — read before touching any funds:</strong>
+                            <strong style="color:var(--accent-red);">⚠️ Critical, read before touching any funds:</strong>
                             <ul style="margin:0.5rem 0 0 1.5rem; line-height:1.9; font-size:0.9rem;">
                                 <li>Never type a seed phrase into any website, app, or computer unless guided by a verified Bitcoin professional in person</li>
-                                <li>No legitimate company will ask you to "verify" or "recover" a seed phrase to release funds — that is a scam</li>
+                                <li>No legitimate company will ask you to "verify" or "recover" a seed phrase to release funds, that is a scam</li>
                                 <li>When in doubt, wait and consult the trusted advisor listed in Step 1 before taking any action</li>
                             </ul>
                         </div>
@@ -1581,7 +1581,7 @@ Multisig: 2-of-3</pre>
                 <!-- Export -->
                 <div style="text-align:center; padding-top:0.5rem; border-top:1px solid var(--border-color); margin-top:0.5rem;">
                     <button class="btn shell-outline-btn" style="max-width:320px; margin-top:1.25rem;" onclick="exportRecoveryPlan()">📋 Export Summary as Text File</button>
-                    <p style="font-size:0.78rem; color:var(--text-dim); margin-top:0.5rem;">Exports labels and locations only — never seed phrases or private keys.</p>
+                    <p style="font-size:0.78rem; color:var(--text-dim); margin-top:0.5rem;">Exports labels and locations only, never seed phrases or private keys.</p>
                 </div>
             </div>
         </div>
@@ -2308,14 +2308,14 @@ Multisig: 2-of-3</pre>
         // ===== HELP MODAL =====
         const HELP_CONTENT = {
             '2fa': {
-                title: '2FA — Two-Factor Authentication',
+                title: '2FA, Two-Factor Authentication',
                 body: `<p>2FA adds a second layer of protection. Even if your password is stolen, the attacker still can't get in without your second factor.</p>
                 <div class="help-example"><strong>Security ranking (best → worst):</strong><br>
-                1. Hardware Key (YubiKey, Titan Key) — physical device, cannot be phished<br>
-                2. Authenticator App (Aegis, Google Authenticator, Raivo) — generates 6-digit codes<br>
-                3. Email 2FA — better than nothing<br>
-                4. SMS — avoid if possible (SIM swap attacks)</div>
-                <p><strong>Recommended:</strong> Use <strong>Aegis</strong> (Android) or <strong>Raivo OTP</strong> (iOS). When setting up, save the original QR code offline — that's your backup.</p>
+                1. Hardware Key (YubiKey, Titan Key), physical device, cannot be phished<br>
+                2. Authenticator App (Aegis, Google Authenticator, Raivo), generates 6-digit codes<br>
+                3. Email 2FA, better than nothing<br>
+                4. SMS, avoid if possible (SIM swap attacks)</div>
+                <p><strong>Recommended:</strong> Use <strong>Aegis</strong> (Android) or <strong>Raivo OTP</strong> (iOS). When setting up, save the original QR code offline, that's your backup.</p>
                 <div class="help-warn-box">⚠ SMS 2FA can be bypassed via SIM swap: a scammer calls your carrier, transfers your number to their phone, then resets all accounts. Exchanges like Coinbase and Kraken have been targeted this way.</div>`
             },
             'withdrawal-test': {
@@ -2324,81 +2324,81 @@ Multisig: 2-of-3</pre>
                 <div class="help-example"><strong>How to test (takes 10 minutes):</strong><br>
                 1. Send a small amount ($10–$20) from the exchange to your own wallet address<br>
                 2. Confirm it arrives at the correct address in your wallet app<br>
-                3. Note the date — document this in your recovery plan<br><br>
+                3. Note the date, document this in your recovery plan<br><br>
                 <strong>Real example:</strong> On Coinbase, go to Send/Receive → Send → paste your Sparrow or Blue Wallet receive address → send $15 → verify arrival within ~10 minutes.</div>
                 <div class="help-warn-box">⚠ Some platforms (Venmo, PayPal) restrict or delay withdrawals. Others require KYC re-verification. Find out before you need to withdraw under pressure.</div>`
             },
             'backup-codes': {
                 title: '2FA Backup Codes',
-                body: `<p>When you set up 2FA on an exchange, you receive one-time backup codes — use these if you lose your phone.</p>
+                body: `<p>When you set up 2FA on an exchange, you receive one-time backup codes, use these if you lose your phone.</p>
                 <div class="help-example"><strong>Best practice:</strong><br>
                 • Print them immediately, seal in an envelope, store with your other paper documents<br>
                 • Do NOT save as a phone screenshot, cloud note, or email draft<br>
-                • Treat them like a spare house key — secure but accessible to you</div>
+                • Treat them like a spare house key, secure but accessible to you</div>
                 <p><strong>Where to find them:</strong> On Coinbase: Settings → Security → 2-Step Verification → Backup codes. On Kraken: Security → Two-Factor Authentication → Recovery codes.</p>
                 <div class="help-warn-box">⚠ If you lose your phone AND your backup codes, account recovery can take weeks and requires identity verification. Some users have permanently lost access.</div>`
             },
             'auth-recovery': {
                 title: 'Authenticator App Recovery',
                 body: `<p>If your phone is lost or wiped, you need a way to restore your 6-digit code generator.</p>
-                <div class="help-example"><strong>Aegis (Android) — recommended:</strong><br>
+                <div class="help-example"><strong>Aegis (Android), recommended:</strong><br>
                 Settings → Backups → Export encrypted backup. Store file + decryption password separately.<br><br>
                 <strong>Google Authenticator:</strong> Settings → Transfer accounts → Export. Screenshot the QR code and store offline.<br><br>
                 <strong>Authy:</strong> Enable "Allow Multi-Device" during setup for easy restore to a new phone.</div>
                 <p><strong>Best practice:</strong> When adding 2FA to any service, photograph or write down the original setup QR code / seed string. Store it securely offline. This lets you add it to any authenticator app from scratch.</p>`
             },
             'script-type': {
-                title: 'Script Types — What Kind of Bitcoin Address?',
+                title: 'Script Types, What Kind of Bitcoin Address?',
                 body: `<p>The script type determines your address format and transaction fee cost. Different wallets default to different types.</p>
-                <div class="help-example"><strong>Native SegWit — p2wpkh</strong> → Address starts with <strong>bc1q...</strong><br>
+                <div class="help-example"><strong>Native SegWit, p2wpkh</strong> → Address starts with <strong>bc1q...</strong><br>
                 Best for single-sig. Lowest fees. Default in Sparrow, Blue Wallet, Coldcard Q.<br><br>
-                <strong>Taproot — p2tr</strong> → Address starts with <strong>bc1p...</strong><br>
+                <strong>Taproot, p2tr</strong> → Address starts with <strong>bc1p...</strong><br>
                 Newest standard. Better privacy. Use in Sparrow Taproot mode or Coldcard latest firmware.<br><br>
-                <strong>SegWit Wrapped — p2sh-p2wpkh</strong> → Address starts with <strong>3...</strong><br>
+                <strong>SegWit Wrapped, p2sh-p2wpkh</strong> → Address starts with <strong>3...</strong><br>
                 Older SegWit format. Higher fees than Native SegWit. Used by some older wallets.<br><br>
-                <strong>Multisig SegWit — p2wsh</strong> → Address starts with <strong>bc1q...</strong> (longer)<br>
+                <strong>Multisig SegWit, p2wsh</strong> → Address starts with <strong>bc1q...</strong> (longer)<br>
                 Required for multisig setups (2-of-3). Needs m/48' derivation path.<br><br>
-                <strong>Legacy — p2pkh</strong> → Address starts with <strong>1...</strong><br>
+                <strong>Legacy, p2pkh</strong> → Address starts with <strong>1...</strong><br>
                 Original Bitcoin format. Highest fees. Only use if required for compatibility.</div>
                 <p><strong>Recommendation:</strong> Native SegWit (p2wpkh) for single-sig. Multisig SegWit (p2wsh) for multisig.</p>`
             },
             'deriv-path': {
-                title: 'Derivation Paths — Where Are Your Keys?',
+                title: 'Derivation Paths, Where Are Your Keys?',
                 body: `<p>Your 12 or 24 seed words can generate billions of different wallets. The derivation path specifies which wallet to use.</p>
                 <div class="help-example"><strong>Standard paths and what they produce:</strong><br>
-                m/44'/0'/0' → Legacy (1...) addresses — BIP44<br>
-                m/49'/0'/0' → SegWit Wrapped (3...) — BIP49<br>
-                m/84'/0'/0' → Native SegWit (bc1q...) — BIP84 — most common today<br>
-                m/86'/0'/0' → Taproot (bc1p...) — BIP86 — newest<br>
-                m/48'/0'/0'/2' → Multisig Native SegWit — BIP48<br>
-                m/48'/0'/0'/3' → Multisig Taproot — BIP48</div>
-                <p>The same 12/24 words with the wrong path appears as an empty wallet — your funds are safe, you just need to use the correct path. This is why recording it is essential.</p>
+                m/44'/0'/0' → Legacy (1...) addresses, BIP44<br>
+                m/49'/0'/0' → SegWit Wrapped (3...), BIP49<br>
+                m/84'/0'/0' → Native SegWit (bc1q...), BIP84, most common today<br>
+                m/86'/0'/0' → Taproot (bc1p...), BIP86, newest<br>
+                m/48'/0'/0'/2' → Multisig Native SegWit, BIP48<br>
+                m/48'/0'/0'/3' → Multisig Taproot, BIP48</div>
+                <p>The same 12/24 words with the wrong path appears as an empty wallet, your funds are safe, you just need to use the correct path. This is why recording it is essential.</p>
                 <div class="help-warn-box">⚠ If you restore in Sparrow and see no balance, check the derivation path. Try m/84' if you originally used Native SegWit. Most hardware wallets default to m/84' for single-sig.</div>`
             },
             'passphrase': {
-                title: 'Passphrase — The 25th Word',
+                title: 'Passphrase, The 25th Word',
                 body: `<p>An optional BIP39 passphrase creates an entirely different wallet from the same seed words. Think of it as a second password layered on top of your seed.</p>
                 <div class="help-example"><strong>How it works:</strong><br>
                 • Your 24 words alone → <strong>Wallet A</strong> (keep a small decoy amount here)<br>
                 • Your 24 words + passphrase "horse$Battery7" → <strong>Wallet B</strong> (your real savings)<br><br>
                 <strong>Wallets that support it:</strong> Coldcard (Q and Mk4), Trezor Safe 3/Safe 5, Sparrow Wallet, Blue Wallet (advanced), Electrum</div>
                 <p><strong>Plausible deniability:</strong> If you're forced to reveal your seed, an attacker only finds Wallet A. Your real funds in Wallet B remain hidden.</p>
-                <div class="help-warn-box">⚠ CRITICAL: Forget the passphrase = lose the Bitcoin. It cannot be recovered. Store it separately from your seed phrase — never together. Consider stamping it on a separate metal plate.</div>`
+                <div class="help-warn-box">⚠ CRITICAL: Forget the passphrase = lose the Bitcoin. It cannot be recovered. Store it separately from your seed phrase, never together. Consider stamping it on a separate metal plate.</div>`
             },
             'seed-location': {
                 title: 'Seed Phrase Storage Best Practices',
                 body: `<p>Your 12 or 24 seed words are the master key. Anyone who finds them can take your Bitcoin.</p>
                 <div class="help-example"><strong>Storage ranked best → worst:</strong><br>
-                ✓ Metal plate (Cryptosteel, SteelWallet, OneKey KeyTag) — fireproof + waterproof<br>
-                ✓ Laminated paper in a fireproof safe — fine for smaller amounts<br>
-                ✗ Unprotected paper — burns, degrades, gets wet<br>
-                ✗ Phone notes, cloud, email, Dropbox — one breach = total loss<br>
-                ✗ Photo on your phone — if phone is stolen or iCloud is hacked, funds gone</div>
+                ✓ Metal plate (Cryptosteel, SteelWallet, OneKey KeyTag), fireproof + waterproof<br>
+                ✓ Laminated paper in a fireproof safe, fine for smaller amounts<br>
+                ✗ Unprotected paper, burns, degrades, gets wet<br>
+                ✗ Phone notes, cloud, email, Dropbox, one breach = total loss<br>
+                ✗ Photo on your phone, if phone is stolen or iCloud is hacked, funds gone</div>
                 <p><strong>Geographic separation:</strong> Keep copies in two different physical locations (home safe + trusted family safe deposit box). One disaster can't destroy both.</p>
-                <p><strong>Rule:</strong> Never store your seed and passphrase together. They are two separate keys — separated, neither is useful alone.</p>`
+                <p><strong>Rule:</strong> Never store your seed and passphrase together. They are two separate keys, separated, neither is useful alone.</p>`
             },
             'descriptor': {
-                title: 'Output Descriptors — Critical for Multisig',
+                title: 'Output Descriptors, Critical for Multisig',
                 body: `<p>An output descriptor precisely describes your wallet's key structure. For single-sig, it's optional but helpful. For multisig, it is essential for recovery.</p>
                 <div class="help-example"><strong>Single-sig example (Sparrow Native SegWit):</strong><br>
                 <code>wpkh([a1b2c3d4/84'/0'/0']xpub6Ebb...)</code><br><br>
@@ -2408,21 +2408,21 @@ Multisig: 2-of-3</pre>
                 <div class="help-warn-box">⚠ For multisig: WITHOUT the descriptor, you cannot reconstruct the wallet even with ALL seed phrases. The descriptor records which exact keys form the quorum. Treat it as a third key.</div>`
             },
             'restore-test': {
-                title: 'Testing Your Backup — Restore Test',
+                title: 'Testing Your Backup, Restore Test',
                 body: `<p>The only way to confirm your backup works is to actually test it before you need it in an emergency.</p>
                 <div class="help-example"><strong>Safe hardware wallet test (takes ~15 min):</strong><br>
                 1. Note your wallet's first receive address (the bc1q... or bc1p... shown in your wallet app)<br>
                 2. Wipe the device: Settings → Factory Reset / Wipe Device<br>
                 3. Choose "Restore from seed" and enter your 12/24 words<br>
-                4. Check that the same first receive address appears — if it matches, backup is valid ✓<br><br>
-                <strong>Coldcard shortcut:</strong> Advanced → Seed Tools → Verify Seed — checks without wiping.</div>
+                4. Check that the same first receive address appears, if it matches, backup is valid ✓<br><br>
+                <strong>Coldcard shortcut:</strong> Advanced → Seed Tools → Verify Seed, checks without wiping.</div>
                 <p><strong>Recommended frequency:</strong> Once a year, after any hardware upgrade, or after moving to a new home.</p>`
             },
             'multisig-policy': {
-                title: 'Multisig Policies — M-of-N Explained',
+                title: 'Multisig Policies, M-of-N Explained',
                 body: `<p>Multisig requires M signatures from N total keys to authorize any transaction. Designed and maintained correctly, this reduces single points of failure.</p>
                 <div class="help-example"><strong>Common configurations:</strong><br>
-                <strong>2-of-3:</strong> 3 keys exist, any 2 are needed. Lose 1 key — still fine. Attacker needs 2 different devices — much harder.<br><br>
+                <strong>2-of-3:</strong> 3 keys exist, any 2 are needed. Lose 1 key, still fine. Attacker needs 2 different devices, much harder.<br><br>
                 <strong>3-of-5:</strong> 5 keys, 3 required. Better for institutional or large amounts.<br><br>
                 <strong>2-of-2:</strong> Both keys always required. Maximum control, but lose one = lose access forever.</div>
                 <p><strong>Recommended setup:</strong> 2-of-3 with Coldcard (home) + Trezor (office or safe deposit box) + Jade (trusted family or collaborative custodian)</p>
@@ -2432,10 +2432,10 @@ Multisig: 2-of-3</pre>
                 title: 'Collaborative Security',
                 body: `<p>A company holds one key in your multisig setup while you hold the others. In this model you hold the majority of keys yourself.</p>
                 <div class="help-example"><strong>Services:</strong><br>
-                <strong>Unchained Capital:</strong> You hold 2 keys, they hold 1. Requires ID verification. Cannot steal from you — ever.<br><br>
+                <strong>Unchained Capital:</strong> You hold 2 keys, they hold 1. Requires ID verification. Cannot steal from you, ever.<br><br>
                 <strong>Casa:</strong> Multiple tiers. Mobile-first. Designed for easy recovery if you lose one of your keys.<br><br>
                 <strong>Theya:</strong> Simple 2-of-3, beginner-friendly guided setup. Good starting point.</div>
-                <p>Unlike an exchange, you always retain majority signing power. The company's key assists with inheritance or key recovery — not with day-to-day spending.</p>
+                <p>Unlike an exchange, you always retain majority signing power. The company's key assists with inheritance or key recovery, not with day-to-day spending.</p>
                 <div class="help-warn-box">⚠ This is NOT the same as keeping Bitcoin on an exchange. With collaborative security (often marketed as collaborative custody), the company cannot unilaterally move your funds. Choose a company with a strong reputation and transparent key management.</div>`
             },
             'metal-backup': {
@@ -2446,11 +2446,11 @@ Multisig: 2-of-3</pre>
                 <strong>SteelWallet:</strong> Compact plate + letter punch. ~$30. DIY.<br>
                 <strong>OneKey KeyTag:</strong> Laser-engraved. ~$25. Budget option.<br>
                 <strong>DIY:</strong> Stainless steel sheet + alphabet stamps from hardware store. ~$15.</div>
-                <p><strong>Tip:</strong> You only need the first 4 letters of each BIP39 word — every word in the official wordlist is uniquely identified by its first 4 characters. Saves space on your plate.</p>`
+                <p><strong>Tip:</strong> You only need the first 4 letters of each BIP39 word, every word in the official wordlist is uniquely identified by its first 4 characters. Saves space on your plate.</p>`
             },
             'wallet-type': {
                 title: 'Single-Sig vs Multisig',
-                body: `<p>Single signature: one seed phrase controls everything. Simple, but one point of failure — one stolen seed means all funds lost.</p>
+                body: `<p>Single signature: one seed phrase controls everything. Simple, but one point of failure, one stolen seed means all funds lost.</p>
                 <p>Multisig: M keys from N total must sign every transaction. No single seed or device theft is sufficient to steal funds.</p>
                 <div class="help-example"><strong>Single-sig is best when:</strong><br>
                 • You're learning Bitcoin for the first time<br>
@@ -2502,7 +2502,7 @@ Multisig: 2-of-3</pre>
                     <div class="rp-field">
                         <label>Platform</label>
                         <select onchange="rpOther(this,'rpex-o-${id}'); rpUpdateProgress()">
-                            <option value="">— select —</option>
+                            <option value="">Select</option>
                             <option>Coinbase</option><option>Cash App</option><option>Venmo</option>
                             <option>Kraken</option><option>Gemini</option><option>Strike</option>
                             <option>River</option><option>Swan Bitcoin</option><option>Bisq (P2P)</option>
@@ -2519,10 +2519,10 @@ Multisig: 2-of-3</pre>
                     <div class="rp-field">
                         <label>2FA Method <button class="help-btn" onclick="showHelp('2fa')" title="What is 2FA?">?</button></label>
                         <select onchange="rpUpdateProgress()">
-                            <option value="">— select —</option>
+                            <option value="">Select</option>
                             <option>Authenticator App (Aegis, Google Auth, Raivo)</option>
                             <option>Hardware Key (YubiKey, Titan)</option>
-                            <option>SMS — not recommended</option>
+                            <option>SMS, not recommended</option>
                             <option>Email 2FA</option>
                             <option>None</option>
                         </select>
@@ -2562,7 +2562,7 @@ Multisig: 2-of-3</pre>
                     <div class="rp-field">
                         <label>Wallet Software</label>
                         <select onchange="rpOther(this,'rpsw-o-${id}'); rpUpdateProgress()">
-                            <option value="">— select —</option>
+                            <option value="">Select</option>
                             <option>Blue Wallet</option><option>Aqua</option><option>Muun</option>
                             <option>Theya</option><option>Sparrow Wallet</option><option>Electrum</option>
                             <option>Nunchuk</option><option>Phoenix (Lightning)</option>
@@ -2583,24 +2583,24 @@ Multisig: 2-of-3</pre>
                     <div class="rp-field">
                         <label>Script Type <button class="help-btn" onclick="showHelp('script-type')" title="What is a script type?">?</button></label>
                         <select id="rpsw-script-${id}" onchange="rpCheckPairById('sw','${id}'); rpUpdateProgress()">
-                            <option value="">— select —</option>
-                            <option>Native SegWit — p2wpkh (bc1q...)</option>
-                            <option>Taproot — p2tr (bc1p...)</option>
-                            <option>SegWit Wrapped — p2sh-p2wpkh (3...)</option>
-                            <option>Multisig SegWit — p2wsh</option>
-                            <option>Legacy — p2pkh (1...)</option>
+                            <option value="">Select</option>
+                            <option>Native SegWit, p2wpkh (bc1q...)</option>
+                            <option>Taproot, p2tr (bc1p...)</option>
+                            <option>SegWit Wrapped, p2sh-p2wpkh (3...)</option>
+                            <option>Multisig SegWit, p2wsh</option>
+                            <option>Legacy, p2pkh (1...)</option>
                         </select>
                     </div>
                     <div class="rp-field">
                         <label>Derivation Path <button class="help-btn" onclick="showHelp('deriv-path')" title="What is a derivation path?">?</button></label>
                         <select id="rpsw-pathsel-${id}" onchange="rpCheckPairById('sw','${id}'); rpOther(this,'rpsw-pathother-${id}'); rpUpdateProgress()">
-                            <option value="">— select —</option>
-                            <option>m/84'/0'/0' — Native SegWit (default)</option>
-                            <option>m/86'/0'/0' — Taproot</option>
-                            <option>m/49'/0'/0' — SegWit Wrapped</option>
-                            <option>m/48'/0'/0'/2' — Multisig Native SegWit</option>
-                            <option>m/48'/0'/0'/3' — Multisig Taproot</option>
-                            <option>m/44'/0'/0' — Legacy</option>
+                            <option value="">Select</option>
+                            <option>m/84'/0'/0', Native SegWit (default)</option>
+                            <option>m/86'/0'/0', Taproot</option>
+                            <option>m/49'/0'/0', SegWit Wrapped</option>
+                            <option>m/48'/0'/0'/2', Multisig Native SegWit</option>
+                            <option>m/48'/0'/0'/3', Multisig Taproot</option>
+                            <option>m/44'/0'/0', Legacy</option>
                             <option value="other">Custom</option>
                         </select>
                         <div class="rp-conditional" id="rpsw-pathother-${id}">
@@ -2615,7 +2615,7 @@ Multisig: 2-of-3</pre>
                 </label>
                 <div class="rp-conditional" id="rpsw-pass-${id}">
                     <div class="rp-field"><label>Passphrase Stored At (location only)</label>
-                        <input type="text" placeholder="Never the passphrase itself — location only" oninput="rpUpdateProgress()" />
+                        <input type="text" placeholder="Never the passphrase itself, location only" oninput="rpUpdateProgress()" />
                     </div>
                 </div>
                 <div class="rp-field" style="margin-top:0.5rem;">
@@ -2624,7 +2624,7 @@ Multisig: 2-of-3</pre>
                 </div>
                 <div class="rp-conditional" id="rpsw-desc-${id}">
                     <div class="rp-field"><label>Wallet Descriptor / Output Descriptor Stored At <button class="help-btn" onclick="showHelp('descriptor')" title="What is an output descriptor?">?</button></label>
-                        <input type="text" placeholder="Required for multisig recovery — location of descriptor file" oninput="rpUpdateProgress()" />
+                        <input type="text" placeholder="Required for multisig recovery, location of descriptor file" oninput="rpUpdateProgress()" />
                     </div>
                 </div>
             </div>`;
@@ -2640,7 +2640,7 @@ Multisig: 2-of-3</pre>
                     <div class="rp-field">
                         <label>Device</label>
                         <select onchange="rpOther(this,'rphw-o-${id}'); rpUpdateProgress()">
-                            <option value="">— select —</option>
+                            <option value="">Select</option>
                             <option>Coldcard Q</option><option>Coldcard Mk4</option>
                             <option>Trezor Safe 5</option><option>Trezor Safe 3</option>
                             <option>Blockstream Jade</option><option>Ledger Nano X</option>
@@ -2655,29 +2655,29 @@ Multisig: 2-of-3</pre>
                     <div class="rp-field">
                         <label>Used As <button class="help-btn" onclick="showHelp('wallet-type')" title="Single-sig vs Multisig">?</button></label>
                         <select onchange="rpToggleDesc(this,'rphw-desc-${id}'); rpUpdateProgress()">
-                            <option value="single">Single Signature — standalone</option>
+                            <option value="single">Single Signature, standalone</option>
                             <option value="multi">Multisig cosigner</option>
                         </select>
                     </div>
                     <div class="rp-field">
                         <label>Script Type <button class="help-btn" onclick="showHelp('script-type')" title="What is a script type?">?</button></label>
                         <select id="rphw-script-${id}" onchange="rpCheckPairById('hw','${id}'); rpUpdateProgress()">
-                            <option value="">— select —</option>
-                            <option>Native SegWit — p2wpkh (bc1q...)</option>
-                            <option>Taproot — p2tr (bc1p...)</option>
-                            <option>Multisig SegWit — p2wsh</option>
-                            <option>SegWit Wrapped — p2sh-p2wpkh (3...)</option>
+                            <option value="">Select</option>
+                            <option>Native SegWit, p2wpkh (bc1q...)</option>
+                            <option>Taproot, p2tr (bc1p...)</option>
+                            <option>Multisig SegWit, p2wsh</option>
+                            <option>SegWit Wrapped, p2sh-p2wpkh (3...)</option>
                         </select>
                     </div>
                     <div class="rp-field">
                         <label>Derivation Path <button class="help-btn" onclick="showHelp('deriv-path')" title="What is a derivation path?">?</button></label>
                         <select id="rphw-pathsel-${id}" onchange="rpCheckPairById('hw','${id}'); rpOther(this,'rphw-pathother-${id}'); rpUpdateProgress()">
-                            <option value="">— select —</option>
-                            <option>m/84'/0'/0' — Native SegWit</option>
-                            <option>m/86'/0'/0' — Taproot</option>
-                            <option>m/48'/0'/0'/2' — Multisig Native SegWit</option>
-                            <option>m/48'/0'/0'/3' — Multisig Taproot</option>
-                            <option>m/44'/0'/0' — Legacy</option>
+                            <option value="">Select</option>
+                            <option>m/84'/0'/0', Native SegWit</option>
+                            <option>m/86'/0'/0', Taproot</option>
+                            <option>m/48'/0'/0'/2', Multisig Native SegWit</option>
+                            <option>m/48'/0'/0'/3', Multisig Taproot</option>
+                            <option>m/44'/0'/0', Legacy</option>
                             <option value="other">Custom</option>
                         </select>
                         <div class="rp-conditional" id="rphw-pathother-${id}">
@@ -2694,7 +2694,7 @@ Multisig: 2-of-3</pre>
                         </label>
                         <div class="rp-conditional" id="rphw-pass-${id}">
                             <div class="rp-field"><label>Passphrase Stored At</label>
-                                <input type="text" placeholder="Location only — never the passphrase itself" oninput="rpUpdateProgress()" />
+                                <input type="text" placeholder="Location only, never the passphrase itself" oninput="rpUpdateProgress()" />
                             </div>
                         </div>
                     </div>
@@ -2709,7 +2709,7 @@ Multisig: 2-of-3</pre>
                 </div>
                 <div class="rp-conditional" id="rphw-desc-${id}">
                     <div class="rp-field"><label>Wallet Descriptor / Wallet File Stored At <button class="help-btn" onclick="showHelp('descriptor')" title="What is an output descriptor?">?</button></label>
-                        <input type="text" placeholder="Required for multisig — location of descriptor file" oninput="rpUpdateProgress()" />
+                        <input type="text" placeholder="Required for multisig, location of descriptor file" oninput="rpUpdateProgress()" />
                     </div>
                 </div>
             </div>`;
@@ -2769,7 +2769,7 @@ Multisig: 2-of-3</pre>
             const expectedPrefix = { p2wpkh: "m/84'", p2tr: "m/86'", 'p2sh-p2wpkh': "m/49'", p2wsh: "m/48'", p2pkh: "m/44'" };
             const correctPath   = { p2wpkh: "m/84'/0'/0'", p2tr: "m/86'/0'/0'", 'p2sh-p2wpkh': "m/49'/0'/0'", p2wsh: "m/48'/0'/0'/2' or /3'", p2pkh: "m/44'/0'/0'" };
             const friendlyName  = { p2wpkh: 'Native SegWit (p2wpkh)', p2tr: 'Taproot (p2tr)', 'p2sh-p2wpkh': 'SegWit Wrapped (p2sh-p2wpkh)', p2wsh: 'Multisig (p2wsh)', p2pkh: 'Legacy (p2pkh)' };
-            const addrExample   = { p2wpkh: 'bc1q... addresses — used by Sparrow & Coldcard by default.', p2tr: 'bc1p... addresses — newest standard.', 'p2sh-p2wpkh': '3... addresses — older SegWit format.', p2wsh: 'multisig bc1q... addresses.', p2pkh: '1... addresses — highest fees.' };
+            const addrExample   = { p2wpkh: 'bc1q... addresses, used by Sparrow & Coldcard by default.', p2tr: 'bc1p... addresses, newest standard.', 'p2sh-p2wpkh': '3... addresses, older SegWit format.', p2wsh: 'multisig bc1q... addresses.', p2pkh: '1... addresses, highest fees.' };
             if (p.startsWith(expectedPrefix[scriptKey])) {
                 return { cls: 'ok', msg: '✓ Correct pairing. Produces ' + addrExample[scriptKey] };
             }
@@ -2832,7 +2832,7 @@ Multisig: 2-of-3</pre>
                     });
                 });
                 // Section-level fields (not inside entries)
-                sec.querySelectorAll('.security-dropdown-content > .rp-field, .security-dropdown-content > .rp-grid-2 .rp-field').forEach(field => {
+                sec.querySelectorAll('.security-dropdown-content > .rp-field .security-dropdown-content > .rp-grid-2 .rp-field').forEach(field => {
                     if (field.closest('.rp-entry') || field.offsetParent === null) return;
                     const lbl = field.querySelector('label');
                     const inp = field.querySelector('input[type="text"], input[type="date"], select');
@@ -2848,7 +2848,7 @@ Multisig: 2-of-3</pre>
             });
             lines.push('\n' + '='.repeat(44));
             lines.push('Generated: ' + new Date().toLocaleString());
-            lines.push('REMINDER: This file contains locations only — never seed phrases or private keys.');
+            lines.push('REMINDER: This file contains locations only, never seed phrases or private keys.');
             lines.push('Store this file securely. Delete from cloud/email after printing.');
             const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
             const url = URL.createObjectURL(blob);
@@ -2930,8 +2930,8 @@ Multisig: 2-of-3</pre>
     <div class="demo-cta-footer"
          data-demo-id="wallet-security-workshop"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
-         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit — the full hardening checklist behind this workshop", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "15 min", "action": "Pressure-test your instincts in the Security Dojo", "href": "/interactive-demos/security-dojo-enhanced/"}]'>
+         data-sub="One paid path, one free path, pick the next concrete step."
+         data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit, the full hardening checklist behind this workshop", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "15 min", "action": "Pressure-test your instincts in the Security Dojo", "href": "/interactive-demos/security-dojo-enhanced/"}]'>
     </div>
         <div class="reflect-widget"
              data-topic="custody"

--- a/interactive-demos/wallet-workshop/index.html
+++ b/interactive-demos/wallet-workshop/index.html
@@ -169,9 +169,9 @@
             margin: 0;
         }
 
-        .recommended-badge,
-        .new-badge,
-        .compatible-badge,
+        .recommended-badge
+        .new-badge
+        .compatible-badge
         .old-badge {
             padding: 0.25rem 0.75rem;
             border-radius: 12px;
@@ -286,7 +286,7 @@
             margin-bottom: 0.5rem;
         }
 
-        .node-value,
+        .node-value
         .node-path {
             font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);
             font-size: 0.85rem;
@@ -409,13 +409,13 @@
             margin-bottom: 1rem;
         }
 
-        .learned-list,
+        .learned-list
         .next-list {
             list-style: none;
             padding: 0;
         }
 
-        .learned-list li,
+        .learned-list li
         .next-list li {
             padding: 0.5rem 0;
         }
@@ -467,7 +467,7 @@
             justify-content: center;
         }
 
-        .path-select,
+        .path-select
         .address-select {
             width: 100%;
             padding: 0.75rem;
@@ -690,14 +690,14 @@
         /* ===== ACCESSIBILITY ENHANCEMENTS (WCAG 2.1 AA) ===== */
 
         /* Color Contrast - Change dim text from muted to #b3b3b3 for 4.6:1 ratio */
-        .header p, .summary-value, .tech-details, .curve-explanation,
+        .header p .summary-value .tech-details .curve-explanation
         .step-arrow, small {
             color: #b3b3b3;
         }
 
         /* Touch Targets - Minimum 44x44px */
-        button, a, [role="button"], input[type="button"], input[type="submit"],
-        .back-btn, .action-btn, .address-type-card {
+        button, a, [role="button"], input[type="button"], input[type="submit"]
+        .back-btn .action-btn .address-type-card {
             min-height: 44px;
             min-width: 44px;
         }
@@ -708,7 +708,7 @@
             outline-offset: 2px;
         }
 
-        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible,
+        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible
         .address-type-card:focus-visible {
             outline: 3px solid var(--primary-orange, #FF7A00);
             outline-offset: 4px;
@@ -732,8 +732,8 @@
         }
 
         @media (max-width: 768px) {
-            .comparison-grid,
-            .one-way-demo,
+            .comparison-grid
+            .one-way-demo
             .format-comparison {
                 grid-template-columns: 1fr;
             }
@@ -800,12 +800,12 @@
             <h2 style="color: var(--primary-orange); margin-bottom: 1rem;">💭 What is a Bitcoin Wallet?</h2>
             
             <p style="font-size: 1.1rem; line-height: 1.8; margin-bottom: 1.5rem;">
-                <strong>A Bitcoin wallet is NOT a physical container.</strong> Your Bitcoin doesn't "live" anywhere—it exists as entries on the blockchain that everyone can see.
+                <strong>A Bitcoin wallet is NOT a physical container.</strong> Your Bitcoin doesn't "live" anywhere, it exists as entries on the blockchain that everyone can see.
             </p>
             
             <div style="background: rgba(255, 122, 0, 0.1); border-left: 4px solid var(--primary-orange); padding: 1.5rem; border-radius: 8px; margin: 1.5rem 0;">
                 <strong style="color: var(--primary-orange); font-size: 1.1rem;">A wallet is actually a key manager:</strong><br><br>
-                It stores your <strong>private keys</strong>—the secret passwords that let you spend Bitcoin associated with your addresses.
+                It stores your <strong>private keys</strong>: the secret passwords that let you spend Bitcoin associated with your addresses.
             </div>
 
             <div class="comparison-grid" style="margin-top: 2rem;">
@@ -827,7 +827,7 @@
             <div style="background: rgba(33, 150, 243, 0.1); border-left: 4px solid #2196F3; padding: 1.5rem; border-radius: 8px; margin-bottom: 2rem;">
                 <strong style="color: #2196F3; font-size: 1.1rem;">The Golden Rule:</strong><br><br>
                 <p style="font-size: 1.1rem;">"<strong>Get your Bitcoin off exchanges.</strong>"<br>
-If you don't control the private keys (the seed words), you don't actually own the Bitcoin—someone else does.</p>
+If you don't control the private keys (the seed words), you don't actually own the Bitcoin, someone else does.</p>
             </div>
 
             <h3 style="color: var(--text-light); margin-top: 2rem; margin-bottom: 1rem;">How to Recognize Each Type:</h3>
@@ -1054,7 +1054,7 @@ If you don't control the private keys (the seed words), you don't actually own t
                         <li style="margin-top: 1rem;"><strong>Generate and write seed words</strong><br>
                             <span style="color: var(--text-dim); font-size: 0.95rem;">• Device generates 12 or 24 words<br>
                             • Write on recovery card or paper included<br>
-                            • Some devices (Coldcard) never show seed on screen—extra security</span>
+                            • Some devices (Coldcard) never show seed on screen, extra security</span>
                         </li>
                         <li style="margin-top: 1rem;"><strong>Verify seed words</strong><br>
                             <span style="color: var(--text-dim); font-size: 0.95rem;">• Device asks you to confirm words in random order<br>
@@ -1068,12 +1068,12 @@ If you don't control the private keys (the seed words), you don't actually own t
                         <li style="margin-top: 1rem;"><strong>Test recovery process</strong><br>
                             <span style="color: var(--text-dim); font-size: 0.95rem;">• Send small test amount<br>
                             • Reset device and restore from seed words<br>
-                            • Verify funds reappear—confirms backup works</span>
+                            • Verify funds reappear, confirms backup works</span>
                         </li>
                     </ol>
 
                     <div style="background: rgba(33, 150, 243, 0.1); border-left: 4px solid #2196F3; padding: 1.5rem; border-radius: 8px; margin-top: 2rem;">
-                        <strong style="color: #2196F3;">💡 Pro Tip:</strong> Many people buy 2 hardware wallets of the same model—one for daily use, one as backup. Both can hold the same seed for redundancy.
+                        <strong style="color: #2196F3;">💡 Pro Tip:</strong> Many people buy 2 hardware wallets of the same model, one for daily use, one as backup. Both can hold the same seed for redundancy.
                     </div>
                 </div>
             </details>
@@ -1100,7 +1100,7 @@ If you don't control the private keys (the seed words), you don't actually own t
                             <span style="color: var(--text-dim); font-size: 0.95rem;">• Usually "Import wallet" or "Restore wallet"</span>
                         </li>
                         <li style="margin-top: 1rem;"><strong>Enter your seed words in order</strong><br>
-                            <span style="color: var(--text-dim); font-size: 0.95rem;">• Type carefully—some wallets autocomplete from BIP39 wordlist<br>
+                            <span style="color: var(--text-dim); font-size: 0.95rem;">• Type carefully, some wallets autocomplete from BIP39 wordlist<br>
                             • Must be EXACT order: word 1, word 2, etc.</span>
                         </li>
                         <li style="margin-top: 1rem;"><strong>Wait for sync</strong><br>
@@ -1128,7 +1128,7 @@ If you don't control the private keys (the seed words), you don't actually own t
                                 <li>Screenshot or photograph seed</li>
                                 <li>Store in cloud (Google Drive, iCloud, Dropbox)</li>
                                 <li>Email to yourself</li>
-                                <li>Store in password manager (controversial—some disagree)</li>
+                                <li>Store in password manager (controversial, some disagree)</li>
                                 <li>Share with anyone, including "support"</li>
                             </ul>
                         </div>
@@ -1154,11 +1154,11 @@ If you don't control the private keys (the seed words), you don't actually own t
             <div style="margin-top: 2rem; padding: 1.5rem; background: rgba(33, 150, 243, 0.1); border-radius: 12px;">
                 <h4 style="color: #2196F3; margin-bottom: 1rem;">📚 Recommended Learning Path:</h4>
                 <ol style="line-height: 2; margin-left: 1.5rem; text-align: left;">
-                    <li><strong>Interactive Wallet Workshop</strong> — Play with entropy, see HD derivation, explore address types (hands-on!)</li>
-                    <li><strong>Wallet Security Workshop</strong> — Generate real seeds, practice backups, verify addresses</li>
-                    <li><strong>Security Training Lab</strong> — Train through hands-on security stations and earn belts</li>
-                    <li><strong>UTXO Visualizer</strong> — Understand how transactions actually work</li>
-                    <li><strong>Emergency Kit</strong> — Know what to do when things go wrong</li>
+                    <li><strong>Interactive Wallet Workshop</strong>: Play with entropy, see HD derivation, explore address types (hands-on!)</li>
+                    <li><strong>Wallet Security Workshop</strong>: Generate real seeds, practice backups, verify addresses</li>
+                    <li><strong>Security Training Lab</strong>: Train through hands-on security stations and earn belts</li>
+                    <li><strong>UTXO Visualizer</strong>: Understand how transactions actually work</li>
+                    <li><strong>Emergency Kit</strong>: Know what to do when things go wrong</li>
                 </ol>
             </div>
         </div>
@@ -1197,7 +1197,7 @@ If you don't control the private keys (the seed words), you don't actually own t
     <div class="demo-cta-footer"
          data-demo-id="wallet-workshop"
          data-heading="Make this real"
-         data-sub="One paid path, one free path — pick the next concrete step."
+         data-sub="One paid path, one free path, pick the next concrete step."
          data-tracks='[{"audience": "holder", "time": "this week", "action": "Get the Self-Custody Starter Kit: go from &#39;set up a wallet&#39; to &#39;secured for years&#39;", "href": "/products/self-custody-starter-kit/"}, {"audience": "beginner", "time": "15 min", "action": "Go deeper on threats in the wallet security workshop", "href": "/interactive-demos/wallet-security-workshop/"}]'>
     </div>
     <!-- Reflect: Socratic questions after activity -->


### PR DESCRIPTION
Eliminates em dashes (U+2014) from interactive-demos HTML per the no-em-dash content rule.

- 39 files edited, 370 em dashes removed.
- Deterministic ruleset: table-cell markers → hyphen, prose → comma + cleanups; en-dashes (–) in numeric ranges preserved.
- Quality pass: select-option placeholders ("— select —" → "Select") and label/description headings upgraded comma → colon where a comma read wrong.
- Out of scope (untouched): `sovereign-vault/templates/emergency-doc.html` (not an index/top-level demo), and css/js (the reflect-widget em-dash injection is a separate task).

Verified: `grep -rl '—' interactive-demos --include='*.html'` returns only the out-of-scope template; no closing-tag spacing eaten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)