### PR TITLE
chore(tokens): Stage 2 — route 80 brand-only pages through tokens.css

### DIFF
--- a/ai-tutors/index.html
+++ b/ai-tutors/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Learning Tutors - Bitcoin Sovereign Academy</title>
     <meta name="description" content="Personalized AI-powered learning companions. Get guided through Bitcoin concepts with interactive tutors tailored to your level.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/archive/interactive-demos/wallet-workshop-interactive.html
+++ b/archive/interactive-demos/wallet-workshop-interactive.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Interactive Wallet Workshop - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/blog/index.html
+++ b/blog/index.html
@@ -4,6 +4,7 @@
 <title>Blog | Bitcoin Sovereign Academy</title>
 <meta name="description" content="Essays by Dalia on Bitcoin, privacy, sovereignty, and the trade-offs we make in a permissioned world.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/blog/">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/blog/the-day-i-traded-my-iris-for-30-seconds.html
+++ b/blog/the-day-i-traded-my-iris-for-30-seconds.html
@@ -4,6 +4,7 @@
 <title>The Day I Traded My Iris for 30 Seconds | Bitcoin Sovereign Academy</title>
 <meta name="description" content="A personal essay on the quiet trade between convenience and control, told from a biometric line at a Colombian airport.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/blog/the-day-i-traded-my-iris-for-30-seconds.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/challenges/index.html
+++ b/challenges/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Learning Challenges - Bitcoin Sovereign Academy</title>
     <meta name="description" content="Structured learning challenges and branching scenarios. Experience the consequences of Bitcoin choices.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/community/index.html
+++ b/community/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Community | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Join the Bitcoin Sovereign Academy community. Connect, learn, and grow with fellow Bitcoin enthusiasts.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/global.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contact | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Get in touch with Bitcoin Sovereign Academy. We'd love to hear from you.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/global.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>

--- a/dalia/icon-explorations.html
+++ b/dalia/icon-explorations.html
@@ -8,6 +8,7 @@
   <title>Icon System Prototype — Phase 1 review | Dalia</title>
   <meta name="description" content="Preview of Tier 1 icon system prototypes drawn from the locked diamond/stroke logo geometry. For sub-project #2.7 review.">
 
+  <link rel="stylesheet" href="/css/tokens.css">
   <link rel="stylesheet" href="/css/brand.css">
   <link rel="stylesheet" href="/css/global.css">
 

--- a/dalia/index.html
+++ b/dalia/index.html
@@ -19,6 +19,7 @@
   <link rel="canonical" href="https://bitcoinsovereign.academy/dalia/">
 
   <!-- BSA brand kit + hub-specific styles -->
+  <link rel="stylesheet" href="/css/tokens.css">
   <link rel="stylesheet" href="/css/brand.css">
   <link rel="stylesheet" href="/dalia/styles.css">
 

--- a/deep-dives/index.html
+++ b/deep-dives/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Deep Dives - Theory, Philosophy &amp; Capital | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Explore Bitcoin in depth — Austrian economics, first principles, philosophy, economic foundations, sovereign tools, and Bitcoin as capital with interactive calculators.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/interactive-demos.css">
     <style>

--- a/deep-dives/money-banking/index.html
+++ b/deep-dives/money-banking/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Money &amp; Banking Deep Dives | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Interactive simulations revealing how modern money actually works. Explore money creation, fractional reserve banking, the Federal Reserve, and bank runs.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         /* Brand color overrides for this page */

--- a/demos/index.html
+++ b/demos/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Interactive Demos - Bitcoin Sovereign Academy</title>
     <meta name="description" content="Explore Bitcoin through 19+ interactive visualizations and demos. Learn how Bitcoin works with no tests, no pressure.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/emergency-kit.html
+++ b/emergency-kit.html
@@ -5,6 +5,7 @@
     <meta name="description" content="Stuck transaction? Lost wallet access? Exchange down? Get immediate help for Bitcoin emergencies with step-by-step solutions and expert guidance.">
     <meta name="keywords" content="bitcoin emergency, stuck transaction, lost bitcoin, wallet recovery, bitcoin help, transaction not confirming">
 
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
 
     <style>

