### PR TITLE
feat(brand): convert filled buttons to gradient-outline (fade = stroke, not fill)

### DIFF
--- a/css/brand.css
+++ b/css/brand.css
@@ -169,21 +169,21 @@ a:hover {
   display: inline-block;
   margin-top: 1rem;
   padding: 0.75rem 1.5rem;
-  background: var(--gradient-brand-horizontal);
-  color: #000000 !important;
+  background: transparent;
+  color: var(--color-brand);
   text-decoration: none;
-  border-radius: var(--radius-md);
+  border: 2px solid transparent;
+  border-image: var(--brand-gradient) 1;
   font-weight: 700;
   font-size: 0.95rem;
   transition: all 0.3s ease;
   text-align: center;
-  box-shadow: var(--glow-orange);
+  box-shadow: none;
 }
 
 .demo-link:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 18px rgba(255, 122, 0, 0.5);
-  color: #000000 !important;
+  background: rgba(255, 122, 0, 0.12);
+  color: var(--color-accent);
 }
 
 /* Accessibility: focus indicators */
@@ -285,16 +285,17 @@ textarea:focus,
 }
 
 .btn-primary {
-  background: var(--gradient-key-takeaway);
-  color: #000000;
-  border-color: var(--color-brand);
-  box-shadow: var(--glow-orange);
+  background: transparent;
+  color: var(--color-brand);
+  border: 2px solid transparent;
+  border-image: var(--brand-gradient) 1;
+  box-shadow: none;
 }
 
 .btn-primary:hover {
-  background: var(--gradient-brand-horizontal);
-  border-color: var(--color-yellow);
-  box-shadow: var(--glow-yellow);
+  background: rgba(255, 122, 0, 0.12);
+  color: var(--color-accent);
+  box-shadow: none;
 }
 
 .btn-secondary {
@@ -426,23 +427,29 @@ h1 {
   background: #FF7A00 !important;
 }
 
-.path-start-btn,
-.btn-primary,
 .progress-fill,
-.skip-link,
-.demo-link {
+.skip-link {
   background: var(--brand-gradient) !important;
   color: #000000 !important;
   border-color: #FF7A00 !important;
-  box-shadow: 0 8px 28px rgba(255, 122, 0, 0.30) !important;
+}
+
+.path-start-btn,
+.btn-primary,
+.demo-link {
+  background: transparent !important;
+  color: #FF7A00 !important;
+  border: 2px solid transparent !important;
+  border-image: var(--brand-gradient) 1 !important;
+  box-shadow: none !important;
 }
 
 .path-start-btn:hover,
 .btn-primary:hover,
 .demo-link:hover {
-  background: var(--brand-gradient) !important;
-  color: #000000 !important;
-  box-shadow: 0 12px 34px rgba(255, 122, 0, 0.42) !important;
+  background: rgba(255, 122, 0, 0.12) !important;
+  color: #FF8A00 !important;
+  box-shadow: none !important;
 }
 
 .btn-secondary {

--- a/css/homepage-bsa-brand-fix.css
+++ b/css/homepage-bsa-brand-fix.css
@@ -271,19 +271,34 @@ em,
   background: linear-gradient(135deg, transparent 0%, rgba(255, 122, 0, 0.32) 100%) !important;
 }
 
-.path-cta,
-.btn-primary,
-.demo-link,
 .logo-icon,
 .timeline-number,
 .mcp-badge,
 .persona-badge,
-.btn-continue,
 .help-bubble,
 .progress-fill {
   background: var(--brand-gradient) !important;
   color: #000000 !important;
   border-color: #FF7A00 !important;
+}
+
+.path-cta,
+.btn-primary,
+.demo-link,
+.btn-continue {
+  background: transparent !important;
+  color: #FF7A00 !important;
+  border: 2px solid transparent !important;
+  border-image: var(--brand-gradient) 1 !important;
+  box-shadow: none !important;
+}
+
+.path-cta:hover,
+.btn-primary:hover,
+.demo-link:hover,
+.btn-continue:hover {
+  background: rgba(255, 122, 0, 0.12) !important;
+  color: #FF8A00 !important;
 }
 
 .btn-secondary {

--- a/css/interactive-demos.css
+++ b/css/interactive-demos.css
@@ -58,7 +58,7 @@ h1 {
 
 /* Bright orange to yellow gradient for section headings */
 h2 {
-    background: linear-gradient(135deg, #ff6b00 0%, #ffeb3b 100%) !important;
+    background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%) !important;
     -webkit-background-clip: text !important;
     -webkit-text-fill-color: transparent !important;
     background-clip: text !important;
@@ -153,24 +153,24 @@ h3 {
    Button Enhancements
    ======================================== */
 
-/* Primary buttons with shimmer effect */
+/* Primary buttons: gradient-outline (brand law — fade is stroke, never a fill) */
 button,
 .btn,
 .button,
 input[type="submit"],
 input[type="button"],
 [class*="btn-"]:not([class*="btn-secondary"]):not([class*="btn-outline"]) {
-    background: linear-gradient(135deg, #ff6b00 0%, #ffeb3b 100%) !important;
-    color: #000000 !important;
-    border: none !important;
-    border-radius: 0.75rem !important;
+    background: transparent !important;
+    color: #FF7A00 !important;
+    border: 2px solid transparent !important;
+    border-image: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%) 1 !important;
+    border-radius: 2px !important;
     padding: 0.875rem 1.75rem !important;
     font-weight: 700 !important;
     cursor: pointer !important;
-    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1) !important;
-    box-shadow: 0 4px 16px rgba(255, 107, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.1) inset !important;
+    transition: all 0.3s ease !important;
+    box-shadow: none !important;
     position: relative !important;
-    overflow: hidden !important;
 }
 
 button::before,
@@ -193,8 +193,10 @@ button:hover,
 .button:hover,
 input[type="submit"]:hover,
 input[type="button"]:hover {
-    transform: translateY(-3px) scale(1.02) !important;
-    box-shadow: 0 8px 28px rgba(255, 107, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.2) inset !important;
+    background: rgba(255, 122, 0, 0.12) !important;
+    color: #FF8A00 !important;
+    transform: translateY(-1px) !important;
+    box-shadow: none !important;
 }
 
 button:hover::before,
@@ -345,9 +347,9 @@ textarea:focus {
     border-radius: 999px !important;
     font-size: 0.8rem !important;
     font-weight: 600 !important;
-    background: linear-gradient(135deg, rgba(255, 107, 0, 0.15) 0%, rgba(255, 235, 59, 0.15) 100%) !important;
-    border: 1px solid rgba(255, 107, 0, 0.3) !important;
-    color: #ffeb3b !important;
+    background: linear-gradient(135deg, rgba(255, 122, 0, 0.15) 0%, rgba(255, 212, 0, 0.15) 100%) !important;
+    border: 1px solid rgba(255, 122, 0, 0.3) !important;
+    color: #FFD400 !important;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15) !important;
 }
 
@@ -366,7 +368,7 @@ textarea:focus {
 .progress-fill,
 .progress-bar > div,
 [class*="progress-fill"] {
-    background: linear-gradient(90deg, #ff6b00 0%, #ffeb3b 100%) !important;
+    background: linear-gradient(90deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%) !important;
     border-radius: 999px !important;
     transition: width 0.3s ease !important;
     box-shadow: 0 0 12px rgba(255, 107, 0, 0.5) !important;

--- a/css/path-bsa-brand-fix.css
+++ b/css/path-bsa-brand-fix.css
@@ -153,20 +153,38 @@ h3,
 }
 
 .time-badge,
+.progress-bar-fill,
+.progress-fill {
+  background: var(--brand-gradient) !important;
+  color: #000000 !important;
+  border-color: #FF7A00 !important;
+}
+
 .module-cta,
 .nav-btn,
 .btn-primary,
 .continue-btn,
 .complete-btn,
-.progress-bar-fill,
-.progress-fill,
 .cta-button,
 button.primary,
 a.button-primary {
-  background: var(--brand-gradient) !important;
-  color: #000000 !important;
-  border-color: #FF7A00 !important;
-  box-shadow: 0 8px 28px rgba(255, 122, 0, 0.32) !important;
+  background: transparent !important;
+  color: #FF7A00 !important;
+  border: 2px solid transparent !important;
+  border-image: var(--brand-gradient) 1 !important;
+  box-shadow: none !important;
+}
+
+.module-cta:hover,
+.nav-btn:hover,
+.btn-primary:hover,
+.continue-btn:hover,
+.complete-btn:hover,
+.cta-button:hover,
+button.primary:hover,
+a.button-primary:hover {
+  background: rgba(255, 122, 0, 0.12) !important;
+  color: #FF8A00 !important;
 }
 
 .nav-btn.secondary,

--- a/js/gemini-tutor-ui.js
+++ b/js/gemini-tutor-ui.js
@@ -207,10 +207,10 @@ class GeminiTutorUI {
                     />
                     <button type="button" id="send-btn" aria-label="Send message" style="
                         padding: 12px 20px;
-                        background: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%);
-                        border: none;
-                        border-radius: 12px;
-                        color: white;
+                        background: transparent;
+                        border: 2px solid transparent;
+                        border-image: linear-gradient(135deg, #FF7A00 0%, #FF9A00 45%, #FFD400 100%) 1;
+                        color: #FF7A00;
                         font-weight: 600;
                         cursor: pointer;
                         transition: all 0.3s ease;


### PR DESCRIPTION
## Buttons: fill → stroke

Enforces the locked brand law — the orange→yellow fade belongs on a button's **stroke, never as a fill**. Follow-up to [#145](https://github.com/Sovereigndwp/bitcoin-sovereign-academy/pull/145) (gradient-value consolidation), which made the fade consistent but left buttons filled.

### What changed
Every primary/conversion button → **gradient-outline** (transparent fill, `--brand-gradient` border via `border-image`, orange label, faint orange hover wash), converted at the source:

- `css/brand.css` — `.btn-primary` / `.path-start-btn` / `.demo-link` (base + the `!important` skin)
- `css/path-bsa-brand-fix.css` — `.module-cta` / `.nav-btn` / `.btn-primary` / `.continue-btn` / `.complete-btn` / `.cta-button` / `button.primary` / `a.button-primary`
- `css/homepage-bsa-brand-fix.css` — `.path-cta` / `.btn-primary` / `.demo-link` / `.btn-continue`
- `css/interactive-demos.css` — the global `button` rule that was forcing a **non-brand** `#ff6b00→#ffeb3b` fill on every demo button via `!important`; also fixed its off-brand `h2` text gradient and chip color to canonical brand values
- `js/gemini-tutor-ui.js` — `#send-btn` inline style

### Kept filled (correctly — not buttons)
`.progress-fill` / progress bars, badges & icons (`.logo-icon`, `.timeline-number`, `.mcp-badge`, `.persona-badge`), and the hidden `.skip-link`.

### Verification
Computed styles on homepage + a demo: the only element still rendering a filled fade is `.skip-link`; every visible button is now outline. Screenshots confirm the quiet outline look (e.g. demo complexity-level buttons, homepage CTAs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)