### PR TITLE
feat(brand): consolidate the orange→yellow fade onto one canonical token

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -89,7 +89,7 @@
         .btn {
             width: 100%;
             padding: 0.75rem;
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: #121212;
             border: none;
             border-radius: 8px;

--- a/ai-agents/index.html
+++ b/ai-agents/index.html
@@ -9,12 +9,12 @@
     header { position: sticky; top: 0; background: #2d2d2d; border-bottom: 2px solid #FF7A00; padding: 0.75rem 1rem; }
     a { color: #FF7A00; text-decoration: none; }
     .container { max-width: 1100px; margin: 0 auto; padding: 1rem; }
-    h1 { margin: 0.5rem 0 1rem; background: linear-gradient(135deg,#FF7A00,#FFD400); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
+    h1 { margin: 0.5rem 0 1rem; background: var(--brand-gradient); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px,1fr)); gap: 1rem; }
     .card { background: rgba(0,0,0,0.3); border: 1px solid rgba(255, 122, 0,0.2); border-radius: 12px; padding: 1rem; }
     .card h2 { color: #FF7A00; margin-top: 0; font-size: 1.1rem; }
     .row { display: flex; gap: 0.5rem; flex-wrap: wrap; }
-    button { background: linear-gradient(135deg,#FF7A00,#FFD400); border: none; color: #fff; font-weight: 600; padding: 0.6rem 1rem; border-radius: 999px; cursor: pointer; }
+    button { background: var(--brand-gradient); border: none; color: #fff; font-weight: 600; padding: 0.6rem 1rem; border-radius: 999px; cursor: pointer; }
     button.secondary { background: transparent; border: 2px solid #FF7A00; color: #FF7A00; }
     pre { white-space: pre-wrap; background: #111; padding: 0.75rem; border-radius: 8px; max-height: 320px; overflow: auto; }
     .badge { display:inline-block; border:1px solid #2196f3; color:#2196f3; background:rgba(33,150,243,.15); border-radius:16px; padding:0.1rem 0.5rem; font-size: 0.8rem; margin-left: 0.5rem; }

--- a/ai-agents/visual-synthesizer/index.html
+++ b/ai-agents/visual-synthesizer/index.html
@@ -47,7 +47,7 @@
         .hero h1 {
             font-size: 3rem;
             margin-bottom: 1rem;
-            background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -117,7 +117,7 @@
 
         .nav-btn {
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: white;
             border: none;
             border-radius: 0.5rem;
@@ -177,7 +177,7 @@
             left: 0;
             width: 4px;
             height: 100%;
-            background: linear-gradient(180deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             opacity: 0;
             transition: opacity 0.3s ease;
         }
@@ -338,7 +338,7 @@
         }
 
         .interactive-button {
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: white;
             border: none;
             padding: 1rem 2rem;

--- a/ai-tutors/index.html
+++ b/ai-tutors/index.html
@@ -58,7 +58,7 @@
         }
 
         .header h1 {
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             font-size: 2.5rem;
@@ -114,7 +114,7 @@
         }
 
         .tutor-title {
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             font-size: 1.3rem;

--- a/analytics/index.html
+++ b/analytics/index.html
@@ -7,12 +7,12 @@
     header { position: sticky; top: 0; background: #2d2d2d; border-bottom: 2px solid #FF7A00; padding: 0.75rem 1rem; }
     a { color: #FF7A00; text-decoration: none; }
     .container { max-width: 1100px; margin: 0 auto; padding: 1rem; }
-    h1 { margin: 0.5rem 0 1rem; background: linear-gradient(135deg,#FF7A00,#FFD400); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
+    h1 { margin: 0.5rem 0 1rem; background: var(--brand-gradient); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px,1fr)); gap: 1rem; }
     .card { background: rgba(0,0,0,0.3); border: 1px solid rgba(255, 122, 0,0.2); border-radius: 12px; padding: 1rem; }
     .card h2 { color: #FF7A00; margin-top: 0; font-size: 1.1rem; }
     pre { white-space: pre-wrap; background: #111; padding: 0.75rem; border-radius: 8px; max-height: 420px; overflow: auto; }
-    button { background: linear-gradient(135deg,#FF7A00,#FFD400); border: none; color: #fff; font-weight: 600; padding: 0.6rem 1rem; border-radius: 999px; cursor: pointer; }
+    button { background: var(--brand-gradient); border: none; color: #fff; font-weight: 600; padding: 0.6rem 1rem; border-radius: 999px; cursor: pointer; }
     .row { display: flex; gap: 0.5rem; flex-wrap: wrap; }
   </style>
 <meta name="description" content="Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here."><link rel="canonical" href="https://bitcoinsovereign.academy/"><meta property="og:title" content="Bitcoin Sovereign Academy"><meta property="og:description" content="Master Bitcoin through interactive experiences, AI-powered learning, and real-world simulations. Your journey from monetary curiosity to financial sovereignty starts here."><meta property="og:image" content="https://bitcoinsovereign.academy/assets/og-image.jpg"><meta property="og:url" content="https://bitcoinsovereign.academy/"><meta property="og:type" content="website"><script type="application/ld+json">{

--- a/archive/interactive-demos/wallet-workshop-interactive.html
+++ b/archive/interactive-demos/wallet-workshop-interactive.html
@@ -166,7 +166,7 @@
                                     <p style="margin-bottom: 1.5rem; line-height: 1.8;">You've explored how wallets work! Ready to practice with real tools?</p>
                                     <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
                                         <a href="/interactive-demos/wallet-security-workshop/" 
-                                           style="display: inline-block; background: linear-gradient(135deg, #FF7A00, #ff6b00); color: white; padding: 0.85rem 1.75rem; border-radius: 8px; text-decoration: none; font-weight: 600; transition: transform 0.2s;">
+                                           style="display: inline-block; background: var(--brand-gradient); color: white; padding: 0.85rem 1.75rem; border-radius: 8px; text-decoration: none; font-weight: 600; transition: transform 0.2s;">
                                             🔐 Practice Wallet Security →
                                         </a>
                                         <a href="/interactive-demos/security-dojo-enhanced/" 

--- a/css/brand-consistency.css
+++ b/css/brand-consistency.css
@@ -19,7 +19,7 @@
   --bsa-border:    #2a2a2a;
   --bsa-radius:    10px;                /* rounded (homepage-matched 2026-06-09) */
   /* Canonical homepage accent fade (exact stops, measured from homepage) */
-  --bsa-grad:      linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%);
+  --bsa-grad:      linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
   --bsa-ink:       #16181c;             /* dark text for use ON the bright gradient */
   --bsa-font:      var(--font-sans, 'Inter', system-ui, -apple-system, sans-serif);
 }

--- a/css/brand.css
+++ b/css/brand.css
@@ -74,41 +74,28 @@
   --color-node-red: #FF2B2B;
   --color-node-blue: #2F75FF;
 
-  /* Signature gradients */
+  /* Signature gradient: orange -> yellow, 135deg, one smooth mid-stop.
+     Canonicalized 2026-06-19 (was 90deg yellow->orange). Mirrors css/tokens.css.
+     All the variants below collapse onto this one signature. */
   --brand-gradient: linear-gradient(
-    90deg,
-    #FFE600 0%,
-    #FFD400 18%,
-    #FF9A00 48%,
-    #FF7A00 78%,
-    #E85F00 100%
-  );
-
-  --gradient-brand: linear-gradient(
     135deg,
-    #FFE600 0%,
-    #FFD400 22%,
-    #FF9A00 52%,
-    #FF7A00 75%,
-    #E85F00 100%
+    #FF7A00 0%,
+    #FF9A00 45%,
+    #FFD400 100%
   );
 
+  /* Horizontal variant for full-width bars / underlines. */
   --gradient-brand-horizontal: linear-gradient(
     90deg,
-    #FFE600 0%,
-    #FFD400 18%,
-    #FF9A00 48%,
-    #FF7A00 78%,
-    #E85F00 100%
+    #FF7A00 0%,
+    #FF9A00 45%,
+    #FFD400 100%
   );
+  --brand-gradient-h: var(--gradient-brand-horizontal);
 
-  --gradient-key-takeaway: linear-gradient(
-    90deg,
-    #FFE600 0%,
-    #FFD400 20%,
-    #FF9A00 55%,
-    #FF7A00 100%
-  );
+  /* Aliases — collapsed onto the signature so old consumers stay consistent. */
+  --gradient-brand: var(--brand-gradient);
+  --gradient-key-takeaway: var(--gradient-brand-horizontal);
 
   --gradient-title: linear-gradient(
     180deg,

--- a/css/demo-shell.css
+++ b/css/demo-shell.css
@@ -20,7 +20,7 @@ body {
 .num-fade {
   font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);
   color: #FF7A00;
-  background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+  background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -53,7 +53,7 @@ body {
   background-image: none !important;
   color: #FF7A00 !important;
   border: 2px solid transparent !important;
-  border-image: linear-gradient(135deg, #FF7A00, #FFD400) 1 !important;
+  border-image: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%) 1 !important;
   box-shadow: none !important;
   font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);
   text-transform: uppercase;

--- a/css/dynamic-content.css
+++ b/css/dynamic-content.css
@@ -51,7 +51,7 @@ input:valid:not(:placeholder-shown) {
     position: fixed;
     top: 20px;
     right: 20px;
-    background: linear-gradient(135deg, #FF7A00, #ff7b00);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     color: white;
     padding: 1rem;
     border-radius: 15px;
@@ -124,7 +124,7 @@ input:valid:not(:placeholder-shown) {
 
 .progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #FF7A00, #ffa500);
+    background: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     border-radius: 4px;
     transition: width 0.5s ease;
 }
@@ -223,7 +223,7 @@ input:valid:not(:placeholder-shown) {
 }
 
 .recommended-badge {
-    background: linear-gradient(45deg, #ffa500, #ff7b00);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     color: white;
     padding: 0.25rem 0.75rem;
     border-radius: 8px;
@@ -278,7 +278,7 @@ input:valid:not(:placeholder-shown) {
     left: 0;
     right: 0;
     height: 4px;
-    background: linear-gradient(90deg, #FF7A00, #ffa500);
+    background: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
 }
 
 .featured-content-card:hover {
@@ -468,7 +468,7 @@ input:valid:not(:placeholder-shown) {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    background: linear-gradient(45deg, #ffa500, #FF7A00);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     color: white;
     padding: 0.5rem 1rem;
     border-radius: 20px;

--- a/css/hero3d.css
+++ b/css/hero3d.css
@@ -47,7 +47,7 @@
     font-size: clamp(2.4rem, 6vw, 4.1rem);
     font-weight: 800;
     letter-spacing: -0.02em;
-    background: linear-gradient(135deg, #ff8c00 0%, #ffd700 100%);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -103,7 +103,7 @@
 }
 
 .hero3d__action--primary:hover {
-    background: linear-gradient(135deg, #FFD400, #FF7A00);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
 }
 
 .hero3d__action--ghost {

--- a/css/homepage-bsa-brand-fix.css
+++ b/css/homepage-bsa-brand-fix.css
@@ -33,8 +33,8 @@
   --color-ink-on-cream: #F7F7F2;
   --color-muted-on-cream: #B8B8B0;
 
-  --brand-gradient: linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%);
-  --gradient-orange: linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%);
+  --brand-gradient: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
+  --gradient-orange: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
   --gradient-dark: linear-gradient(135deg, #16181C 0%, #1F2024 100%);
 }
 

--- a/css/icons.css
+++ b/css/icons.css
@@ -30,7 +30,7 @@
 .icon-cream { color: var(--color-text, #F7F7F2); }
 
 .icon-gradient {
-  background: var(--brand-gradient, linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%));
+  background: var(--brand-gradient, linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%));
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;

--- a/css/lab-guide.css
+++ b/css/lab-guide.css
@@ -352,7 +352,7 @@
     position: absolute;
     top: 0; left: 0; right: 0;
     height: 2px;
-    background: linear-gradient(90deg, #FF7A00, #ff6b35);
+    background: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
 }
 .lab-card:hover {
     border-color: rgba(255, 122, 0,0.65);

--- a/css/learning-path.css
+++ b/css/learning-path.css
@@ -106,7 +106,7 @@
 
 .progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #FF7A00, #ffa500);
+    background: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     border-radius: 6px;
     transition: width 0.5s ease;
     position: relative;
@@ -353,7 +353,7 @@
 }
 
 .checkpoint-badge {
-    background: linear-gradient(45deg, #ffa500, #ff7b00);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     color: white;
     padding: 0.25rem 0.75rem;
     border-radius: 12px;
@@ -433,7 +433,7 @@
 }
 
 .achievement-points {
-    background: linear-gradient(45deg, #ffa500, #FF7A00);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     color: white;
     padding: 0.5rem 1rem;
     border-radius: 20px;
@@ -466,7 +466,7 @@
 }
 
 .achievement-popup {
-    background: linear-gradient(135deg, #FF7A00, #ffa500);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     color: white;
     padding: 1.5rem;
     border-radius: 15px;

--- a/css/onboarding-flow.css
+++ b/css/onboarding-flow.css
@@ -433,7 +433,7 @@ body.onboarding-active {
 }
 
 .completion-popup {
-    background: linear-gradient(135deg, var(--primary-orange), #ffa500);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     color: white;
     padding: 3rem;
     border-radius: 20px;

--- a/css/path-bsa-brand-fix.css
+++ b/css/path-bsa-brand-fix.css
@@ -15,7 +15,7 @@
   --text-light: #F7F7F2 !important;
   --text-dim: #B8B8B0 !important;
   --border-color: rgba(255, 122, 0, 0.24) !important;
-  --brand-gradient: linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%) !important;
+  --brand-gradient: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%) !important;
 }
 
 html,

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -85,31 +85,28 @@ html {
    * Avoid gradients on body text and full page backgrounds.
    * ============================================================ */
 
+  /* The signature: orange -> yellow, 135deg, one smooth mid-stop.
+     Canonicalized 2026-06-19 (was 90deg yellow->orange). Direction matches
+     the brand intent "bright orange to bright yellow fade" and the dominant
+     site usage. Use this for headline/numeric text, key bars, icon fills. */
   --brand-gradient: linear-gradient(
-    90deg,
-    #FFE600 0%,
-    #FFD400 18%,
-    #FF9A00 48%,
-    #FF7A00 78%,
-    #E85F00 100%
-  );
-
-  --brand-gradient-angled: linear-gradient(
     135deg,
-    #FFE600 0%,
-    #FFD400 22%,
-    #FF9A00 52%,
-    #FF7A00 75%,
-    #E85F00 100%
+    #FF7A00 0%,
+    #FF9A00 45%,
+    #FFD400 100%
   );
 
-  --brand-gradient-key-takeaway: linear-gradient(
+  /* Horizontal variant for full-width bars / underlines where 135deg looks wrong. */
+  --brand-gradient-h: linear-gradient(
     90deg,
-    #FFE600 0%,
-    #FFD400 20%,
-    #FF9A00 55%,
-    #FF7A00 100%
+    #FF7A00 0%,
+    #FF9A00 45%,
+    #FFD400 100%
   );
+
+  /* Now redundant — kept as aliases so existing consumers collapse onto the signature. */
+  --brand-gradient-angled: var(--brand-gradient);
+  --brand-gradient-key-takeaway: var(--brand-gradient-h);
 
   --brand-gradient-financial: linear-gradient(
     135deg,

--- a/css/youth-engine.css
+++ b/css/youth-engine.css
@@ -83,7 +83,7 @@
 .yf-sheet-kicker { font-size: 0.72rem; font-weight: 700; color: var(--yf-accent); font-family: 'JetBrains Mono', var(--yf-font); }
 .yf-sheet-title {
   margin: 0.4rem 0 0.9rem; font-size: 1.4rem; font-weight: 800;
-  background: linear-gradient(90deg, #FFE600 0%, #FFD400 18%, #FF9A00 48%, #FF7A00 78%, #E85F00 100%);
+  background: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
   -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: var(--yf-accent);
 }
 .yf-sheet-table { width: 100%; border-collapse: collapse; }

--- a/css/youth-skin.css
+++ b/css/youth-skin.css
@@ -68,5 +68,5 @@ body.bsa-skin :is(.choice-type, [class*="badge"], [class*="chip"], [class*="pill
    into a gradient (e.g. week-09's budget-fill.good `…, #34d399`). All progress /
    budget / meter fills use the canonical orange→yellow fade. */
 body.bsa-skin :is(.progress-fill, .budget-fill, [class*="-fill"], [class*="meter-bar"] > span) {
-  background: var(--bsa-grad, linear-gradient(90deg, #FF7A00 0%, #FFD400 100%)) !important;
+  background: var(--bsa-grad, var(--brand-gradient-h)) !important;
 }

--- a/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
@@ -37,7 +37,7 @@
     --dim: #F7F7F2;
     --muted: #F7F7F2;
     --faint: #B3B3B3;
-    --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+    --grad: var(--brand-gradient);
     --grad-soft: linear-gradient(135deg, rgba(255, 122, 0,0.12), rgba(255,215,0,0.04));
     --yellow: #f59e0b;
     --blue: #3b82f6;

--- a/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
@@ -40,7 +40,7 @@
     --dim: #F7F7F2;
     --muted: #F7F7F2;
     --faint: #B3B3B3;
-    --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+    --grad: var(--brand-gradient);
     --grad-soft: linear-gradient(135deg, rgba(255, 122, 0,0.15), rgba(255,215,0,0.05));
     --red: #dc3545;
     --red-soft: rgba(239,68,68,0.12);

--- a/deep-dives/bitcoin-capital/index.html
+++ b/deep-dives/bitcoin-capital/index.html
@@ -28,7 +28,7 @@
     --dim: #F7F7F2;
     --muted: #F7F7F2;
     --faint: #B3B3B3;
-    --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+    --grad: var(--brand-gradient);
     --grad-soft: linear-gradient(135deg, rgba(255, 122, 0,0.12), rgba(255,215,0,0.04));
     --yellow: #f59e0b;
     --yellow-soft: rgba(245,158,11,0.12);

--- a/deep-dives/first-principles/digital-scarcity.html
+++ b/deep-dives/first-principles/digital-scarcity.html
@@ -16,7 +16,7 @@
         .header { text-align: center; padding: 40px 20px; margin-bottom: 40px; }
         .header h1 {
             font-size: 2.5rem; margin-bottom: 15px;
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
         }
         .header .subtitle { font-size: 1.3rem; color: #FF7A00; margin-bottom: 10px; font-weight: 600; }
@@ -27,11 +27,11 @@
             border-radius: 15px; margin-bottom: 25px; overflow: hidden; border: 1px solid #FF7A00;
         }
         .section-header {
-            background: linear-gradient(45deg, #FF7A00, #FFD400); color: black;
+            background: var(--brand-gradient); color: black;
             padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between;
             align-items: center; font-size: 1.2rem; font-weight: bold; transition: all 0.3s;
         }
-        .section-header:hover { background: linear-gradient(45deg, #FF7A00, #FFD400); }
+        .section-header:hover { background: var(--brand-gradient); }
         .section-icon { font-size: 1.5rem; transition: transform 0.3s; }
         .section-body { max-height: 0; overflow: hidden; transition: max-height 0.5s ease; background: #2d2d2d; }
         .section-body.active { max-height: 12000px; }
@@ -43,7 +43,7 @@
         .demo-container { background: #2D2D2D; border-radius: 10px; padding: 25px; margin: 20px 0; border: 2px solid #FF7A00; }
 
         .btn {
-            background: linear-gradient(45deg, #FF7A00, #FFD400); color: black; border: none;
+            background: var(--brand-gradient); color: black; border: none;
             padding: 12px 24px; border-radius: 25px; cursor: pointer; font-size: 1rem;
             font-weight: 700; transition: all 0.3s; margin: 5px;
         }
@@ -71,14 +71,14 @@
         .supply-bar-outer { background: #333; border-radius: 10px; height: 50px; overflow: hidden; margin: 15px 0; position: relative; }
         .supply-bar-fill {
             height: 100%; border-radius: 10px; transition: width 1.5s ease;
-            background: linear-gradient(90deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient-h);
             display: flex; align-items: center; padding-left: 15px; font-weight: 700; color: #000;
         }
         .supply-info { display: flex; justify-content: space-between; font-size: 0.9rem; color: #aaa; margin-top: 5px; }
 
         /* Halving Timeline */
         .halving-timeline { position: relative; padding: 20px 0; }
-        .halving-line { position: absolute; left: 50%; top: 0; bottom: 0; width: 3px; background: linear-gradient(180deg, #FF7A00, #FFD400); transform: translateX(-50%); }
+        .halving-line { position: absolute; left: 50%; top: 0; bottom: 0; width: 3px; background: var(--brand-gradient); transform: translateX(-50%); }
         .halving-event {
             position: relative; margin-bottom: 25px; display: flex; align-items: center;
             cursor: pointer; transition: all 0.3s;
@@ -397,7 +397,7 @@
                                     <span id="s2f-btc-val">S2F: ~120</span>
                                 </div>
                                 <div class="compare-bar-outer">
-                                    <div class="compare-bar-fill" id="s2f-btc" style="width: 0%; background: linear-gradient(90deg, #FF7A00, #FFD400); color: #000;"></div>
+                                    <div class="compare-bar-fill" id="s2f-btc" style="width: 0%; background: var(--brand-gradient-h); color: #000;"></div>
                                 </div>
                             </div>
                             <div class="compare-item">
@@ -406,7 +406,7 @@
                                     <span>S2F: ~62</span>
                                 </div>
                                 <div class="compare-bar-outer">
-                                    <div class="compare-bar-fill" id="s2f-gold" style="width: 0%; background: linear-gradient(90deg, #FFD400, #FFD400); color: #000;"></div>
+                                    <div class="compare-bar-fill" id="s2f-gold" style="width: 0%; background: var(--brand-gradient-h); color: #000;"></div>
                                 </div>
                             </div>
                             <div class="compare-item">
@@ -424,7 +424,7 @@
                                     <span>S2F: ~4</span>
                                 </div>
                                 <div class="compare-bar-outer">
-                                    <div class="compare-bar-fill" id="s2f-usd" style="width: 0%; background: linear-gradient(90deg, #FF7A00, #FF7A00); color: #000;"></div>
+                                    <div class="compare-bar-fill" id="s2f-usd" style="width: 0%; background: var(--color-brand); color: #000;"></div>
                                 </div>
                             </div>
                         </div>

--- a/deep-dives/first-principles/index.html
+++ b/deep-dives/first-principles/index.html
@@ -35,7 +35,7 @@
             font-size: 3rem;
             margin-bottom: 10px;
             color: #FFD400;
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
         }
 
@@ -63,7 +63,7 @@
         }
 
         .principle-fill {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             height: 100%;
             width: 0%;
             transition: width 0.5s ease;
@@ -84,7 +84,7 @@
         }
 
         .principle-header {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: #101010;
             padding: 20px 30px;
             cursor: pointer;
@@ -97,7 +97,7 @@
         }
 
         .principle-header:hover {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
         }
 
         .principle-icon {
@@ -168,7 +168,7 @@
         }
 
         .btn {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: #101010;
             border: none;
             padding: 12px 24px;
@@ -184,15 +184,15 @@
         .btn:hover {
             transform: translateY(-2px);
             box-shadow: 0 5px 15px rgba(255, 122, 0, 0.4);
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
         }
 
         .btn-success {
-            background: linear-gradient(45deg, #FF7A00, #FF7A00);
+            background: var(--color-brand);
         }
 
         .btn-success:hover {
-            background: linear-gradient(45deg, #FF7A00, #FF7A00);
+            background: var(--color-brand);
             box-shadow: 0 5px 15px rgba(255, 122, 0, 0.4);
         }
 
@@ -241,7 +241,7 @@
         }
 
         .person {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: #101010;
             padding: 10px 15px;
             border-radius: 50px;
@@ -257,7 +257,7 @@
         }
 
         .coin {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: #101010;
             padding: 8px 12px;
             border-radius: 50%;
@@ -2355,7 +2355,7 @@
             const puzzlePiece = document.getElementById(`puzzle${attempt}`);
             
             if (attempt === 3) {
-                puzzlePiece.style.background = 'linear-gradient(45deg, #FF7A00, #FF7A00)';
+                puzzlePiece.style.background = 'var(--color-brand)';
                 hashElement.style.color = '#FF7A00';
                 document.getElementById('puzzle-result').innerHTML = `
                     <div class="result-box" style="background: #101010; color: #FF7A00; padding: 15px; border-radius: 5px;">
@@ -2388,7 +2388,7 @@
                 const puzzlePiece = document.getElementById(`puzzle${i}`);
                 if (hashElement) hashElement.textContent = 'Click to hash';
                 if (hashElement) hashElement.style.color = '#ffffff';
-                if (puzzlePiece) puzzlePiece.style.background = 'linear-gradient(45deg, #FF7A00, #FFD400)';
+                if (puzzlePiece) puzzlePiece.style.background = 'var(--brand-gradient)';
             }
             const puzzleResult = document.getElementById('puzzle-result');
             if (puzzleResult) puzzleResult.innerHTML = '';
@@ -2753,7 +2753,7 @@
     <!-- More First Principles Articles -->
     <div style="max-width:900px;margin:2rem auto;padding:0 1.5rem">
         <div style="background: linear-gradient(135deg, #2d2d2d 0%, #101010 100%); border-radius: 15px; padding: 30px; border: 1px solid #2A2A2A;">
-            <h3 style="text-align: center; margin-bottom: 20px; color: #FFD400; background: linear-gradient(45deg, #FF7A00, #FFD400); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; font-size: 1.5rem;">Explore More First Principles</h3>
+            <h3 style="text-align: center; margin-bottom: 20px; color: #FFD400; background: var(--brand-gradient); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; font-size: 1.5rem;">Explore More First Principles</h3>
             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 15px;">
                 <a href="/deep-dives/first-principles/original-question-everything.html" style="background: rgba(255,140,0,0.1); border: 2px solid #FF7A00; border-radius: 10px; padding: 20px; text-decoration: none; color: #fff; transition: all 0.3s;">
                     <div style="font-size: 1.5rem; margin-bottom: 8px;">🔥</div>

--- a/deep-dives/first-principles/original-question-everything.html
+++ b/deep-dives/first-principles/original-question-everything.html
@@ -34,7 +34,7 @@
             font-size: 3rem;
             margin-bottom: 10px;
             text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -64,7 +64,7 @@
         }
 
         .principle-fill {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             height: 100%;
             width: 0%;
             transition: width 0.5s ease;
@@ -85,7 +85,7 @@
         }
 
         .principle-header {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: black;
             padding: 20px 30px;
             cursor: pointer;
@@ -98,7 +98,7 @@
         }
 
         .principle-header:hover {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
         }
 
         .principle-icon {
@@ -169,7 +169,7 @@
         }
 
         .btn {
-            background: linear-gradient(45deg, #FF7A00, #FF7A00);
+            background: var(--color-brand);
             color: white;
             border: none;
             padding: 12px 24px;
@@ -184,15 +184,15 @@
         .btn:hover {
             transform: translateY(-2px);
             box-shadow: 0 5px 15px rgba(255, 122, 0, 0.4);
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
         }
 
         .btn-success {
-            background: linear-gradient(45deg, #FF7A00, #FF7A00);
+            background: var(--color-brand);
         }
 
         .btn-success:hover {
-            background: linear-gradient(45deg, #FF7A00, #FF7A00);
+            background: var(--color-brand);
             box-shadow: 0 5px 15px rgba(255, 122, 0, 0.4);
         }
 
@@ -241,7 +241,7 @@
         }
 
         .person {
-            background: linear-gradient(45deg, #FF7A00, #FF7A00);
+            background: var(--color-brand);
             color: white;
             padding: 10px 15px;
             border-radius: 50px;
@@ -257,7 +257,7 @@
         }
 
         .coin {
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: #101010;
             padding: 8px 12px;
             border-radius: 50%;
@@ -559,7 +559,7 @@
             left: 0;
             right: 0;
             height: 2px;
-            background: linear-gradient(to right, #FF7A00, #FF7A00);
+            background: var(--color-brand);
             z-index: 1;
         }
         
@@ -2337,7 +2337,7 @@
             const puzzlePiece = document.getElementById(`puzzle${attempt}`);
             
             if (attempt === 3) {
-                puzzlePiece.style.background = 'linear-gradient(45deg, #FF7A00, #FF7A00)';
+                puzzlePiece.style.background = 'var(--color-brand)';
                 hashElement.style.color = '#FF7A00';
                 document.getElementById('puzzle-result').innerHTML = `
                     <div class="result-box" style="background: #101010; color: #FF7A00; padding: 15px; border-radius: 5px;">
@@ -2370,7 +2370,7 @@
                 const puzzlePiece = document.getElementById(`puzzle${i}`);
                 if (hashElement) hashElement.textContent = 'Click to hash';
                 if (hashElement) hashElement.style.color = '#ffffff';
-                if (puzzlePiece) puzzlePiece.style.background = 'linear-gradient(45deg, #FF7A00, #FF7A00)';
+                if (puzzlePiece) puzzlePiece.style.background = 'var(--color-brand)';
             }
             const puzzleResult = document.getElementById('puzzle-result');
             if (puzzleResult) puzzleResult.innerHTML = '';

--- a/deep-dives/first-principles/why-money-fails.html
+++ b/deep-dives/first-principles/why-money-fails.html
@@ -16,7 +16,7 @@
         .header { text-align: center; padding: 40px 20px; margin-bottom: 40px; }
         .header h1 {
             font-size: 2.5rem; margin-bottom: 15px;
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;
         }
         .header p { font-size: 1.1rem; opacity: 0.9; max-width: 700px; margin: 0 auto; }
@@ -25,11 +25,11 @@
             border-radius: 15px; margin-bottom: 25px; overflow: hidden; border: 1px solid #FF7A00;
         }
         .failure-header {
-            background: linear-gradient(45deg, #FF7A00, #FFD400); color: black;
+            background: var(--brand-gradient); color: black;
             padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between;
             align-items: center; font-size: 1.2rem; font-weight: bold; transition: all 0.3s;
         }
-        .failure-header:hover { background: linear-gradient(45deg, #FF7A00, #FFD400); }
+        .failure-header:hover { background: var(--brand-gradient); }
         .failure-icon { font-size: 1.5rem; transition: transform 0.3s; }
         .failure-content { max-height: 0; overflow: hidden; transition: max-height 0.5s ease; background: #2d2d2d; }
         .failure-content.active { max-height: 8000px; }
@@ -50,7 +50,7 @@
         .event-impact { font-size: 0.85rem; color: #F7F7F2; }
         .inflation-meter { background: #333; border-radius: 10px; height: 40px; overflow: hidden; margin: 15px 0; position: relative; }
         .inflation-fill { height: 100%; border-radius: 10px; transition: width 1s ease; display: flex; align-items: center; justify-content: flex-end; padding-right: 15px; font-weight: 700; font-size: 0.9rem; }
-        .inflation-fill.mild { background: linear-gradient(90deg, #FF7A00, #f59e0b); }
+        .inflation-fill.mild { background: var(--brand-gradient-h); }
         .inflation-fill.high { background: linear-gradient(90deg, #f59e0b, #dc3545); }
         .inflation-fill.hyper { background: linear-gradient(90deg, #dc3545, #dc3545); }
         .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 15px; margin: 20px 0; }
@@ -58,7 +58,7 @@
         .stat-value { font-size: 1.8rem; font-weight: 800; color: #FF7A00; margin-bottom: 5px; }
         .stat-label { color: #F7F7F2; font-size: 0.9rem; }
         .btn {
-            background: linear-gradient(45deg, #FF7A00, #FFD400); color: black; border: none;
+            background: var(--brand-gradient); color: black; border: none;
             padding: 12px 24px; border-radius: 25px; cursor: pointer; font-size: 1rem;
             font-weight: 700; transition: all 0.3s; margin: 5px;
         }

--- a/deep-dives/money-banking/cantillon-effect.html
+++ b/deep-dives/money-banking/cantillon-effect.html
@@ -16,7 +16,7 @@
         .header h1 {
             font-size: 2.5rem; margin-bottom: 15px;
             color: #FFD400;
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
         }
         .header p { font-size: 1.1rem; color: #F7F7F2; max-width: 700px; margin: 0 auto; }
@@ -26,11 +26,11 @@
             border: 2px solid #2A2A2A;
         }
         .section-header {
-            background: linear-gradient(135deg, #FF7A00, #FF7A00); color: white;
+            background: var(--color-brand); color: white;
             padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between;
             align-items: center; font-size: 1.2rem; font-weight: bold; transition: all 0.3s;
         }
-        .section-header:hover { background: linear-gradient(135deg, #FF7A00, #FF7A00); }
+        .section-header:hover { background: var(--color-brand); }
         .section-icon { font-size: 1.5rem; }
         .section-body { max-height: 0; overflow: hidden; transition: max-height 0.5s ease; }
         .section-body.active { max-height: 10000px; }
@@ -42,7 +42,7 @@
         .demo-container { background: #101010; border-radius: 10px; padding: 25px; margin: 20px 0; border: 2px solid #FF7A00; }
 
         .btn {
-            background: linear-gradient(135deg, #FF7A00, #FF7A00); color: white; border: none;
+            background: var(--color-brand); color: white; border: none;
             padding: 12px 24px; border-radius: 10px; cursor: pointer; font-size: 1rem;
             font-weight: 700; transition: all 0.3s; margin: 5px;
         }
@@ -129,7 +129,7 @@
                                     <div class="wf-name">Federal Reserve</div>
                                     <div class="wf-desc">Creates new money digitally</div>
                                 </div>
-                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-0" style="width: 0%; background: linear-gradient(90deg, #FF7A00, #FF7A00);"></div></div>
+                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-0" style="width: 0%; background: var(--color-brand);"></div></div>
                             </div>
                             <div class="waterfall-level" id="wf-1">
                                 <div class="wf-icon">🏦</div>
@@ -137,7 +137,7 @@
                                     <div class="wf-name">Big Banks & Primary Dealers</div>
                                     <div class="wf-desc">First recipients — buy assets before prices rise</div>
                                 </div>
-                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-1" style="width: 0%; background: linear-gradient(90deg, #FF7A00, #FF7A00);"></div></div>
+                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-1" style="width: 0%; background: var(--color-brand);"></div></div>
                             </div>
                             <div class="waterfall-level" id="wf-2">
                                 <div class="wf-icon">🏢</div>
@@ -145,7 +145,7 @@
                                     <div class="wf-name">Large Corporations</div>
                                     <div class="wf-desc">Cheap loans, stock buybacks, asset purchases</div>
                                 </div>
-                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-2" style="width: 0%; background: linear-gradient(90deg, #FF7A00, #FF7A00);"></div></div>
+                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-2" style="width: 0%; background: var(--color-brand);"></div></div>
                             </div>
                             <div class="waterfall-level" id="wf-3">
                                 <div class="wf-icon">💼</div>
@@ -153,7 +153,7 @@
                                     <div class="wf-name">Wealthy Investors</div>
                                     <div class="wf-desc">Asset prices already rising — stocks, real estate, bonds</div>
                                 </div>
-                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-3" style="width: 0%; background: linear-gradient(90deg, #FF7A00, #FF7A00);"></div></div>
+                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-3" style="width: 0%; background: var(--color-brand);"></div></div>
                             </div>
                             <div class="waterfall-level" id="wf-4">
                                 <div class="wf-icon">🏪</div>
@@ -161,7 +161,7 @@
                                     <div class="wf-name">Small Businesses</div>
                                     <div class="wf-desc">Higher costs, wages lag behind price increases</div>
                                 </div>
-                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-4" style="width: 0%; background: linear-gradient(90deg, #FF7A00, #FF7A00);"></div></div>
+                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-4" style="width: 0%; background: var(--color-brand);"></div></div>
                             </div>
                             <div class="waterfall-level" id="wf-5">
                                 <div class="wf-icon">👨‍👩‍👧‍👦</div>
@@ -169,7 +169,7 @@
                                     <div class="wf-name">Average Workers & Savers</div>
                                     <div class="wf-desc">Last in line — prices already up, wages haven't caught up</div>
                                 </div>
-                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-5" style="width: 0%; background: linear-gradient(90deg, #FF7A00, #FF7A00);"></div></div>
+                                <div class="wf-bar-outer"><div class="wf-bar-fill" id="wfb-5" style="width: 0%; background: var(--color-brand);"></div></div>
                             </div>
                         </div>
 

--- a/deep-dives/money-banking/central-banking-explained.html
+++ b/deep-dives/money-banking/central-banking-explained.html
@@ -10,11 +10,11 @@
         .back-link { display: inline-flex; align-items: center; gap: 0.5rem; color: #FF7A00; text-decoration: none; margin-bottom: 2rem; font-weight: 600; }
         .back-link:hover { color: #FF7A00; }
         .header { text-align: center; padding: 40px 20px; margin-bottom: 40px; }
-        .header h1 { font-size: 2.5rem; margin-bottom: 15px; color: #FFD400; background: linear-gradient(45deg, #FF7A00, #FFD400); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+        .header h1 { font-size: 2.5rem; margin-bottom: 15px; color: #FFD400; background: var(--brand-gradient); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
         .header p { font-size: 1.1rem; color: #F7F7F2; max-width: 700px; margin: 0 auto; }
         .section { background: #101010; border-radius: 15px; margin-bottom: 25px; overflow: hidden; border: 2px solid #2A2A2A; }
-        .section-header { background: linear-gradient(135deg, #FF7A00, #FF7A00); color: white; padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-size: 1.2rem; font-weight: bold; transition: all 0.3s; }
-        .section-header:hover { background: linear-gradient(135deg, #FF7A00, #FF7A00); }
+        .section-header { background: var(--color-brand); color: white; padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-size: 1.2rem; font-weight: bold; transition: all 0.3s; }
+        .section-header:hover { background: var(--color-brand); }
         .section-icon { font-size: 1.5rem; }
         .section-body { max-height: 0; overflow: hidden; transition: max-height 0.5s ease; }
         .section-body.active { max-height: 10000px; }
@@ -23,7 +23,7 @@
         .insight-box { background: #101010; border-left: 3px solid #FF7A00; border-radius: 0 10px 10px 0; padding: 20px; margin: 20px 0; }
         .solution-box { background: #101010; border-left: 3px solid #FF7A00; border-radius: 0 10px 10px 0; padding: 20px; margin: 20px 0; }
         .demo-container { background: #101010; border-radius: 10px; padding: 25px; margin: 20px 0; border: 2px solid #FF7A00; }
-        .btn { background: linear-gradient(135deg, #FF7A00, #FF7A00); color: white; border: none; padding: 12px 24px; border-radius: 10px; cursor: pointer; font-size: 1rem; font-weight: 700; transition: all 0.3s; margin: 5px; }
+        .btn { background: var(--color-brand); color: white; border: none; padding: 12px 24px; border-radius: 10px; cursor: pointer; font-size: 1rem; font-weight: 700; transition: all 0.3s; margin: 5px; }
         .btn:hover { transform: translateY(-2px); box-shadow: 0 5px 15px rgba(255, 122, 0, 0.3); }
         .btn.active-tool { background: linear-gradient(135deg, #dc3545, #dc3545); box-shadow: 0 0 15px rgba(233, 30, 99, 0.4); }
 
@@ -43,7 +43,7 @@
 
         /* Timeline */
         .timeline { position: relative; padding: 20px 0; }
-        .timeline::before { content: ''; position: absolute; left: 20px; top: 0; bottom: 0; width: 3px; background: linear-gradient(180deg, #FF7A00, #FF7A00); }
+        .timeline::before { content: ''; position: absolute; left: 20px; top: 0; bottom: 0; width: 3px; background: var(--color-brand); }
         .tl-event { position: relative; margin-left: 50px; margin-bottom: 25px; padding: 15px; background: #16181C; border: 1px solid #2A2A2A; border-radius: 10px; cursor: pointer; transition: all 0.3s; }
         .tl-event:hover { border-color: #FF7A00; }
         .tl-event::before { content: ''; position: absolute; left: -38px; top: 20px; width: 16px; height: 16px; background: #101010; border-radius: 50%; border: 3px solid #FF7A00; }

--- a/deep-dives/money-banking/history-of-money.html
+++ b/deep-dives/money-banking/history-of-money.html
@@ -10,7 +10,7 @@
         .back-link { display: inline-flex; align-items: center; gap: 0.5rem; color: #FF7A00; text-decoration: none; margin-bottom: 2rem; font-weight: 600; }
         .back-link:hover { color: #FF7A00; }
         .header { text-align: center; padding: 40px 20px; margin-bottom: 40px; }
-        .header h1 { font-size: 2.5rem; margin-bottom: 15px; color: #FFD400; background: linear-gradient(45deg, #FF7A00, #FFD400); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+        .header h1 { font-size: 2.5rem; margin-bottom: 15px; color: #FFD400; background: var(--brand-gradient); -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
         .header p { font-size: 1.1rem; color: #F7F7F2; max-width: 700px; margin: 0 auto; }
 
         .era-card {

--- a/deep-dives/money-banking/index.html
+++ b/deep-dives/money-banking/index.html
@@ -40,7 +40,7 @@
         .hero h1 {
             font-size: 3rem;
             color: #FFD400;
-            background: linear-gradient(45deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             background-clip: text;
             -webkit-text-fill-color: transparent;
@@ -146,7 +146,7 @@
         .cta-btn {
             display: inline-block;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #FF7A00, #FF7A00);
+            background: var(--color-brand);
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;
@@ -156,7 +156,7 @@
         }
 
         .cta-btn:hover {
-            background: linear-gradient(135deg, #FF7A00, #FF7A00);
+            background: var(--color-brand);
             transform: translateY(-2px);
         }
 

--- a/deep-dives/philosophy-economics/property-rights.html
+++ b/deep-dives/philosophy-economics/property-rights.html
@@ -10,11 +10,11 @@
         .back-link { display: inline-flex; align-items: center; gap: 0.5rem; color: #FF7A00; text-decoration: none; margin-bottom: 2rem; font-weight: 600; }
         .back-link:hover { color: #FF7A00; }
         .header { text-align: center; padding: 40px 20px; margin-bottom: 40px; }
-        .header h1 { font-size: 2.5rem; margin-bottom: 15px; background: linear-gradient(135deg, #FF7A00, #FFD400); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+        .header h1 { font-size: 2.5rem; margin-bottom: 15px; background: var(--brand-gradient); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
         .header p { font-size: 1.1rem; color: #999; max-width: 700px; margin: 0 auto; }
         .section { background: #16181C; border-radius: 15px; margin-bottom: 25px; overflow: hidden; border: 1px solid rgba(255, 122, 0, 0.25); }
-        .section-header { background: linear-gradient(135deg, #FF7A00, #FFD400); color: black; padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-size: 1.2rem; font-weight: bold; }
-        .section-header:hover { background: linear-gradient(135deg, #f59e0b, #FFD400); }
+        .section-header { background: var(--brand-gradient); color: black; padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-size: 1.2rem; font-weight: bold; }
+        .section-header:hover { background: var(--brand-gradient); }
         .section-icon { font-size: 1.5rem; }
         .section-body { max-height: 0; overflow: hidden; transition: max-height 0.5s ease; }
         .section-body.active { max-height: 10000px; }

--- a/deep-dives/philosophy-economics/time-preference.html
+++ b/deep-dives/philosophy-economics/time-preference.html
@@ -10,11 +10,11 @@
         .back-link { display: inline-flex; align-items: center; gap: 0.5rem; color: #FF7A00; text-decoration: none; margin-bottom: 2rem; font-weight: 600; }
         .back-link:hover { color: #FF7A00; }
         .header { text-align: center; padding: 40px 20px; margin-bottom: 40px; }
-        .header h1 { font-size: 2.5rem; margin-bottom: 15px; background: linear-gradient(135deg, #FF7A00, #FFD400); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+        .header h1 { font-size: 2.5rem; margin-bottom: 15px; background: var(--brand-gradient); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
         .header p { font-size: 1.1rem; color: #999; max-width: 700px; margin: 0 auto; }
         .section { background: #16181C; border-radius: 15px; margin-bottom: 25px; overflow: hidden; border: 1px solid rgba(255, 122, 0, 0.25); }
-        .section-header { background: linear-gradient(135deg, #FF7A00, #FFD400); color: black; padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-size: 1.2rem; font-weight: bold; }
-        .section-header:hover { background: linear-gradient(135deg, #f59e0b, #FFD400); }
+        .section-header { background: var(--brand-gradient); color: black; padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-size: 1.2rem; font-weight: bold; }
+        .section-header:hover { background: var(--brand-gradient); }
         .section-icon { font-size: 1.5rem; }
         .section-body { max-height: 0; overflow: hidden; transition: max-height 0.5s ease; }
         .section-body.active { max-height: 10000px; }
@@ -23,7 +23,7 @@
         .problem-box { background: #101010; border-left: 3px solid #dc3545; border-radius: 0 10px 10px 0; padding: 20px; margin: 20px 0; }
         .solution-box { background: #101010; border-left: 3px solid #FF7A00; border-radius: 0 10px 10px 0; padding: 20px; margin: 20px 0; }
         .demo-container { background: #101010; border-radius: 10px; padding: 25px; margin: 20px 0; border: 2px solid #FF7A00; }
-        .btn { background: linear-gradient(135deg, #FF7A00, #FFD400); color: black; border: none; padding: 12px 24px; border-radius: 25px; cursor: pointer; font-size: 1rem; font-weight: 700; transition: all 0.3s; margin: 5px; }
+        .btn { background: var(--brand-gradient); color: black; border: none; padding: 12px 24px; border-radius: 25px; cursor: pointer; font-size: 1rem; font-weight: 700; transition: all 0.3s; margin: 5px; }
         .btn:hover { transform: translateY(-2px); box-shadow: 0 5px 15px rgba(255, 122, 0, 0.4); }
 
         .tp-slider-container { margin: 25px 0; }

--- a/deep-dives/philosophy-economics/voluntaryism-bitcoin.html
+++ b/deep-dives/philosophy-economics/voluntaryism-bitcoin.html
@@ -10,11 +10,11 @@
         .back-link { display: inline-flex; align-items: center; gap: 0.5rem; color: #FF7A00; text-decoration: none; margin-bottom: 2rem; font-weight: 600; }
         .back-link:hover { color: #FF7A00; }
         .header { text-align: center; padding: 40px 20px; margin-bottom: 40px; }
-        .header h1 { font-size: 2.5rem; margin-bottom: 15px; background: linear-gradient(135deg, #FF7A00, #FFD400); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+        .header h1 { font-size: 2.5rem; margin-bottom: 15px; background: var(--brand-gradient); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
         .header p { font-size: 1.1rem; color: #999; max-width: 700px; margin: 0 auto; }
         .section { background: #16181C; border-radius: 15px; margin-bottom: 25px; overflow: hidden; border: 1px solid rgba(255, 122, 0, 0.25); }
-        .section-header { background: linear-gradient(135deg, #FF7A00, #FFD400); color: black; padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-size: 1.2rem; font-weight: bold; }
-        .section-header:hover { background: linear-gradient(135deg, #f59e0b, #FFD400); }
+        .section-header { background: var(--brand-gradient); color: black; padding: 20px 30px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-size: 1.2rem; font-weight: bold; }
+        .section-header:hover { background: var(--brand-gradient); }
         .section-icon { font-size: 1.5rem; }
         .section-body { max-height: 0; overflow: hidden; transition: max-height 0.5s ease; }
         .section-body.active { max-height: 10000px; }

--- a/embeds/intent-theft-sandbox/index.html
+++ b/embeds/intent-theft-sandbox/index.html
@@ -43,7 +43,7 @@
     --or:#F7931A;        /* bitcoin orange */
     --or-2:#FBB034;
     --ye:#FCD116;        /* bright yellow */
-    --grad:linear-gradient(100deg,#F7931A 0%,#FBB034 52%,#FCD116 100%);
+    --grad:var(--brand-gradient-h);
     --green:#34c759;
     --green-d:rgba(52,199,89,.12);
     --amber:#f0a92b;

--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
             --text-dim: #b3b3b3; /* WCAG 2.1 AA contrast fix - changed from #999 */
             --success-green: #28a745;
             --danger-red: #f44336;
-            --gradient-orange: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --gradient-orange: var(--brand-gradient);
             --gradient-dark: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);
             --path-curious: #28a745;
             --path-hurried: #f59e0b;
@@ -1500,7 +1500,7 @@
         }
 
         .featured-exp-card.experiences::before {
-            background: linear-gradient(135deg, #FF7A00, #ab47bc);
+            background: var(--brand-gradient);
         }
 
         .featured-exp-card.experiences:hover {

--- a/institutional/cities.html
+++ b/institutional/cities.html
@@ -18,7 +18,7 @@
             --light: #e0e0e0;
             --dim: #b3b3b3;
             --green: #4caf50;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/corporations.html
+++ b/institutional/corporations.html
@@ -18,7 +18,7 @@
             --light: #e0e0e0;
             --dim: #b3b3b3;
             --green: #4caf50;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
@@ -164,7 +164,7 @@
                     <span style="font-size:3rem; display:block; margin-bottom:1rem;">🇨🇴</span>
                     <h3 style="color:#fcd116; font-size:1.3rem; margin-bottom:0.75rem;">Colombia</h3>
                     <p style="color:var(--dim); font-size:0.9rem; margin-bottom:1.5rem;">Educación financiera práctica para equipos, habilidades digitales, estabilidad laboral</p>
-                    <a href="/institutional/corporations/colombia/" style="display:inline-block; padding:0.75rem 1.5rem; background:linear-gradient(135deg,#fcd116 0%,#FF7A00 100%); color:var(--dark); text-decoration:none; border-radius:25px; font-weight:600;">Explorar Programa</a>
+                    <a href="/institutional/corporations/colombia/" style="display:inline-block; padding:0.75rem 1.5rem; background:var(--brand-gradient); color:var(--dark); text-decoration:none; border-radius:25px; font-weight:600;">Explorar Programa</a>
                 </div>
                 <div class="region-card" style="background:rgba(26,26,26,0.8); border:2px solid rgba(16,185,129,0.4); border-radius:12px; padding:2rem; text-align:center;">
                     <span style="font-size:3rem; display:block; margin-bottom:1rem;">💰</span>

--- a/institutional/correctional.html
+++ b/institutional/correctional.html
@@ -18,7 +18,7 @@
             --light: #e0e0e0;
             --dim: #b3b3b3;
             --green: #4caf50;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/education.html
+++ b/institutional/education.html
@@ -18,7 +18,7 @@
             --light: #e0e0e0;
             --dim: #b3b3b3;
             --green: #4caf50;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/index.html
+++ b/institutional/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Custom Bitcoin education programs for cities, corporations, wealth advisors, correctional facilities, and educational institutions. Schedule a free consultation.">
     <link rel="canonical" href="https://bitcoinsovereign.academy/institutional/">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --grad:linear-gradient(135deg,#FF7A00,#FFD400); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .header { background:rgba(45,45,45,0.97); backdrop-filter:blur(10px); padding:1rem 0; border-bottom:2px solid var(--primary); position:fixed; width:100%; top:0; z-index:1000; }

--- a/institutional/real-estate-developers/calculator/index.html
+++ b/institutional/real-estate-developers/calculator/index.html
@@ -9,7 +9,7 @@
   :root {
     --primary:#FF7A00; --primary-soft:#ffb04a; --dark:#1a1a1a; --dark2:#2d2d2d;
     --dark3:#383838; --light:#e0e0e0; --dim:#b3b3b3; --faint:#7a7a7a;
-    --grad:linear-gradient(135deg,#FF7A00,#ffb04a);
+    --grad:var(--brand-gradient);
     --green:#3ccb7f; --red:#ff6b6b; --yellow:#ffcb57; --blue:#6bb4ff;
     --border:rgba(255,255,255,0.1); --border-strong:rgba(255, 122, 0,0.45);
   }

--- a/institutional/real-estate-developers/index.html
+++ b/institutional/real-estate-developers/index.html
@@ -11,7 +11,7 @@
     <meta property="og:url" content="https://bitcoinsovereign.academy/institutional/real-estate-developers/">
     <meta property="og:type" content="website">
     <style>
-        :root { --primary:#FF7A00; --primary-soft:#FFD400; --dark:#1a1a1a; --dark2:#2d2d2d; --dark3:#383838; --light:#e0e0e0; --dim:#b3b3b3; --faint:#7a7a7a; --grad:linear-gradient(135deg,#FF7A00,#FFD400); }
+        :root { --primary:#FF7A00; --primary-soft:#FFD400; --dark:#1a1a1a; --dark2:#2d2d2d; --dark3:#383838; --light:#e0e0e0; --dim:#b3b3b3; --faint:#7a7a7a; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.7; }
         a { color:var(--primary); text-decoration:none; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/advisor-toolkit.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/advisor-toolkit.html
@@ -16,7 +16,7 @@
             --red: #f44336;
             --blue: #2196f3;
             --yellow: #ffc107;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
 
         * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-1/module-01-problem-bitcoin-solves.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-1/module-01-problem-bitcoin-solves.html
@@ -13,7 +13,7 @@
             --dim: #b3b3b3;
             --green: #4caf50;
             --red: #f44336;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-1/module-02-bitcoin-monetary-economics.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-1/module-02-bitcoin-monetary-economics.html
@@ -13,7 +13,7 @@
             --dim: #b3b3b3;
             --green: #4caf50;
             --red: #f44336;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-1/module-03-bitcoin-as-portfolio-asset.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-1/module-03-bitcoin-as-portfolio-asset.html
@@ -13,7 +13,7 @@
             --dim: #b3b3b3;
             --green: #4caf50;
             --red: #f44336;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-1/module-04-portfolio-allocation-strategies.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-1/module-04-portfolio-allocation-strategies.html
@@ -13,7 +13,7 @@
             --dim: #b3b3b3;
             --green: #4caf50;
             --red: #f44336;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-2/module-05-understanding-bitcoin-custody.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-2/module-05-understanding-bitcoin-custody.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 5: Understanding Bitcoin Custody | Bitcoin Advisor Certification</title>
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .container { max-width:1000px; margin:0 auto; padding:2rem; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-2/module-06-exchange-and-etf-custody.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-2/module-06-exchange-and-etf-custody.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 6: Exchange and ETF Custody | Bitcoin Advisor Certification</title>
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .container { max-width:1000px; margin:0 auto; padding:2rem; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-2/module-07-self-custody-hardware-wallets.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-2/module-07-self-custody-hardware-wallets.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 7: Self-Custody and Hardware Wallets | Bitcoin Advisor Certification</title>
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .container { max-width:1000px; margin:0 auto; padding:2rem; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-2/module-08-collaborative-custody-multisig.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-2/module-08-collaborative-custody-multisig.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 8: Collaborative Custody and Multisignature | Bitcoin Advisor Certification</title>
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .container { max-width:1000px; margin:0 auto; padding:2rem; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-09-bitcoin-tax-treatment.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-09-bitcoin-tax-treatment.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 9: Bitcoin Tax Treatment | Bitcoin Advisor Certification</title>
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .container { max-width:1000px; margin:0 auto; padding:2rem; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-10-estate-inheritance-planning.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-10-estate-inheritance-planning.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 10: Estate &amp; Inheritance Planning | Bitcoin Advisor Certification</title>
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .container { max-width:1000px; margin:0 auto; padding:2rem; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-11-client-education-communication.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-11-client-education-communication.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 11: Client Education &amp; Communication | Bitcoin Advisor Certification</title>
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .container { max-width:1000px; margin:0 auto; padding:2rem; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-12-building-advisory-practice.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/day-3/module-12-building-advisory-practice.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Module 12: Building a Bitcoin Advisory Practice | Bitcoin Advisor Certification</title>
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .container { max-width:1000px; margin:0 auto; padding:2rem; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/index.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/index.html
@@ -17,7 +17,7 @@
             --blue: #2196f3;
             --red: #f44336;
             --yellow: #ffc107;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         
         * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -651,7 +651,7 @@
                 
                 <p style="color: #b3b3b3; max-width: 760px; margin: 0 auto 1.5rem;">Use the toolkit as a repeatable client workflow: discovery first, allocation second, custody third.</p>
                 <div style="margin-top: 2rem;">
-                    <a href="advisor-toolkit.html#client-discovery-tool" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%); color: white; text-decoration: none; border-radius: 25px; font-weight: 600; transition: all 0.3s; margin-right: 1rem;">🧭 Start Client Discovery</a>
+                    <a href="advisor-toolkit.html#client-discovery-tool" style="display: inline-block; padding: 1rem 2rem; background: var(--brand-gradient); color: white; text-decoration: none; border-radius: 25px; font-weight: 600; transition: all 0.3s; margin-right: 1rem;">🧭 Start Client Discovery</a>
                     <a href="advisor-toolkit.html#custody-framework-tool" style="display: inline-block; padding: 1rem 2rem; background: transparent; border: 2px solid #FF7A00; color: #FF7A00; text-decoration: none; border-radius: 25px; font-weight: 600; transition: all 0.3s;">🔐 Open Custody Framework</a>
                 </div>
         </div>

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-01-why-advisors-cannot-ignore-bitcoin.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-01-why-advisors-cannot-ignore-bitcoin.html
@@ -15,7 +15,7 @@
             --green: #4caf50;
             --red: #f44336;
             --blue: #2196f3;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
             --accent-grad: linear-gradient(135deg, #2196f3 0%, #42a5f5 100%);
         }
         

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-02-bitcoin-explained-professionals.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-02-bitcoin-explained-professionals.html
@@ -6,7 +6,7 @@
     <title>Module 2: Bitcoin Explained for Financial Professionals | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Master the 3-sentence Bitcoin explanation framework. Understand monetary properties and confidently differentiate Bitcoin from broader cryptocurrency.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-03-bitcoin-as-asset-class.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-03-bitcoin-as-asset-class.html
@@ -6,7 +6,7 @@
     <title>Module 3: Bitcoin as an Asset Class | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Evaluate Bitcoin in portfolio context with a practical framework for volatility, time horizon, and allocation discipline.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-04-allocation-frameworks.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-04-allocation-frameworks.html
@@ -6,7 +6,7 @@
     <title>Module 4: Allocation Frameworks | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Create defensible Bitcoin allocation ranges using a practical advisor framework for risk, liquidity, and conviction.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-05-bitcoin-investment-vehicles.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-05-bitcoin-investment-vehicles.html
@@ -6,7 +6,7 @@
     <title>Module 5: Bitcoin Investment Vehicles | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Compare Bitcoin investment vehicles and match the wrapper to client goals, account type, and implementation complexity.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-06-custody-and-security.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-06-custody-and-security.html
@@ -6,7 +6,7 @@
     <title>Module 6: Custody and Security | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Learn the custody spectrum for Bitcoin and identify clear handoff points from advisor guidance to specialist implementation.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-07-bitcoin-taxation.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-07-bitcoin-taxation.html
@@ -6,7 +6,7 @@
     <title>Module 7: Bitcoin Taxation | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Learn the practical tax treatment of Bitcoin in the U.S., including property treatment, taxable events, recordkeeping, and 1099-DA awareness.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-08-estate-and-inheritance-planning.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-08-estate-and-inheritance-planning.html
@@ -6,7 +6,7 @@
     <title>Module 8: Estate and Inheritance Planning | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Plan for Bitcoin inheritance with practical advisor guidance and clear specialist handoff points for secure implementation.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-09-compliance-and-fiduciary-duty.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-09-compliance-and-fiduciary-duty.html
@@ -6,7 +6,7 @@
     <title>Module 9: Compliance and Fiduciary Duty | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Build a practical Bitcoin compliance and fiduciary process for documentation, suitability, and specialist handoff.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-10-client-communication-mastery.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-10-client-communication-mastery.html
@@ -6,7 +6,7 @@
     <title>Module 10: Client Communication Mastery | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Master clear, non-hype Bitcoin client communication and know when to answer directly versus when to bring in a specialist.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-11-case-studies-common-scenarios.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-11-case-studies-common-scenarios.html
@@ -6,7 +6,7 @@
     <title>Module 11: Case Studies and Common Scenarios | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Apply Bitcoin advisory frameworks to realistic client cases and identify the right advisor-specialist workflow.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-12-building-advisory-practice.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-12-building-advisory-practice.html
@@ -6,7 +6,7 @@
     <title>Module 12: Building Your Bitcoin Advisory Practice | Bitcoin in Wealth Advisory</title>
     <meta name="description" content="Build a responsible Bitcoin advisory offering with clear scope, process, and specialist partnership design.">
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --red:#f44336; --blue:#2196f3; --grad:var(--brand-gradient); }
         *{margin:0;padding:0;box-sizing:border-box}
         body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--dark);color:var(--light);line-height:1.6}
         .header{background:rgba(45,45,45,.97);backdrop-filter:blur(10px);padding:1rem 0;border-bottom:2px solid var(--primary);position:fixed;width:100%;top:0;z-index:1000}

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-13-working-with-bitcoin-specialists.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/modules/module-13-working-with-bitcoin-specialists.html
@@ -15,7 +15,7 @@
             --green: #4caf50;
             --red: #f44336;
             --blue: #2196f3;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         
         * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/resources/advisor-simulation-exercise.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/resources/advisor-simulation-exercise.html
@@ -14,7 +14,7 @@
             --green: #4caf50;
             --red: #f44336;
             --blue: #2196f3;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/resources/client-risk-assessment-tool.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/resources/client-risk-assessment-tool.html
@@ -14,7 +14,7 @@
             --green: #4caf50;
             --red: #f44336;
             --blue: #2196f3;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/resources/custody-decision-tree.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/resources/custody-decision-tree.html
@@ -15,7 +15,7 @@
             --red: #f44336;
             --blue: #2196f3;
             --purple: #9c27b0;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }

--- a/institutional/wealth-advisors/bitcoin-advisor-certification/resources/slide-deck.html
+++ b/institutional/wealth-advisors/bitcoin-advisor-certification/resources/slide-deck.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Slide Deck | Bitcoin Advisor Certification</title>
     <style>
-        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --grad:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%); }
+        :root { --primary:#FF7A00; --dark:#1a1a1a; --dark2:#2d2d2d; --light:#e0e0e0; --dim:#b3b3b3; --green:#4caf50; --grad:var(--brand-gradient); }
         * { margin:0; padding:0; box-sizing:border-box; }
         body { font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif; background:var(--dark); color:var(--light); line-height:1.6; }
         .container { max-width:1000px; margin:0 auto; padding:2rem; }

--- a/institutional/wealth-advisors/index.html
+++ b/institutional/wealth-advisors/index.html
@@ -20,7 +20,7 @@
             --green: #4caf50;
             --blue: #2196f3;
             --red: #f44336;
-            --grad: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            --grad: var(--brand-gradient);
         }
         
         * { margin: 0; padding: 0; box-sizing: border-box; }

--- a/interactive-demos/bitcoin-dca-time-machine/index.html
+++ b/interactive-demos/bitcoin-dca-time-machine/index.html
@@ -36,7 +36,7 @@
 
         .header h1 {
             font-size: clamp(2rem, 5vw, 3rem);
-            background: linear-gradient(135deg, #FF7A00 0%, #FFD700 100%);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -168,7 +168,7 @@
         .calculate-btn {
             width: 100%;
             padding: 1.25rem;
-            background: linear-gradient(135deg, #FF7A00 0%, #E58210 100%);
+            background: var(--brand-gradient);
             border: none;
             border-radius: 0.75rem;
             color: white;

--- a/interactive-demos/bitcoin-genesis-timeline/index.html
+++ b/interactive-demos/bitcoin-genesis-timeline/index.html
@@ -136,7 +136,7 @@
             font-size: 2.5rem;
             color: var(--primary-orange);
             margin-bottom: 1rem;
-            background: linear-gradient(135deg, var(--primary-orange), #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -302,7 +302,7 @@
 
         .demo-button {
             padding: 0.6rem 1.2rem;
-            background: linear-gradient(135deg, var(--primary-orange), #FFD400);
+            background: var(--brand-gradient);
             color: white;
             border: none;
             border-radius: 0.5rem;

--- a/interactive-demos/bitcoin-vs-banking/index.html
+++ b/interactive-demos/bitcoin-vs-banking/index.html
@@ -42,7 +42,7 @@
         .header h1 {
             font-size: 2.5rem;
             margin-bottom: 1rem;
-            background: linear-gradient(135deg, #FF7A00 0%, #FFA940 100%);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;

--- a/interactive-demos/energy-bucket/index.html
+++ b/interactive-demos/energy-bucket/index.html
@@ -77,7 +77,7 @@
 
         .progress-fill {
             height: 100%;
-            background: linear-gradient(90deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient-h);
             width: 16.67%;
             transition: width 0.5s ease;
             border-radius: 3px;
@@ -272,7 +272,7 @@
 
         .energy-fill {
             height: 100%;
-            background: linear-gradient(90deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient-h);
             width: 0%;
             transition: width 0.3s ease;
             border-radius: 13px;
@@ -298,7 +298,7 @@
             position: absolute;
             bottom: 0;
             width: 100%;
-            background: linear-gradient(180deg, #FF7A00, #ff8c00);
+            background: var(--brand-gradient);
             transition: height 0.5s ease;
             border-radius: 0 0 17px 17px;
         }
@@ -900,7 +900,7 @@
             document.getElementById('energyFill').style.width = '0%';
             document.getElementById('bucketFill1').style.height = '0%';
             document.getElementById('bucketAfterTime').style.height = '80%';
-            document.getElementById('bucketAfterTime').style.background = 'linear-gradient(180deg, #FF7A00, #ff8c00)';
+            document.getElementById('bucketAfterTime').style.background = 'var(--brand-gradient)';
             document.getElementById('fiatFill').style.height = '80%';
             document.getElementById('spendingBucket').style.height = '80%';
             document.getElementById('clock').textContent = '🕐';

--- a/interactive-demos/fee-master-tool/index.html
+++ b/interactive-demos/fee-master-tool/index.html
@@ -69,7 +69,7 @@
         .header h1 {
             font-size: 2.5rem;
             margin-bottom: 1rem;
-            background: linear-gradient(135deg, #FF7A00 0%, #FFA940 100%);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -105,7 +105,7 @@
         }
         
         .tab-button.active {
-            background: linear-gradient(135deg, #FF7A00 0%, #E58210 100%);
+            background: var(--brand-gradient);
             border-color: #FF7A00;
             color: white;
             font-weight: 600;
@@ -186,7 +186,7 @@
         .btn-primary {
             width: 100%;
             padding: 1rem;
-            background: linear-gradient(135deg, #FF7A00, #E58210);
+            background: var(--brand-gradient);
             color: white;
             border: none;
             border-radius: 8px;

--- a/interactive-demos/index.html
+++ b/interactive-demos/index.html
@@ -15,7 +15,7 @@
         --border: var(--color-border);
         --chip: var(--color-chip);
         --accent: var(--color-accent);
-        --fade: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+        --fade: var(--brand-gradient);
       }
 
       html,body{margin:0;padding:0;background:var(--color-bg,#16181C);color:var(--color-text,#F7F7F2);font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Arial}
@@ -68,7 +68,7 @@
       .grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fill,minmax(220px,1fr))}
 
       .wrap .card{background:var(--color-surface,#1F2024) !important;border:1px solid var(--color-border,#2D2F35) !important;box-shadow:none !important;color:var(--color-text,#F7F7F2) !important;border-radius:8px;padding:14px 16px;text-decoration:none;display:block;transition:border-color .15s ease,background .15s ease}
-      .wrap .card:hover{border-color:transparent !important;box-shadow:none !important;background:linear-gradient(var(--color-surface,#1F2024),var(--color-surface,#1F2024)) padding-box,linear-gradient(135deg,#FF7A00,#FFD400) border-box !important}
+      .wrap .card:hover{border-color:transparent !important;box-shadow:none !important;background:linear-gradient(var(--color-surface,#1F2024),var(--color-surface,#1F2024)) padding-box,var(--brand-gradient) border-box !important}
       .wrap .card::before{display:none !important}
       .card h2{margin:0 0 6px;font-size:.95rem;font-weight:600;display:flex;align-items:center;gap:8px;line-height:1.3;color:var(--color-text,#F7F7F2)}
       .card p{font-size:.83rem;line-height:1.4;color:var(--color-muted,#B8B8B0);margin:0 0 10px}
@@ -87,7 +87,7 @@
 
       .wrap .featured-card{grid-column:1/-1;background:var(--color-surface,#1F2024) !important;border:1px solid var(--color-accent,#FF8A00) !important;box-shadow:none !important}
       .wrap .featured-card::after{display:none !important}
-      .wrap .featured-card:hover{border-color:transparent !important;box-shadow:none !important;background:linear-gradient(var(--color-surface,#1F2024),var(--color-surface,#1F2024)) padding-box,linear-gradient(135deg,#FF7A00,#FFD400) border-box !important}
+      .wrap .featured-card:hover{border-color:transparent !important;box-shadow:none !important;background:linear-gradient(var(--color-surface,#1F2024),var(--color-surface,#1F2024)) padding-box,var(--brand-gradient) border-box !important}
 
       .card{min-height:44px}
       button,a,[role="button"]{min-height:44px;min-width:44px}

--- a/interactive-demos/kyc-best-practices/index.html
+++ b/interactive-demos/kyc-best-practices/index.html
@@ -112,7 +112,7 @@
             box-shadow: 0 0 0 3px rgba(255, 122, 0,0.35);
         }
         .kyc-decider__btn {
-            background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            background: var(--brand-gradient);
             color: #0b0e14;
             padding: 0.75rem 1.5rem;
             border-radius: 8px;

--- a/interactive-demos/sat-stacking-calculator/index.html
+++ b/interactive-demos/sat-stacking-calculator/index.html
@@ -57,7 +57,7 @@
         /* Shell pilot: brand numeric fade (orange -> yellow) with solid fallback for readability */
         .num-fade {
             color: #FF7A00;
-            background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             background-clip: text;
             -webkit-text-fill-color: transparent;
@@ -80,7 +80,7 @@
             font-size: 2.5rem;
             margin-bottom: 1rem;
             color: #FF7A00;
-            background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -210,7 +210,7 @@
             font-weight: 700;
             font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);
             color: #FF7A00;
-            background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             background-clip: text;
             -webkit-text-fill-color: transparent;
@@ -265,7 +265,7 @@
             font-weight: 700;
             font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace);
             color: #FF7A00;
-            background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             background-clip: text;
             -webkit-text-fill-color: transparent;

--- a/interactive-demos/utxo-visualizer-enhanced/index.html
+++ b/interactive-demos/utxo-visualizer-enhanced/index.html
@@ -241,7 +241,7 @@
         }
 
         .utxo-coin {
-            background: linear-gradient(135deg, #FF7A00, #ff6b00);
+            background: var(--brand-gradient);
             border: 3px solid #ff9800;
             border-radius: 12px;
             padding: 1rem;

--- a/interactive-demos/wallet-security-workshop/index.html
+++ b/interactive-demos/wallet-security-workshop/index.html
@@ -591,7 +591,7 @@
     }
     .rp-progress-bar-fill {
         height: 100%;
-        background: linear-gradient(90deg, var(--primary-orange), #FFD400);
+        background: var(--brand-gradient-h);
         border-radius: 4px; transition: width 0.4s ease; width: 0%;
     }
 

--- a/interactive-demos/wallet-workshop/index.html
+++ b/interactive-demos/wallet-workshop/index.html
@@ -1144,7 +1144,7 @@ If you don't control the private keys (the seed words), you don't actually own t
             <p style="margin-bottom: 2rem; line-height: 1.8;">You've learned the foundation. Ready to see how it all works interactively?</p>
             
             <div style="display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;">
-                <a href="/interactive-demos/wallet-security-workshop/" class="action-btn" style="text-decoration: none; display: inline-block; background: linear-gradient(135deg, #FF7A00 0%, #ff6b00 100%);">
+                <a href="/interactive-demos/wallet-security-workshop/" class="action-btn" style="text-decoration: none; display: inline-block; background: var(--brand-gradient);">
                     🔐 Practice Wallet Security Workshop
                 </a>
                 <a href="/interactive-demos/security-dojo-enhanced/" class="action-btn" style="background: #4caf50; text-decoration: none; display: inline-block;">

--- a/js/email-capture.js
+++ b/js/email-capture.js
@@ -108,7 +108,7 @@ substackUrl: '',
                     background: transparent;
                     color: #FF7A00;
                     border: 2px solid transparent;
-                    border-image: linear-gradient(135deg, #FF7A00, #FFD400) 1;
+                    border-image: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%) 1;
                     font-family: 'JetBrains Mono', ui-monospace, monospace;
                     font-weight: 700;
                     font-size: 0.8rem;

--- a/js/gemini-tutor-ui.js
+++ b/js/gemini-tutor-ui.js
@@ -207,7 +207,7 @@ class GeminiTutorUI {
                     />
                     <button type="button" id="send-btn" aria-label="Send message" style="
                         padding: 12px 20px;
-                        background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+                        background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                         border: none;
                         border-radius: 12px;
                         color: white;

--- a/js/learning-path-navigator.js
+++ b/js/learning-path-navigator.js
@@ -334,7 +334,7 @@
             }
 
             .lpn-btn-primary {
-                background: linear-gradient(135deg, #FF7A00, #FFD400);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 color: white;
                 box-shadow: 0 2px 10px rgba(255, 122, 0, 0.3);
             }

--- a/js/membership-gate.js
+++ b/js/membership-gate.js
@@ -529,7 +529,7 @@
                 }
 
                 .gate-btn.primary {
-                    background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+                    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                     color: #000;
                 }
 

--- a/js/module-gate-subdomain.js
+++ b/js/module-gate-subdomain.js
@@ -563,7 +563,7 @@
                 font-size: 0.95rem;
             }
             .module-lock-cta {
-                background: linear-gradient(135deg, #FF7A00, #FFD400);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 color: #121212;
                 font-weight: 700;
                 border: none;

--- a/js/module-gate.js
+++ b/js/module-gate.js
@@ -440,7 +440,7 @@
                 flex-wrap: wrap;
             }
             .btn-primary-small {
-                background: linear-gradient(135deg, #FF7A00, #FFD400);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 color: #121212;
                 font-weight: 600;
                 padding: 0.6rem 1.25rem;
@@ -627,7 +627,7 @@
                 font-size: 0.9rem;
             }
             .module-lock-cta {
-                background: linear-gradient(135deg, #FF7A00, #FFD400);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 color: #121212;
                 font-weight: 700;
                 font-size: 1.1rem;

--- a/js/module-progress.js
+++ b/js/module-progress.js
@@ -81,7 +81,7 @@
 
             .progress-fill-bar {
                 height: 100%;
-                background: linear-gradient(90deg, #FF7A00, #FFD400);
+                background: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 width: 0%;
                 transition: width 0.1s linear;
             }

--- a/js/navigation-context.js
+++ b/js/navigation-context.js
@@ -332,7 +332,7 @@ class NavigationContextManager {
             }
             
             .bsa-return-nav--floating .bsa-return-nav__link:hover {
-                background: linear-gradient(135deg, #FF7A00 0%, #ff8c00 100%);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 color: white;
                 transform: translateY(-2px);
                 box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5), 0 0 24px rgba(255, 122, 0, 0.4);
@@ -344,7 +344,7 @@ class NavigationContextManager {
                 justify-content: center;
                 gap: 0.75rem;
                 padding: 0.75rem 2rem;
-                background: linear-gradient(135deg, #FF7A00 0%, #ff8c00 100%);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 color: white;
                 text-decoration: none;
                 font-weight: 600;
@@ -353,7 +353,7 @@ class NavigationContextManager {
             }
             
             .bsa-return-nav--top .bsa-return-nav__link:hover {
-                background: linear-gradient(135deg, #ff8c00 0%, #FF7A00 100%);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
             }
             
             .bsa-return-nav__icon {
@@ -491,7 +491,7 @@ class NavigationContextManager {
             
             .bsa-completion-prompt__btn {
                 padding: 0.875rem 2rem;
-                background: linear-gradient(135deg, #FF7A00 0%, #ff8c00 100%);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 color: white;
                 text-decoration: none;
                 border-radius: 50px;

--- a/js/payment-access-control.js
+++ b/js/payment-access-control.js
@@ -345,7 +345,7 @@ const AccessControl = (function() {
       position: absolute;
       top: 10px;
       right: 10px;
-      background: linear-gradient(135deg, #FF7A00, #ff8c00);
+      background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
       color: white;
       padding: 6px 12px;
       border-radius: 20px;
@@ -524,7 +524,7 @@ style.textContent = `
   }
 
   .btn-unlock-premium {
-    background: linear-gradient(135deg, #FF7A00, #ff8c00);
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
     color: white;
     border: none;
     padding: 1rem 2rem;

--- a/js/referral-program.js
+++ b/js/referral-program.js
@@ -106,7 +106,7 @@
                 font-size: 0.85rem;
             }
             .referral-link-box button {
-                background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 color: #000;
                 border: none;
                 padding: 0.75rem 1.25rem;

--- a/js/site-nav.js
+++ b/js/site-nav.js
@@ -45,7 +45,7 @@
     }
     .bsa-nav__links a:hover, .bsa-nav__links a.active { color: #FF7A00; }
     .bsa-nav__cta {
-        background: linear-gradient(135deg, #FF7A00, #FFD400);
+        background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
         color: #000 !important; font-weight: 700 !important;
         padding: 0.35rem 1rem; border-radius: 999px;
         font-size: 0.85rem; white-space: nowrap;
@@ -59,7 +59,7 @@
         width: 60px; height: 6px; background: #202938; border-radius: 3px; overflow: hidden;
     }
     .bsa-nav__progress-fill {
-        height: 100%; background: linear-gradient(90deg, #FF7A00, #FFD400); border-radius: 3px;
+        height: 100%; background: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%); border-radius: 3px;
         transition: width 0.3s;
     }
     .bsa-nav__hamburger {

--- a/js/subdomain-access-control.js
+++ b/js/subdomain-access-control.js
@@ -287,7 +287,7 @@
                 `;
             } else if (accessLevel === CONFIG.accessLevels.PREVIEW) {
                 bannerHTML = `
-                    <div id="subdomain-access-banner" style="background: linear-gradient(135deg, #FF7A00, #FFD400); color: #121212; padding: 0.75rem 1.5rem; text-align: center; font-weight: 600; position: fixed; top: 0; left: 0; right: 0; z-index: 10000; box-shadow: 0 2px 10px rgba(0,0,0,0.3);">
+                    <div id="subdomain-access-banner" style="background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%); color: #121212; padding: 0.75rem 1.5rem; text-align: center; font-weight: 600; position: fixed; top: 0; left: 0; right: 0; z-index: 10000; box-shadow: 0 2px 10px rgba(0,0,0,0.3);">
                         <span style="font-size: 1.1rem;">👁️ Preview Mode Active</span>
                         <span style="margin: 0 1rem; opacity: 0.7;">|</span>
                         <span style="font-size: 0.9rem;">Demo access enabled</span>

--- a/js/tip-cta.js
+++ b/js/tip-cta.js
@@ -95,7 +95,7 @@
                     background: transparent;
                     color: #FF7A00;
                     border: 2px solid transparent;
-                    border-image: linear-gradient(135deg, #FF7A00, #FFD400) 1;
+                    border-image: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%) 1;
                     font-family: 'JetBrains Mono', ui-monospace, monospace;
                     text-transform: uppercase;
                     letter-spacing: 0.08em;

--- a/js/tutor-loader.js
+++ b/js/tutor-loader.js
@@ -99,7 +99,7 @@
                 top: 10px;
                 right: 10px;
                 padding: 8px 16px;
-                background: linear-gradient(135deg, #FF7A00 0%, #FFD400 100%);
+                background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
                 color: white;
                 border: none;
                 border-radius: 20px;

--- a/licensing.html
+++ b/licensing.html
@@ -64,7 +64,7 @@
         .demo-item { padding: 0.5rem; background: var(--surface-2); border-radius: 6px; font-size: 0.9rem; }
         
         .cta-section { background: linear-gradient(135deg, rgba(255, 122, 0, 0.1) 0%, rgba(255, 122, 0, 0.05) 100%); border: 2px solid rgba(255, 122, 0, 0.3); border-radius: 16px; padding: 2rem; text-align: center; margin: 3rem 0; }
-        .btn-primary { display: inline-block; background: linear-gradient(135deg, var(--accent) 0%, #FFD400 100%); color: #000; padding: 1rem 2rem; border-radius: 12px; font-weight: 700; text-decoration: none; transition: all 0.3s ease; }
+        .btn-primary { display: inline-block; background: var(--brand-gradient); color: #000; padding: 1rem 2rem; border-radius: 12px; font-weight: 700; text-decoration: none; transition: all 0.3s ease; }
         .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 8px 24px rgba(255, 122, 0, 0.4); }
         
         .faq { margin: 2rem 0; }

--- a/mockups/catalog-card-final.html
+++ b/mockups/catalog-card-final.html
@@ -19,10 +19,10 @@
   .cat-head{display:flex;align-items:center;gap:12px;padding-bottom:8px;position:relative;
        border-bottom:1px solid var(--color-border,#2D2F35);margin-bottom:14px;}
   .cat-head::after{content:'';position:absolute;left:0;bottom:-1px;width:96px;height:2px;
-       background:linear-gradient(90deg,#FF7A00,#FFD400);}
+       background:var(--brand-gradient-h);}
   /* Gradient header TEXT with a solid gold fallback (stays readable if clip fails) */
   .cat-title{font-size:18px;font-weight:700;margin:0;color:#F4B14A;
-       background:linear-gradient(135deg,#FF7A00 0%,#FFD400 100%);
+       background:var(--brand-gradient);
        -webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;}
   .cat-icon{font-size:18px;}
   .cat-count{margin-left:auto;font:600 12px/1 'SF Mono',Monaco,monospace;letter-spacing:.06em;
@@ -38,7 +38,7 @@
        transition:border-color .15s,background .15s;}
   .wrap .card:hover{border-color:transparent !important;box-shadow:none !important;
        background:linear-gradient(var(--color-surface,#1F2024),var(--color-surface,#1F2024)) padding-box,
-                  linear-gradient(135deg,#FF7A00,#FFD400) border-box !important;}
+                  var(--brand-gradient) border-box !important;}
   .wrap .card h3{font-size:15px;margin:0 0 4px;font-weight:600;color:var(--color-text,#F7F7F2);line-height:1.3;}
   .wrap .card p{font-size:13px;color:var(--color-muted,#B8B8B0) !important;margin:0 0 12px;line-height:1.4;}
   .card .meta{display:flex;justify-content:space-between;align-items:center;font-size:11px;}

--- a/modules/cbdc-vs-bitcoin.html
+++ b/modules/cbdc-vs-bitcoin.html
@@ -7,11 +7,11 @@
     header { position: sticky; top: 0; background: #2d2d2d; border-bottom: 2px solid #FF7A00; padding: 0.75rem 1rem; }
     a { color: #FF7A00; text-decoration: none; }
     .container { max-width: 1100px; margin: 0 auto; padding: 1rem; }
-    h1 { margin: 0.5rem 0 1rem; background: linear-gradient(135deg,#FF7A00,#FFD400); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
+    h1 { margin: 0.5rem 0 1rem; background: var(--brand-gradient); -webkit-background-clip:text; -webkit-text-fill-color:transparent; }
     .grid { display: grid; grid-template-columns: 280px 1fr; gap: 1rem; }
     .panel { background: rgba(0,0,0,0.3); border: 1px solid rgba(255, 122, 0,0.2); border-radius: 12px; padding: 1rem; }
     .panel h2 { color: #FF7A00; margin-top: 0; font-size: 1.1rem; }
-    button { background: linear-gradient(135deg,#FF7A00,#FFD400); border: none; color: #fff; font-weight: 600; padding: 0.6rem 1rem; border-radius: 999px; cursor: pointer; }
+    button { background: var(--brand-gradient); border: none; color: #fff; font-weight: 600; padding: 0.6rem 1rem; border-radius: 999px; cursor: pointer; }
     .list button { width: 100%; margin-bottom: 0.5rem; background: transparent; border: 2px solid #FF7A00; color: #FF7A00; }
     pre { white-space: pre-wrap; background: #111; padding: 0.75rem; border-radius: 8px; max-height: 520px; overflow: auto; }
   </style>

--- a/my-learning/index.html
+++ b/my-learning/index.html
@@ -34,7 +34,7 @@
 
         .dashboard-header h1 {
             font-size: 2.5rem;
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;

--- a/paths/builder/index.html
+++ b/paths/builder/index.html
@@ -225,7 +225,7 @@
             font-size: 2.5rem;
             color: var(--primary-orange);
             margin-bottom: 1rem;
-            background: linear-gradient(135deg, var(--primary-orange), #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -382,7 +382,7 @@
 
         .demo-button {
             padding: 0.6rem 1.2rem;
-            background: linear-gradient(135deg, var(--primary-orange), #FFD400);
+            background: var(--brand-gradient);
             color: #101010;
             border: none;
             border-radius: 0.5rem;

--- a/paths/builder/stage-1/module-1.html
+++ b/paths/builder/stage-1/module-1.html
@@ -227,7 +227,7 @@
             display: inline-block;
             margin-top: 1rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #d97706, var(--primary-orange, #FF7A00));
+            background: var(--brand-gradient);
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;

--- a/paths/builder/stage-2/module-1.html
+++ b/paths/builder/stage-2/module-1.html
@@ -280,7 +280,7 @@
             display: inline-block;
             margin-top: 1rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #d97706, var(--primary-orange, #FF7A00));
+            background: var(--brand-gradient);
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;

--- a/paths/builder/stage-2/module-2.html
+++ b/paths/builder/stage-2/module-2.html
@@ -294,7 +294,7 @@
             display: inline-block;
             margin-top: 1rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #d97706, var(--primary-orange, #FF7A00));
+            background: var(--brand-gradient);
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;

--- a/paths/builder/stage-2/module-4.html
+++ b/paths/builder/stage-2/module-4.html
@@ -472,7 +472,7 @@
             display: inline-block;
             margin-top: 1rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #d97706, var(--primary-orange, #FF7A00));
+            background: var(--brand-gradient);
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;

--- a/paths/curious/stage-1/es/module-1.html
+++ b/paths/curious/stage-1/es/module-1.html
@@ -717,7 +717,7 @@
 
                     .progress-fill-demo {
                         height: 100%;
-                        background: linear-gradient(90deg, #FF7A00, #FFD400);
+                        background: var(--brand-gradient-h);
                         width: 16.67%;
                         transition: width 0.5s ease;
                         border-radius: 3px;
@@ -840,7 +840,7 @@
                         position: absolute;
                         bottom: 0;
                         width: 100%;
-                        background: linear-gradient(180deg, var(--primary-orange), #ff8c00);
+                        background: var(--brand-gradient);
                         transition: height 0.5s ease;
                         border-radius: 0 0 10px 10px;
                     }
@@ -857,7 +857,7 @@
 
                     .energy-fill {
                         height: 100%;
-                        background: linear-gradient(90deg, var(--primary-orange), #FFD400);
+                        background: var(--brand-gradient-h);
                         width: 0%;
                         transition: width 0.3s ease;
                         border-radius: 8px;

--- a/paths/curious/stage-1/module-1.html
+++ b/paths/curious/stage-1/module-1.html
@@ -716,7 +716,7 @@
 
                     .progress-fill-demo {
                         height: 100%;
-                        background: linear-gradient(90deg, #FF7A00, #FFD400);
+                        background: var(--brand-gradient-h);
                         width: 16.67%;
                         transition: width 0.5s ease;
                         border-radius: 3px;
@@ -839,7 +839,7 @@
                         position: absolute;
                         bottom: 0;
                         width: 100%;
-                        background: linear-gradient(180deg, var(--primary-orange), #ff8c00);
+                        background: var(--brand-gradient);
                         transition: height 0.5s ease;
                         border-radius: 0 0 10px 10px;
                     }
@@ -856,7 +856,7 @@
 
                     .energy-fill {
                         height: 100%;
-                        background: linear-gradient(90deg, var(--primary-orange), #FFD400);
+                        background: var(--brand-gradient-h);
                         width: 0%;
                         transition: width 0.3s ease;
                         border-radius: 8px;

--- a/paths/curious/stage-2/module-2.html
+++ b/paths/curious/stage-2/module-2.html
@@ -835,7 +835,7 @@
                         See how Bitcoin's <strong>stock-to-flow ratio</strong> compares to gold and other assets.
                         Understand why halvings make Bitcoin progressively scarcer over time.
                     </p>
-                    <a href="/interactive-demos/stock-to-flow/index.html" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, #FF7A00, #FFD400); color: white; text-decoration: none; border-radius: 999px; font-weight: 700; transition: all 0.3s ease; box-shadow: 0 4px 12px rgba(255, 122, 0, 0.3);">
+                    <a href="/interactive-demos/stock-to-flow/index.html" style="display: inline-block; padding: 1rem 2rem; background: var(--brand-gradient); color: white; text-decoration: none; border-radius: 999px; font-weight: 700; transition: all 0.3s ease; box-shadow: 0 4px 12px rgba(255, 122, 0, 0.3);">
                         Launch Stock-to-Flow Demo →
                     </a>
                     <p style="margin-top: 1rem; font-size: 0.85rem; color: var(--text-dim);">

--- a/paths/curious/stage-2/module-3.html
+++ b/paths/curious/stage-2/module-3.html
@@ -636,7 +636,7 @@
             display: inline-block;
             margin-top: 1rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #d97706, var(--primary-orange, #FF7A00));
+            background: var(--brand-gradient);
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;

--- a/paths/curious/stage-3/module-1.html
+++ b/paths/curious/stage-3/module-1.html
@@ -343,7 +343,7 @@
             display: inline-block;
             margin-top: 1rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #d97706, var(--primary-orange, #FF7A00));
+            background: var(--brand-gradient);
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;

--- a/paths/curious/stage-3/module-3.html
+++ b/paths/curious/stage-3/module-3.html
@@ -354,7 +354,7 @@
             display: inline-block;
             margin-top: 1rem;
             padding: 0.75rem 1.5rem;
-            background: linear-gradient(135deg, #d97706, var(--primary-orange, #FF7A00));
+            background: var(--brand-gradient);
             color: white;
             text-decoration: none;
             border-radius: 0.5rem;

--- a/paths/hurried/index.html
+++ b/paths/hurried/index.html
@@ -60,7 +60,7 @@
 
         .time-badge {
             display: inline-block;
-            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            background: var(--brand-gradient);
             color: #101010;
             padding: 0.75rem 1.5rem;
             border-radius: 2rem;

--- a/paths/hurried/stage-1/module-1.html
+++ b/paths/hurried/stage-1/module-1.html
@@ -339,7 +339,7 @@
             align-items: center;
             gap: 0.5rem;
             padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            background: var(--brand-gradient);
             color: #101010;
             border-radius: 0.5rem;
             text-decoration: none;
@@ -469,7 +469,7 @@
                 </div>
 
                 <div style="text-align: center;">
-                    <a href="/interactive-demos/onramp-chooser/" style="display: inline-block; padding: 1.25rem 2.5rem; background: linear-gradient(135deg, var(--accent-gold), #FF7A00); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.25rem; box-shadow: 0 4px 12px rgba(255, 167, 38, 0.4); transition: all 0.3s ease;">
+                    <a href="/interactive-demos/onramp-chooser/" style="display: inline-block; padding: 1.25rem 2.5rem; background: var(--brand-gradient); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 700; font-size: 1.25rem; box-shadow: 0 4px 12px rgba(255, 167, 38, 0.4); transition: all 0.3s ease;">
                         Find My Best Option → (2 min)
                     </a>
                 </div>
@@ -669,7 +669,7 @@
         <div class="hands-on-box" style="background: linear-gradient(135deg, rgba(255, 122, 0, 0.15), rgba(255, 122, 0, 0.05)); border: 2px solid var(--accent-gold); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0;">
             <h3 style="color: var(--accent-gold); margin-bottom: 1rem;">🧮 Practice Tool: Bitcoin Unit Converter</h3>
             <p style="margin-bottom: 1rem;">Before you buy, practice converting between USD, BTC, and sats. Understanding units prevents costly mistakes.</p>
-            <a href="/interactive-demos/bitcoin-unit-converter/" style="display: inline-block; padding: 0.875rem 1.5rem; background: linear-gradient(135deg, var(--accent-gold), #FF7A00); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s; box-shadow: 0 4px 12px rgba(255, 167, 38, 0.3);">
+            <a href="/interactive-demos/bitcoin-unit-converter/" style="display: inline-block; padding: 0.875rem 1.5rem; background: var(--brand-gradient); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 600; transition: all 0.3s; box-shadow: 0 4px 12px rgba(255, 167, 38, 0.3);">
                 Try Unit Converter →
             </a>
         </div>

--- a/paths/hurried/stage-1/module-2.html
+++ b/paths/hurried/stage-1/module-2.html
@@ -208,7 +208,7 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            background: var(--brand-gradient);
             color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }
@@ -385,7 +385,7 @@
 
                 <div style="margin-bottom: 1.5rem;">
                     <button onclick="generateAddress('native-segwit')" style="padding: 0.75rem 1.5rem; background: #28a745; color: white; border: none; border-radius: 0.5rem; cursor: pointer; margin-right: 0.5rem; margin-bottom: 0.5rem; min-height: 44px; font-weight: 600;">Generate bc1 Address</button>
-                    <button onclick="generateAddress('segwit')" style="padding: 0.75rem 1.5rem; background: linear-gradient(135deg, var(--accent-gold), #FF7A00); color: #101010; border: none; border-radius: 0.5rem; cursor: pointer; margin-right: 0.5rem; margin-bottom: 0.5rem; min-height: 44px; font-weight: 600;">Generate 3 Address</button>
+                    <button onclick="generateAddress('segwit')" style="padding: 0.75rem 1.5rem; background: var(--brand-gradient); color: #101010; border: none; border-radius: 0.5rem; cursor: pointer; margin-right: 0.5rem; margin-bottom: 0.5rem; min-height: 44px; font-weight: 600;">Generate 3 Address</button>
                     <button onclick="generateAddress('legacy')" style="padding: 0.75rem 1.5rem; background: rgba(255, 167, 38, 0.2); color: var(--text-light); border: 2px solid var(--border-color); border-radius: 0.5rem; cursor: pointer; margin-bottom: 0.5rem; min-height: 44px; font-weight: 600;">Generate 1 Address</button>
                 </div>
 

--- a/paths/hurried/stage-1/module-3.html
+++ b/paths/hurried/stage-1/module-3.html
@@ -182,7 +182,7 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            background: var(--brand-gradient);
             color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }

--- a/paths/hurried/stage-2/module-4.html
+++ b/paths/hurried/stage-2/module-4.html
@@ -167,7 +167,7 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            background: var(--brand-gradient);
             color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }
@@ -372,7 +372,7 @@
             <div class="practice-link" style="background: rgba(255, 167, 38, 0.1); border: 2px solid var(--accent-gold); border-radius: 0.75rem; padding: 2rem; margin: 2rem 0; text-align: center;">
                 <h3 style="color: var(--accent-gold); margin-bottom: 1rem;">⚡ Check Current Network Fees</h3>
                 <p style="margin-bottom: 1.5rem;">See real-time fee estimates and mempool status:</p>
-                <a href="https://mempool.space/" target="_blank" rel="noopener noreferrer" style="display: inline-block; padding: 1rem 2rem; background: linear-gradient(135deg, var(--accent-gold), #FF7A00); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px; margin-right: 1rem; margin-bottom: 1rem;">
+                <a href="https://mempool.space/" target="_blank" rel="noopener noreferrer" style="display: inline-block; padding: 1rem 2rem; background: var(--brand-gradient); color: #101010; text-decoration: none; border-radius: 0.5rem; font-weight: 700; transition: all 0.3s ease; min-height: 44px; margin-right: 1rem; margin-bottom: 1rem;">
                     View Live Mempool →
                 </a>
                 <a href="/interactive-demos/fee-master-tool/" target="_blank" style="display: inline-block; padding: 1rem 2rem; background: rgba(255, 167, 38, 0.2); color: var(--accent-gold); text-decoration: none; border-radius: 0.5rem; font-weight: 700; border: 2px solid var(--accent-gold); transition: all 0.3s ease; min-height: 44px; margin-bottom: 1rem;">

--- a/paths/hurried/stage-2/module-5.html
+++ b/paths/hurried/stage-2/module-5.html
@@ -166,7 +166,7 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            background: var(--brand-gradient);
             color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }

--- a/paths/hurried/stage-3/module-6.html
+++ b/paths/hurried/stage-3/module-6.html
@@ -170,7 +170,7 @@
 
         .nav-link {
             display: inline-flex; align-items: center; gap: 0.5rem; padding: 1rem 2rem;
-            background: linear-gradient(135deg, var(--accent-gold), #FF7A00);
+            background: var(--brand-gradient);
             color: #101010; border-radius: 0.5rem; text-decoration: none;
             font-weight: 700; font-size: 1.1rem; transition: all 0.3s ease;
         }

--- a/paths/principled/index.html
+++ b/paths/principled/index.html
@@ -80,7 +80,7 @@
 
         .hero h1 {
             font-size: 3rem;
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;

--- a/paths/principled/stage-1/module-1.html
+++ b/paths/principled/stage-1/module-1.html
@@ -196,7 +196,7 @@
 
         .meter-fill {
             height: 100%;
-            background: linear-gradient(90deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient-h);
             transition: width 0.5s ease;
             display: flex;
             align-items: center;
@@ -211,7 +211,7 @@
         }
 
         .meter-fill.currency {
-            background: linear-gradient(90deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient-h);
         }
 
         .demo-controls {

--- a/paths/principled/stage-1/module-2.html
+++ b/paths/principled/stage-1/module-2.html
@@ -218,7 +218,7 @@
         }
 
         .integrity-fill.degraded {
-            background: linear-gradient(90deg, #FF7A00, #f59e0b);
+            background: var(--brand-gradient-h);
         }
 
         .integrity-fill.corrupted {

--- a/paths/principled/stage-3/module-2.html
+++ b/paths/principled/stage-3/module-2.html
@@ -148,7 +148,7 @@
             top: 0;
             bottom: 0;
             width: 2px;
-            background: linear-gradient(180deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
         }
         .timeline-item {
             position: relative;

--- a/paths/principled/stage-3/module-3.html
+++ b/paths/principled/stage-3/module-3.html
@@ -187,7 +187,7 @@
         }
         .energy-fill {
             height: 100%;
-            background: linear-gradient(90deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient-h);
             transition: width 0.5s ease;
             display: flex;
             align-items: center;

--- a/paths/principled/stage-4/module-1.html
+++ b/paths/principled/stage-4/module-1.html
@@ -202,7 +202,7 @@
             transition: all 0.5s ease;
         }
         .entropy-block.ordered {
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
         }
         .reflection-section {
             background: linear-gradient(135deg, rgba(31, 32, 36, 0.1), rgba(31, 32, 36, 0.05));

--- a/paths/principled/stage-4/module-3.html
+++ b/paths/principled/stage-4/module-3.html
@@ -226,7 +226,7 @@
         }
         .health-fill {
             height: 100%;
-            background: linear-gradient(90deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient-h);
             transition: width 0.5s ease;
             display: flex;
             align-items: center;

--- a/paths/sovereign-journey-intro.html
+++ b/paths/sovereign-journey-intro.html
@@ -64,7 +64,7 @@
 
         .hero h1 {
             font-size: 3.5rem;
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -141,7 +141,7 @@
             top: 0;
             bottom: 0;
             width: 2px;
-            background: linear-gradient(to bottom, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             transform: translateX(-50%);
         }
 
@@ -332,7 +332,7 @@
         }
 
         .cta-btn-primary {
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: #101010;
         }
 

--- a/paths/sovereign/stage-3/alternatives-to-bitcoin.html
+++ b/paths/sovereign/stage-3/alternatives-to-bitcoin.html
@@ -208,7 +208,7 @@
         .intro-text h1 {
             font-size: 2.5rem;
             margin-bottom: 1rem;
-            background: linear-gradient(135deg, var(--sovereign-gold), #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -224,7 +224,7 @@
         .cta-start {
             margin-top: 2rem;
             padding: 1rem 2.5rem;
-            background: linear-gradient(135deg, var(--sovereign-gold), #FFD400);
+            background: var(--brand-gradient);
             color: #101010;
             border: none;
             border-radius: 2rem;
@@ -514,7 +514,7 @@
 
         .poll-bar-fill {
             height: 30px;
-            background: linear-gradient(90deg, var(--sovereign-gold), rgba(212, 175, 55, 0.5));
+            background: var(--color-brand);
             border-radius: 4px;
             transition: width 0.8s ease;
             display: flex;

--- a/paths/sovereign/stage-3/index.html
+++ b/paths/sovereign/stage-3/index.html
@@ -538,7 +538,7 @@
 
                     <!-- Monetary Alternatives Guide (NEW) -->
                     <div style="background: var(--secondary-dark); border: 2px solid var(--border-color); border-radius: 1rem; padding: 2rem; display: grid; grid-template-columns: auto 1fr auto; gap: 1.5rem; align-items: center;">
-                        <div style="width: 60px; height: 60px; background: linear-gradient(135deg, #FF7A00, #FFD400); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.75rem;"><span data-icon="chat"></span> </div>
+                        <div style="width: 60px; height: 60px; background: var(--brand-gradient); border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.75rem;"><span data-icon="chat"></span> </div>
                         <div>
                             <h3 style="color: var(--sovereign-gold); margin-bottom: 0.5rem;">Alternatives to Bitcoin</h3>
                             <p style="color: var(--text-dim); margin-bottom: 0.5rem; font-size: 0.95rem;">
@@ -551,7 +551,7 @@
                             </div>
                         </div>
                         <div>
-                            <a href="alternatives-to-bitcoin.html" style="padding: 0.75rem 1.5rem; background: linear-gradient(135deg, #FF7A00, #FFD400); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; white-space: nowrap; display: inline-block;">Explore Systems →</a>
+                            <a href="alternatives-to-bitcoin.html" style="padding: 0.75rem 1.5rem; background: var(--brand-gradient); color: white; text-decoration: none; border-radius: 0.5rem; font-weight: 600; white-space: nowrap; display: inline-block;">Explore Systems →</a>
                         </div>
                     </div>
                 </div>

--- a/sponsor.html
+++ b/sponsor.html
@@ -61,7 +61,7 @@
         .stat .label { font-size: 0.85rem; color: var(--muted); }
         
         .cta-section { background: linear-gradient(135deg, rgba(255, 122, 0, 0.1) 0%, rgba(255, 122, 0, 0.05) 100%); border: 2px solid rgba(255, 122, 0, 0.3); border-radius: 16px; padding: 2rem; text-align: center; margin: 3rem 0; }
-        .btn-primary { display: inline-block; background: linear-gradient(135deg, var(--accent) 0%, #FFD400 100%); color: #000; padding: 1rem 2rem; border-radius: 12px; font-weight: 700; text-decoration: none; transition: all 0.3s ease; }
+        .btn-primary { display: inline-block; background: var(--brand-gradient); color: #000; padding: 1rem 2rem; border-radius: 12px; font-weight: 700; text-decoration: none; transition: all 0.3s ease; }
         .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 8px 24px rgba(255, 122, 0, 0.4); }
         
         .disclosure { background: var(--surface); padding: 1.5rem; border-radius: 12px; margin: 1.5rem 0; }

--- a/start/index.html
+++ b/start/index.html
@@ -36,7 +36,7 @@
 
         .welcome-screen h1 {
             font-size: 2.5rem;
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -93,7 +93,7 @@
 
         .progress-fill {
             height: 100%;
-            background: linear-gradient(90deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient-h);
             border-radius: 10px;
             transition: width 0.3s ease;
         }
@@ -210,7 +210,7 @@
         }
 
         .btn-primary {
-            background: linear-gradient(135deg, #FF7A00, #FFD400);
+            background: var(--brand-gradient);
             color: white;
         }
 

--- a/tests/widget-demo.html
+++ b/tests/widget-demo.html
@@ -29,7 +29,7 @@
         h1 {
             font-size: 2.5rem;
             margin-bottom: 1rem;
-            background: linear-gradient(135deg, #FF7A00 0%, #FFA940 100%);
+            background: var(--brand-gradient);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;

--- a/youth-families/week-03/index.html
+++ b/youth-families/week-03/index.html
@@ -254,7 +254,7 @@
         .con-trk { position: absolute; left: 14px; right: 14px; height: 18px; background: #0e0f12; border-radius: 9px; overflow: hidden; }
         .con-run { height: 100%; width: 5%; border-radius: 9px; transition: width 0.12s linear; }
         #con-lp { top: 38px; left: 16px; } #con-tp { top: 54px; }
-        #con-rp { background: linear-gradient(90deg, var(--primary-orange), #FFD400); }
+        #con-rp { background: var(--brand-gradient-h); }
         #con-lm { top: 84px; left: 16px; } #con-tm { top: 100px; }
         #con-rm { background: #6b7280; }
         #con-melt {


### PR DESCRIPTION
## Brand fade consolidation (value-only)

The signature fade was defined globally but **hardcoded ~249 times across 37 drifting variants** — different angles, stop counts, fake solid-gradients, even an orange→purple. This makes it a single canonical token and conforms every usage to it.

Sign-off: **Option C** — `135deg, #FF7A00 → #FF9A00 → #FFD400` (orange→yellow, smooth), matching the brand intent ("bright orange to bright yellow fade") and the dominant existing usage, so the visible change is minimal but now uniform. A `--brand-gradient-h` (90°) variant covers full-width bars.

### Changes
- **Tokens**: `css/tokens.css` (hub-synced from [sovereign-academy-hub@bd1a8c4](https://github.com/Sovereigndwp/sovereign-academy-hub/commit/bd1a8c4)) + `css/brand.css` redefined; old aliases (`--gradient-brand/-angled/-key-takeaway`) collapse onto the signature. FSA unaffected (separate green gradient, doesn't consume this token).
- **HTML layer**: 208 inline gradients across 109 pages → `var(--brand-gradient)` / `-h`; 27 fake solid-gradients → flat `var(--color-brand)`.
- **Shared layer**: 41 instances in 10 CSS + 14 JS files (demo-shell `.num-fade`, the `*-brand-fix` sheets, nav/gate/tip-cta injected styles) → canonical **literal** (kept literal, not `var()`, so standalone/injected styles never hit an undefined var).
- **Violations fixed**: orange→purple on `index.html`, old `#F7931A` on an embed.
- **Preserved** (decision-tree skipped all non-brand gradients): semantic green/red/blue gradients, the white→orange `--gradient-title`, dark surface gradients.

### How it was done
A balanced-paren scanner classified each `linear-gradient(...)`: brand-family-only → token; all-same-color → flat; horizontal angle → `-h`; contains green (`#28a745`) → **skipped** (semantic); purple → converted (the violation). 122 foreign gradients (dark surfaces, rgba washes, red, gray) correctly left untouched.

### Verification
Computed values confirm both layers resolve to the canonical fade (`.num-fade` 135°, `.skip-link`/`.tip-cta` 90°). Homepage + demos render the consistent orange→yellow signature; semantic-green status dots preserved; 0 console errors.

### Deliberately NOT in this PR
Several **conversion buttons still fill** with the fade (homepage CTA, email-capture SUBSCRIBE, tip-cta, reflect Ask); brand law is stroke-only. That turned out to be a multi-component restyle with override conflicts + non-brand button colors — it gets its own focused PR (a button-component audit → coherent fill→stroke). This PR is purely the **gradient value**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)