--- a/glossary.html
+++ b/glossary.html
@@ -8,6 +8,7 @@
   <meta name="description" content="A sovereignty glossary for Bitcoin learners, families, builders, and advisors. Simple explanations of money, economics, custody, privacy, cryptography, Lightning, fiscal terms, Colombia context, and DevOps concepts.">
   <meta name="keywords" content="bitcoin glossary, sovereignty glossary, financial literacy, bitcoin custody, seed phrase, UTXO, Lightning Network, cryptography, DevOps, Colombia financial education">
 
+  <link rel="stylesheet" href="/css/tokens.css">
   <link rel="stylesheet" href="/css/brand.css">
   <link rel="stylesheet" href="/css/icons.css">
   <link rel="canonical" href="https://bitcoinsovereign.academy/glossary.html">

--- a/guides/advisor-10-questions/index.html
+++ b/guides/advisor-10-questions/index.html
@@ -4,6 +4,7 @@
 <title>10 Bitcoin Questions Every Advisor Should Be Ready to Answer | BSA</title>
 <meta name="description" content="A free readiness check for wealth advisors, CPAs, estate attorneys, and fiduciaries whose clients already own Bitcoin, are asking about it, or may pass it to heirs.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/guides/advisor-10-questions/">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/guides/advisor-pre-discovery/index.html
+++ b/guides/advisor-pre-discovery/index.html
@@ -4,6 +4,7 @@
 <title>Privacy pre-discovery for advisors | Bitcoin Sovereign Academy</title>
 <meta name="description" content="A short list of pre-discovery questions a wealth advisor can send a Bitcoin-holding client before the privacy conversation. 10 minutes, gets the right inputs on the table.">
 <meta name="robots" content="noindex">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/demo-cta-footer.css">

--- a/guides/disclosure-audit/index.html
+++ b/guides/disclosure-audit/index.html
@@ -4,6 +4,7 @@
 <title>Personal disclosure audit | Bitcoin Sovereign Academy</title>
 <meta name="description" content="A 30-minute exercise for HNW Bitcoin holders. Catalog every counterparty who has seen one of your receive addresses. The result is your doxxing surface.">
 <meta name="robots" content="noindex">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/demo-cta-footer.css">

--- a/guides/inheritance-privacy/index.html
+++ b/guides/inheritance-privacy/index.html
@@ -4,6 +4,7 @@
 <title>Inheritance privacy context | Bitcoin Sovereign Academy</title>
 <meta name="description" content="When you pass keys to heirs, you also pass an inheritance of disclosure. A short template for documenting the privacy context heirs need.">
 <meta name="robots" content="noindex">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/demo-cta-footer.css">

--- a/guides/sparrow-utxo-map/index.html
+++ b/guides/sparrow-utxo-map/index.html
@@ -4,6 +4,7 @@
 <title>Map your UTXOs with Sparrow | Bitcoin Sovereign Academy</title>
 <meta name="description" content="A 5-minute walk-through to install Sparrow Wallet in watch-only mode and map your existing wallet's UTXOs — the prerequisite for any privacy decision.">
 <meta name="robots" content="noindex"><!-- guide is a stub; do not index until content lands -->
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/demo-cta-footer.css">

--- a/institutional/wealth-advisors/kit/advisor-role-boundary-checklist.html
+++ b/institutional/wealth-advisors/kit/advisor-role-boundary-checklist.html
@@ -5,6 +5,7 @@
 <meta name="description" content="Advisor Role-Boundary Checklist — a working template in the full Advisor Readiness Kit.">
 <meta name="robots" content="noindex">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/advisor-role-boundary-checklist.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/kit/client-discovery-questionnaire.html
+++ b/institutional/wealth-advisors/kit/client-discovery-questionnaire.html
@@ -4,6 +4,7 @@
 <title>Bitcoin Client Discovery Questionnaire | BSA Advisor Kit</title>
 <meta name="description" content="Twenty intake questions across existence, custody, continuity, and records. For professional advisors. Education only.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/client-discovery-questionnaire.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/kit/client-meeting-script.html
+++ b/institutional/wealth-advisors/kit/client-meeting-script.html
@@ -5,6 +5,7 @@
 <meta name="description" content="Client Meeting Scripts — a working template in the full Advisor Readiness Kit.">
 <meta name="robots" content="noindex">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/client-meeting-script.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/kit/custody-lanes-worksheet.html
