### PR TITLE
chore(tokens): Stage 1 — flatten radius to brand law + mark canonical source

### DIFF
--- a/css/brand.css
+++ b/css/brand.css
@@ -9,6 +9,10 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=JetBrains+Mono:wght@300;400;500;700&family=Crimson+Pro:ital,wght@0,300;0,400;0,600;1,300;1,400&family=Inter:wght@400;500;600;700&display=swap');
 
+/* NOTE (2026-06-18): The :root block below duplicates css/tokens.css, the
+   canonical variable source of truth. It is being dissolved — these vars stay
+   only because 79 pages link brand.css without tokens.css. Keep brand.css's
+   component rules; define new tokens in tokens.css, not here. */
 :root {
   /* Brand core */
   --color-brand: #FF7A00;              /* flat orange, daily workhorse */

--- a/css/design-tokens.css
+++ b/css/design-tokens.css
@@ -1,8 +1,11 @@
 /**
  * Design Tokens - Bitcoin Sovereign Academy
- * 
- * Central source of truth for all design values.
- * These tokens enforce visual consistency across the platform.
+ *
+ * LEGACY (2026-06-18). NOT the source of truth — css/tokens.css is.
+ * Only 3 isolated pages still link this sheet (start-simple.html,
+ * paths/curious/index.html, interactive-demos/inflation-impact-calculator).
+ * Some values here diverge from brand law (rounded radius, SF Mono, old
+ * semantic hues); do NOT add consumers. Pending migration onto tokens.css.
  */
 
 :root {

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -220,12 +220,15 @@ html {
 
   /* ============================================================
    * Border radius
+   * Flat 2px corners (was rounded 4/6/12px). Aligns the canonical token
+   * with the flattened brand direction already in use downstream.
    * ============================================================ */
 
-  --radius-sm:   4px;
-  --radius-md:   6px;
-  --radius-lg:   12px;
-  --radius-pill: 999px;
+  --radius-sm:    2px;
+  --radius-md:    4px;
+  --radius-lg:    8px;
+  --radius-button: 2px;
+  --radius-pill:  999px;
 
   /* ============================================================
    * Motion


### PR DESCRIPTION
## Token consolidation — Stage 1 (additive, verified zero-render-change)

First gated stage of folding BSA's split token sources into one canonical file. **Nothing renders differently** today; this is the safe groundwork.

### Context: the real landscape
Tokens live across 5 places — `tokens.css` (2 pages), `design-tokens.css` (4 pages), **`brand.css` (81 pages — de-facto source)**, and `icons.css` → 2 hidden `!important` fix sheets (164 pages). `tokens.css` is hub-owned and one-way-synced (`scripts/sync-tokens.sh`, `cp hub → consumer`), shared with FSA.

### What this PR does
- **`tokens.css`** — synced from the hub canonical ([hub commit](https://github.com/Sovereigndwp/sovereign-academy-hub/commit/0b3339d)), which now carries the flat **2px** brand law (`--radius-sm/md/lg` were rounded `4/6/12px`) + adds `--radius-button`. tokens.css previously held *stale* radius that would have *regressed* corners if promoted as-is.
- **`design-tokens.css`** — marked **LEGACY** (only 3 isolated pages still link it: `start-simple.html`, `paths/curious/index.html`, inflation-impact-calculator; its values diverge from brand law — do not add consumers).
- **`brand.css`** — note that its `:root` duplicates tokens.css and is being dissolved.

### Why it's a verified no-op
On every page that links tokens.css (BSA index + about, hub index), `brand.css` loads **after** and wins the radius cascade — computed `--radius-*` is identical before/after (checked live: `2px / 4px / 8px / 2px`). FSA links tokens.css from **nothing**, so it's unaffected. The 2px only activates in later stages.

### Verification
- Computed `--radius-*` on `index.html` + `about.html` unchanged (preview_eval, before & after).
- Homepage renders intact (2px corners, mono labels, orange accents); 0 console errors.

### Not in this PR (later gated stages, each its own screenshot-gated PR)
1. Route the 79 brand-only pages through tokens.css — needs a var-usage audit first (some use tokens.css-only vars like `--space-*`/`--font-mono` that are currently undefined).
2. Migrate the 3 legacy `design-tokens.css` pages (also off-brand rounded corners).
3. Migrate the 332 hardcoded-hex HTML files.
4. Retire the `icons.css` fix sheets (riskiest — last).

### Follow-up housekeeping
FSA's `tokens.css` should be resynced (`scripts/sync-tokens.sh ../sovereign-academy-hub`) to stay byte-identical to the hub — pure no-op (nothing links it), deferred to avoid writing into FSA's active content branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)