+++ b/institutional/wealth-advisors/kit/custody-lanes-worksheet.html
@@ -5,6 +5,7 @@
 <meta name="description" content="Custody Lanes Worksheet — a working template in the full Advisor Readiness Kit.">
 <meta name="robots" content="noindex">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/custody-lanes-worksheet.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/kit/engagement-letter-language.html
+++ b/institutional/wealth-advisors/kit/engagement-letter-language.html
@@ -5,6 +5,7 @@
 <meta name="description" content="Engagement-Letter Language — a working template in the full Advisor Readiness Kit.">
 <meta name="robots" content="noindex">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/engagement-letter-language.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/kit/index.html
+++ b/institutional/wealth-advisors/kit/index.html
@@ -4,6 +4,7 @@
 <title>Advisor Readiness Kit — Preview | BSA</title>
 <meta name="description" content="Preview selected tools from the Advisor Readiness Kit. The full kit includes working templates for custody mapping, recovery readiness, specialist handoff, client meeting scripts, role boundaries, and counsel-reviewed engagement language.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/kit/recovery-readiness-scorecard.html
+++ b/institutional/wealth-advisors/kit/recovery-readiness-scorecard.html
@@ -5,6 +5,7 @@
 <meta name="description" content="Recovery-Readiness Scorecard — a working template in the full Advisor Readiness Kit.">
 <meta name="robots" content="noindex">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/recovery-readiness-scorecard.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/kit/seed-phrase-red-flag-protocol.html
+++ b/institutional/wealth-advisors/kit/seed-phrase-red-flag-protocol.html
@@ -4,6 +4,7 @@
 <title>Seed Phrase Red-Flag Protocol | BSA Advisor Kit</title>
 <meta name="description" content="The never-handle-keys rule, the red flags that precede it, decline scripts, and the documentation step. Education only.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/seed-phrase-red-flag-protocol.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/kit/specialist-handoff-memo.html
+++ b/institutional/wealth-advisors/kit/specialist-handoff-memo.html
@@ -5,6 +5,7 @@
 <meta name="description" content="Specialist Handoff Memo — a working template in the full Advisor Readiness Kit.">
 <meta name="robots" content="noindex">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/kit/specialist-handoff-memo.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/tools/client-script-builder.html
+++ b/institutional/wealth-advisors/tools/client-script-builder.html
@@ -4,6 +4,7 @@
 <title>Client Script Builder for Advisors | BSA</title>
 <meta name="description" content="Pick the Bitcoin question your client just asked. Get a calm, professional response script — plus what not to say and when to bring in a specialist.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/tools/client-script-builder.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/institutional/wealth-advisors/tools/seed-phrase-red-flags.html
+++ b/institutional/wealth-advisors/tools/seed-phrase-red-flags.html
@@ -4,6 +4,7 @@
 <title>Seed Phrase Red Flags — Should the Advisor Do This? | BSA</title>
 <meta name="description" content="A short scenario activity for professional advisors: learn to recognize the moments when a client conversation crosses into seed-phrase danger — and what to do instead.">
 <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/wealth-advisors/tools/seed-phrase-red-flags.html">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/global.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/brand-consistency.css">

--- a/interactive-demos/bitcoin-genesis-timeline/index.html
+++ b/interactive-demos/bitcoin-genesis-timeline/index.html
@@ -5,6 +5,7 @@
 
     <!-- Plausible Analytics -->
 
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/bitcoin-key-generator-visual/index.html
+++ b/interactive-demos/bitcoin-key-generator-visual/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Bitcoin Key Generator, Visual Learning</title>
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/brand.css">
 <style>
 /* ── base ── */

--- a/interactive-demos/bitcoin-price-timeline/index.html
+++ b/interactive-demos/bitcoin-price-timeline/index.html
@@ -4,6 +4,7 @@
     <title>Bitcoin Price Timeline | Learn Why Prices Move | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Interactive Bitcoin price timeline exploring the 'why' behind every major price movement from 2009 to 2025. Understand halving cycles, market events, and adoption milestones.">
 
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         * {

--- a/interactive-demos/bitcoin-sovereign-game/index.html
+++ b/interactive-demos/bitcoin-sovereign-game/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>History doesn't repeat, but it Rhymes | Bitcoin Sovereign Journey | Bitcoin Sovereign Academy</title>
     
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/bitcoin-vs-banking/index.html
+++ b/interactive-demos/bitcoin-vs-banking/index.html
@@ -5,6 +5,7 @@
     <title>Bitcoin vs Banking | Bitcoin Sovereign Academy</title>
     
     <!-- Styles -->
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/widgets.css">
     

--- a/interactive-demos/building-the-chain-demo/index.html
+++ b/interactive-demos/building-the-chain-demo/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Building the Chain Demo - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/computational-puzzles-demo/index.html
+++ b/interactive-demos/computational-puzzles-demo/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Computational Puzzles Demo - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/consensus-game/index.html
+++ b/interactive-demos/consensus-game/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Consensus Game - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/digital-signatures-demo/index.html
+++ b/interactive-demos/digital-signatures-demo/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Digital Signatures Demo - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/double-spending-demo/index.html
+++ b/interactive-demos/double-spending-demo/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>You Just Got Scammed - Double-Spending Demo | Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/fee-master-tool/index.html
+++ b/interactive-demos/fee-master-tool/index.html
@@ -4,6 +4,7 @@
     <meta name="description" content="Complete Bitcoin transaction fee management: estimate, decide, and track">
     <title>Fee Master Tool | Bitcoin Sovereign Academy</title>
     
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/widgets.css">
 

--- a/interactive-demos/index.html
+++ b/interactive-demos/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Interactive Demos - Bitcoin Sovereign Academy</title>
     <meta name="description" content="Browse all Bitcoin Sovereign Academy interactive demos - wallets, security, mining, transactions, and more">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">
     <style>

--- a/interactive-demos/kyc-best-practices/index.html
+++ b/interactive-demos/kyc-best-practices/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>KYC, no-KYC, or hybrid: which fits your situation? | Bitcoin Sovereign Academy</title>
     <meta name="description" content="A short decision aid for buying Bitcoin. Pick by jurisdiction, amount, and privacy preference, get a recommendation with specific platforms verified for April 2026.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/interactive-demos.css">
     <link rel="stylesheet" href="/css/demo-cta-footer.css">

--- a/interactive-demos/ledger-keeper-dilemma/index.html
+++ b/interactive-demos/ledger-keeper-dilemma/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Ledger Keeper's Dilemma 2.0, Interactive Comparison</title>
     <meta name="description" content="Compare payment systems: CBDCs, state rails, Bitcoin, and more. Interactive table shows speed, control, privacy trade-offs.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/interactive-demos.css">
     <style>

--- a/interactive-demos/lightning-network-demo/index.html
+++ b/interactive-demos/lightning-network-demo/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lightning Network Interactive Demo - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/status-indicators.css">
     <style>

--- a/interactive-demos/mempool-visualizer/index.html
+++ b/interactive-demos/mempool-visualizer/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitcoin Mempool &amp; Fee Market Visualizer | Learn Bitcoin Transaction Dynamics</title>
     <meta name="description" content="Interactive visualization of Bitcoin's mempool and fee market. Understand how transactions are prioritized, how miners select transactions, and how to estimate optimal fees.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/interactive-demos.css">
     <link rel="stylesheet" href="styles.css">

--- a/interactive-demos/mining-economics-demo/index.html
+++ b/interactive-demos/mining-economics-demo/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mining Economics Demo - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/mining-simulator/index.html
+++ b/interactive-demos/mining-simulator/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mining Simulator - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/money-properties-comparison/index.html
+++ b/interactive-demos/money-properties-comparison/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Money Properties Comparison - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/network-consensus-demo/index.html
+++ b/interactive-demos/network-consensus-demo/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Network Consensus Demo - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/node-setup-sandbox/index.html
+++ b/interactive-demos/node-setup-sandbox/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Interactive Bitcoin node setup simulator. Learn how to install, configure, and run your own Bitcoin Core full node with step-by-step guidance for beginner, intermediate, and advanced users.">
     <title>Bitcoin Node Setup Sandbox - Interactive Learning Tool | Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/status-indicators.css">
     <link rel="stylesheet" href="/css/interactive-demos.css">

--- a/interactive-demos/sat-stacking-calculator/index.html
+++ b/interactive-demos/sat-stacking-calculator/index.html
@@ -5,6 +5,7 @@
     <title>Sat Stacking Calculator | Bitcoin Sovereign Academy</title>
     
     <!-- Styles -->
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/widgets.css">
     

--- a/interactive-demos/security-dojo-enhanced/index.html
+++ b/interactive-demos/security-dojo-enhanced/index.html
@@ -2,6 +2,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bitcoin Security Training Lab – Hands-On Security Practice</title>
+  <link rel="stylesheet" href="/css/tokens.css">
   <link rel="stylesheet" href="/css/brand.css">
   <link rel="stylesheet" href="/css/status-indicators.css">
   <style>

--- a/interactive-demos/sovereign-vault/index.html
+++ b/interactive-demos/sovereign-vault/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sovereign Vault - Bitcoin Custody Management | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Client-side encrypted custody documentation for Bitcoin self-custody. Document your wallets, backups, and inheritance plans with strong, client-side encryption.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/status-indicators.css">
     <link rel="stylesheet" href="css/vault.css">

--- a/interactive-demos/testnet-practice-guide/index.html
+++ b/interactive-demos/testnet-practice-guide/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitcoin Testnet Practice Guide - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/status-indicators.css">
 

--- a/interactive-demos/transaction-builder/index.html
+++ b/interactive-demos/transaction-builder/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Transaction Builder - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/interactive-demos/utxo-visualizer-enhanced/index.html
+++ b/interactive-demos/utxo-visualizer-enhanced/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Enhanced UTXO Visualizer - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         * {

--- a/interactive-demos/wallet-security-workshop/index.html
+++ b/interactive-demos/wallet-security-workshop/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitcoin Wallet Security Workshop - Bitcoin Sovereign Academy</title>
     <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/status-indicators.css">
     <style>

--- a/interactive-demos/wallet-workshop/index.html
+++ b/interactive-demos/wallet-workshop/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Wallet Basics - Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/licensing.html
+++ b/licensing.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Educational Licensing | Bitcoin Sovereign Academy</title>
     <meta name="description" content="License our interactive Bitcoin demos for your school, organization, or training program. White-label or co-branded options available.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/membership-success.html
+++ b/membership-success.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Welcome, Sovereign! | Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/membership.html
+++ b/membership.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Membership | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Choose your learning path: free exploration, Apprentice deposit access, or lifetime Sovereign access.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/mockups/catalog-card-final.html
+++ b/mockups/catalog-card-final.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Catalog — Final card design</title>
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/brand.css">
 <style>
   /* Explicit fallbacks on EVERY color so text stays readable even if brand.css fails to load. */

--- a/mockups/catalog-card-mockups.html
+++ b/mockups/catalog-card-mockups.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Catalog Card Mockups A–D</title>
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/brand.css">
 <style>
   body{margin:0;background:var(--color-bg,#16181C);color:var(--color-text,#F7F7F2);

--- a/my-learning/index.html
+++ b/my-learning/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Your Learning Path | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Your personalized Bitcoin learning journey">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         * {

--- a/nostr/index.html
+++ b/nostr/index.html
@@ -10,6 +10,7 @@
 <meta property="og:description" content="Bitcoin education, without the confusion. Free lessons. Zaps welcome if useful.">
 <meta property="og:url" content="https://bitcoinsovereign.academy/nostr/">
 <meta property="og:type" content="website">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/brand.css">
 <style>
   :root { color-scheme: dark; }

--- a/paths/index.html
+++ b/paths/index.html
@@ -11,6 +11,7 @@
     <meta property="og:url" content="https://bitcoinsovereign.academy/paths/">
     <meta property="og:type" content="website">
 
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/paths/principled/stage-1/index.html
+++ b/paths/principled/stage-1/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stage 1: Foundations of Reality | Principled Path</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/paths/principled/stage-2/index.html
+++ b/paths/principled/stage-2/index.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stage 2: Human Systems &amp; Incentives | Principled Path</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/paths/principled/stage-2/module-3.html
+++ b/paths/principled/stage-2/module-3.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 3: Trust, Power, and Accountability | Stage 2 | Principled Path</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/paths/principled/stage-3/module-1.html
+++ b/paths/principled/stage-3/module-1.html
@@ -2,6 +2,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 3.1: The Building Blocks of Digital Trust | Principled Path</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/privacy.html
+++ b/privacy.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Privacy Policy for Bitcoin Sovereign Academy - how we handle your data with privacy-first principles.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/sponsor.html
+++ b/sponsor.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sponsor Bitcoin Sovereign Academy | Partner With Us</title>
     <meta name="description" content="Support Bitcoin education through ethical sponsorship. No paid placement in lessons. Strict editorial separation.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/start-simple/index.html
+++ b/start-simple/index.html
@@ -6,6 +6,7 @@
   <title>Start Simple | Bitcoin Sovereign Academy</title>
   <meta name="description" content="A simple starting path for learning Bitcoin without confusion.">
   <link rel="canonical" href="https://bitcoinsovereign.academy/start-simple/">
+  <link rel="stylesheet" href="/css/tokens.css">
   <link rel="stylesheet" href="/css/brand.css">
   <style>
     * {

--- a/start/index.html
+++ b/start/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Start Your Bitcoin Journey | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Get your personalized Bitcoin learning path in 2 minutes. No signup required.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         * {

--- a/styleguide.html
+++ b/styleguide.html
@@ -5,6 +5,7 @@
 <title>Design System | Bitcoin Sovereign Academy</title>
 <meta name="robots" content="noindex">
 <meta name="description" content="Internal component reference for the Bitcoin Sovereign Academy design system.">
+<link rel="stylesheet" href="/css/tokens.css">
 <link rel="stylesheet" href="/css/brand.css">
 <link rel="stylesheet" href="/css/demo-shell.css">
 <style>

--- a/terms.html
+++ b/terms.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Terms of Service | Bitcoin Sovereign Academy</title>
     <meta name="description" content="Terms of Service for Bitcoin Sovereign Academy - educational platform for Bitcoin learning.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/tools/index.html
+++ b/tools/index.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitcoin Tools Library - Bitcoin Sovereign Academy</title>
     <meta name="description" content="Real Bitcoin utilities for everyday situations. Instant, practical tools for transactions, conversions, and more.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/transparency.html
+++ b/transparency.html
@@ -3,6 +3,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Transparency | Bitcoin Sovereign Academy</title>
     <meta name="description" content="How we fund Bitcoin Sovereign Academy and where the money goes. Full transparency on tips, grants, and sponsorships.">
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {

--- a/weekly/index.html
+++ b/weekly/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Weekly Progress — Bitcoin Sovereign Academy</title>
+    <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <style>
         :root {


### PR DESCRIPTION
## Token consolidation — Stage 2 (verified zero-render-change)

Routes the **80 brand-only pages** (linked `brand.css` but not `tokens.css`) through the canonical token file, so the whole site now resolves design tokens from one source. Follows [#141](https://github.com/Sovereigndwp/bitcoin-sovereign-academy/pull/141) (Stage 1).

### What it does
Inserts `<link rel="stylesheet" href="/css/tokens.css">` as the **first stylesheet** on each page. Because tokens.css loads *before* every other sheet (`global.css` / `brand.css` / page CSS), those still win all conflicts — so nothing renders differently today. This is the plumbing that lets later stages use `var(--brand-gradient)` etc. on pages that previously couldn't.

### Why it's safe (var-usage audit)
Of **107** vars tokens.css defines but brand.css doesn't, only **30** are consumed anywhere, and only **2 pages** used one without a fallback *and* without a local def: `contact.html` + `community/index.html`. Both link `css/global.css` (a 6th token source that defines the legacy aliases), so they were never broken — and tokens.css is inserted *before* global.css so global.css still wins.

### Verification (preview, computed values)
- **contact.html / community/index.html**: `--text-light` stays `#e0e0e0` (global.css wins, not tokens.css's `#F7F7F2`); `--primary-orange #FF7A00`, `--radius-md 4px` — unchanged.
- **Pure brand pages** (e.g. sat-stacking-calculator): `--color-brand / --color-bg / --radius-md` unchanged; renders intact; **0 console errors**.
- `+1` line per file, no deletions, no non-HTML changes.

### Next stage
**Gradient consolidation** — replace the 72 hardcoded orange→yellow fades (24+ drifting variants) with `var(--brand-gradient)`, kill the fake solid-gradients (`linear-gradient(#FF7A00,#FF7A00)`), and enforce the locked rule (fade = numerics + primary-button stroke only). That's the stage that delivers a consistent signature across pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)