### PR TITLE
chore(brand): unify last legacy bitcoin-orange #f7931a → brand #FF7A00

### DIFF
--- a/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-loans.html
@@ -1063,7 +1063,7 @@
           <line x1="84" y1="180" x2="640" y2="180" stroke="rgba(255,255,255,0.08)" stroke-width="1" stroke-dasharray="3,3"/>
 
           <!-- Payoff line (downward slope: profit when BTC drops, loss when BTC rises) -->
-          <line x1="80" y1="60" x2="640" y2="300" stroke="#f7931a" stroke-width="2.5"/>
+          <line x1="80" y1="60" x2="640" y2="300" stroke="#FF7A00" stroke-width="2.5"/>
 
           <!-- Gain region shading (left of origin, above break-even) -->
           <polygon points="80,60 80,180 360,180" fill="rgba(16,185,129,0.10)"/>
@@ -1098,13 +1098,13 @@
           <text x="545" y="269" text-anchor="middle" fill="#cbd2da" font-size="10">to repurchase → forfeit</text>
 
           <!-- Origin annotation -->
-          <circle cx="360" cy="180" r="4" fill="#f7931a"/>
-          <text x="370" y="175" fill="#f7931a" font-size="11" font-weight="700">Origination</text>
+          <circle cx="360" cy="180" r="4" fill="#FF7A00"/>
+          <text x="370" y="175" fill="#FF7A00" font-size="11" font-weight="700">Origination</text>
           <text x="370" y="190" fill="#9aa4b2" font-size="10">BTC at $100K = break-even</text>
 
           <!-- Asymmetry annotation -->
           <text x="360" y="355" text-anchor="middle" fill="#cbd2da" font-size="12">
-            <tspan font-weight="700" fill="#f7931a">Asymmetric:</tspan>
+            <tspan font-weight="700" fill="#FF7A00">Asymmetric:</tspan>
             <tspan>downside (loss zone) is unbounded; upside (gain zone) is capped at BTC reaching $0.</tspan>
           </text>
         </svg>
@@ -1234,9 +1234,9 @@
           <text x="20" y="24" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">B</text>
           <text x="20" y="50" text-anchor="middle" fill="#10b981" font-size="10" font-weight="600">Borrower</text>
 
-          <circle cx="65" cy="20" r="12" fill="#f7931a"/>
+          <circle cx="65" cy="20" r="12" fill="#FF7A00"/>
           <text x="65" y="24" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">L</text>
-          <text x="65" y="50" text-anchor="middle" fill="#f7931a" font-size="10" font-weight="600">Lender</text>
+          <text x="65" y="50" text-anchor="middle" fill="#FF7A00" font-size="10" font-weight="600">Lender</text>
 
           <circle cx="110" cy="20" r="12" fill="#3b82f6"/>
           <text x="110" y="24" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">A</text>
@@ -1256,7 +1256,7 @@
         <g transform="translate(220, 200)">
           <circle cx="20" cy="20" r="12" fill="#10b981"/>
           <text x="20" y="24" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">B</text>
-          <circle cx="60" cy="20" r="12" fill="#f7931a"/>
+          <circle cx="60" cy="20" r="12" fill="#FF7A00"/>
           <text x="60" y="24" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">L</text>
           <circle cx="100" cy="20" r="12" fill="#a855f7"/>
           <text x="100" y="24" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">D</text>
@@ -1264,7 +1264,7 @@
           <text x="140" y="24" text-anchor="middle" fill="#fff" font-size="13" font-weight="700">A</text>
 
           <text x="20" y="50" text-anchor="middle" fill="#10b981" font-size="9">Borrower</text>
-          <text x="60" y="50" text-anchor="middle" fill="#f7931a" font-size="9">Lender</text>
+          <text x="60" y="50" text-anchor="middle" fill="#FF7A00" font-size="9">Lender</text>
           <text x="100" y="50" text-anchor="middle" fill="#a855f7" font-size="9">Debifi</text>
           <text x="140" y="50" text-anchor="middle" fill="#3b82f6" font-size="9">AnchorWatch</text>
 
@@ -1617,8 +1617,8 @@
 
           <!-- Payoff line: from (80, 60) up to strike then flat at -premium -->
           <!-- Strike at x=220 → premium line is flat at y=240 (just below break-even = small loss) -->
-          <line x1="80" y1="60" x2="220" y2="240" stroke="#f7931a" stroke-width="2.5"/>
-          <line x1="220" y1="240" x2="640" y2="240" stroke="#f7931a" stroke-width="2.5"/>
+          <line x1="80" y1="60" x2="220" y2="240" stroke="#FF7A00" stroke-width="2.5"/>
+          <line x1="220" y1="240" x2="640" y2="240" stroke="#FF7A00" stroke-width="2.5"/>
 
           <!-- Gain region shading (left of strike, above break-even) -->
           <polygon points="80,60 80,220 220,220" fill="rgba(16,185,129,0.10)"/>
@@ -1652,12 +1652,12 @@
           <text x="480" y="201" text-anchor="middle" fill="#cbd2da" font-size="10">Capped at ~$8,594 (1.7% notional)</text>
 
           <!-- Spot annotation -->
-          <circle cx="500" cy="240" r="4" fill="#f7931a"/>
-          <text x="510" y="245" fill="#f7931a" font-size="11" font-weight="700">Today's spot</text>
+          <circle cx="500" cy="240" r="4" fill="#FF7A00"/>
+          <text x="510" y="245" fill="#FF7A00" font-size="11" font-weight="700">Today's spot</text>
 
           <!-- Bottom message -->
           <text x="360" y="355" text-anchor="middle" fill="#cbd2da" font-size="12">
-            <tspan font-weight="700" fill="#f7931a">Asymmetric the right way:</tspan>
+            <tspan font-weight="700" fill="#FF7A00">Asymmetric the right way:</tspan>
             <tspan>bounded loss (premium), unbounded protection below the margin threshold.</tspan>
           </text>
       </svg>

--- a/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
+++ b/deep-dives/bitcoin-capital/bitcoin-backed-mortgages.html
@@ -711,9 +711,9 @@
 <!-- DISCLOSURE BANNER (consistency with loans deep dive) -->
 <div id="mortgages-disclosure" style="background:linear-gradient(180deg,rgba(255,122,0,0.08),rgba(255,122,0,0.04));border-bottom:1px solid rgba(255,122,0,0.2);padding:0.85rem 0;">
   <div style="max-width:1100px;margin:0 auto;padding:0 2rem;display:flex;align-items:flex-start;gap:1rem;font-size:0.85rem;color:var(--dim,#cbd2da);line-height:1.55;">
-    <span style="color:var(--primary,#f7931a);font-weight:700;flex-shrink:0;font-family:var(--mono,monospace);font-size:0.9rem;">ⓘ</span>
+    <span style="color:var(--primary,#FF7A00);font-weight:700;flex-shrink:0;font-family:var(--mono,monospace);font-size:0.9rem;">ⓘ</span>
     <div style="flex:1;">
-      <strong style="color:var(--primary,#f7931a);">Heads-up before you read.</strong> BSA's founder Dalia advises at The Bitcoin Adviser (TBA), parent of <strong>Loan My Coins (LMC)</strong>. LMC is a non-mortgage product covered in the sibling <a href="/deep-dives/bitcoin-capital/bitcoin-backed-loans.html" style="color:var(--primary,#f7931a);">Bitcoin-Backed Loans deep dive</a>. This piece focuses on mortgage products (Milo, Better+Coinbase, Peoples Reserve). We scrutinize each product the same way — including where each one isn't the right fit. The math is the math regardless of who built the product.
+      <strong style="color:var(--primary,#FF7A00);">Heads-up before you read.</strong> BSA's founder Dalia advises at The Bitcoin Adviser (TBA), parent of <strong>Loan My Coins (LMC)</strong>. LMC is a non-mortgage product covered in the sibling <a href="/deep-dives/bitcoin-capital/bitcoin-backed-loans.html" style="color:var(--primary,#FF7A00);">Bitcoin-Backed Loans deep dive</a>. This piece focuses on mortgage products (Milo, Better+Coinbase, Peoples Reserve). We scrutinize each product the same way — including where each one isn't the right fit. The math is the math regardless of who built the product.
     </div>
     <button id="mortgages-disclosure-dismiss" aria-label="Dismiss disclosure banner" style="background:transparent;border:1px solid rgba(255,255,255,0.08);color:var(--muted,#9aa4b2);cursor:pointer;padding:0.2rem 0.5rem;border-radius:4px;font-size:0.85rem;flex-shrink:0;">Dismiss ×</button>
   </div>
@@ -870,8 +870,8 @@
         <line x1="605" y1="95" x2="605" y2="115" stroke="#9aa4b2" stroke-width="1.5"/>
 
         <!-- Model A column -->
-        <rect x="20" y="115" width="190" height="50" rx="6" fill="rgba(247,147,26,0.15)" stroke="#f7931a" stroke-width="1.5"/>
-        <text x="115" y="138" text-anchor="middle" fill="#f7931a" font-size="12" font-weight="700" letter-spacing="0.08em">MODEL A</text>
+        <rect x="20" y="115" width="190" height="50" rx="6" fill="rgba(247,147,26,0.15)" stroke="#FF7A00" stroke-width="1.5"/>
+        <text x="115" y="138" text-anchor="middle" fill="#FF7A00" font-size="12" font-weight="700" letter-spacing="0.08em">MODEL A</text>
         <text x="115" y="156" text-anchor="middle" fill="#e6edf3" font-size="13">Milo</text>
 
         <line x1="115" y1="165" x2="115" y2="185" stroke="#9aa4b2" stroke-width="1.5"/>
@@ -941,7 +941,7 @@
         <!-- Bottom label -->
         <rect x="40" y="408" width="640" height="40" rx="6" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.08)"/>
         <text x="360" y="425" text-anchor="middle" fill="#cbd2da" font-size="12">
-          <tspan font-weight="700" fill="#f7931a">The structural insight:</tspan> the same BTC price drop produces three completely different borrower experiences.
+          <tspan font-weight="700" fill="#FF7A00">The structural insight:</tspan> the same BTC price drop produces three completely different borrower experiences.
         </text>
         <text x="360" y="440" text-anchor="middle" fill="#9aa4b2" font-size="11" font-style="italic">Comparing these products on "interest rate" alone misses what makes them different products.</text>
       </svg>

--- a/embeds/intent-theft-sandbox/index.html
+++ b/embeds/intent-theft-sandbox/index.html
@@ -40,7 +40,7 @@
     --line-soft:rgba(255,255,255,.08);
     --text:#f3f4f6;
     --muted:#9aa0aa;
-    --or:#F7931A;        /* bitcoin orange */
+    --or:#FF7A00;        /* bitcoin orange */
     --or-2:#FBB034;
     --ye:#FCD116;        /* bright yellow */
     --grad:var(--brand-gradient-h);

--- a/emergency-kit.html
+++ b/emergency-kit.html
@@ -493,11 +493,11 @@
             </div>
 
             <!-- Closing CTA: free emergency help -> paid prevention (Family Bitcoin Recovery Kit). spine-repair A1 -->
-            <div style="margin-top:2.5rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#f7931a);border-radius:8px;background:rgba(247,147,26,0.06);">
+            <div style="margin-top:2.5rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#FF7A00);border-radius:8px;background:rgba(247,147,26,0.06);">
                 <h3 style="margin:0 0 .5rem;">Don't want to be back here next time?</h3>
                 <p style="margin:0 0 1.25rem;color:var(--text-dim,#9aa0aa);">Most Bitcoin emergencies trace back to a missing plan — no tested backup, no recovery sequence, no one who knows what to do if you can't act. The <strong>Family Bitcoin Recovery Kit</strong> is the prevention layer: a structured, family-readable recovery plan that never exposes your keys.</p>
-                <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#f7931a);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
-                <p style="margin:1rem 0 0;color:var(--text-dim,#9aa0aa);font-size:.9rem;">Not sure where the gap is? <a href="/deep-dives/jurisdictional-exposure-audit/audit/" style="color:var(--color-brand,#f7931a);">Map your exposure first</a> — a free, no-login audit that shows whether your risk is custody, family, documents, or jurisdiction.</p>
+                <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#FF7A00);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
+                <p style="margin:1rem 0 0;color:var(--text-dim,#9aa0aa);font-size:.9rem;">Not sure where the gap is? <a href="/deep-dives/jurisdictional-exposure-audit/audit/" style="color:var(--color-brand,#FF7A00);">Map your exposure first</a> — a free, no-login audit that shows whether your risk is custody, family, documents, or jurisdiction.</p>
             </div>
         </div>
 

--- a/interactive-demos/sovereign-vault/index.html
+++ b/interactive-demos/sovereign-vault/index.html
@@ -1001,11 +1001,11 @@
 <!-- Analytics, Email Capture & Tip CTAs -->
 <div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
     <!-- Closing CTA: free vault tool -> paid prevention (Family Bitcoin Recovery Kit). funnel: family-education -->
-    <div style="margin-bottom:2rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#f7931a);border-radius:8px;background:rgba(247,147,26,0.06);">
+    <div style="margin-bottom:2rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#FF7A00);border-radius:8px;background:rgba(247,147,26,0.06);">
         <h3 style="margin:0 0 .5rem;">Built your vault here? Make it survivable.</h3>
         <p style="margin:0 0 1.25rem;color:var(--text-dim,#9aa0aa);">A vault only protects your family if they can actually recover it. The <strong>Family Bitcoin Recovery Kit</strong> turns what you just set up into a structured, family-readable recovery plan, tested backups, a clear sequence, and not a single exposed key.</p>
-        <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#f7931a);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
-        <p style="margin:1rem 0 0;color:var(--text-dim,#9aa0aa);font-size:.9rem;">Want the bigger picture first? <a href="/deep-dives/jurisdictional-exposure-audit/audit/" style="color:var(--color-brand,#f7931a);">Map your jurisdictional exposure</a>, a free, no-login audit covering custody, family, documents, banking, and jurisdiction.</p>
+        <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#FF7A00);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
+        <p style="margin:1rem 0 0;color:var(--text-dim,#9aa0aa);font-size:.9rem;">Want the bigger picture first? <a href="/deep-dives/jurisdictional-exposure-audit/audit/" style="color:var(--color-brand,#FF7A00);">Map your jurisdictional exposure</a>, a free, no-login audit covering custody, family, documents, banking, and jurisdiction.</p>
     </div>
     <div id="email-capture-page" data-email-capture="family-education-vault" data-title="🔐 Protect your family's Bitcoin" data-subtitle="Get our custody &amp; inheritance guides and new content announcements, for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
     <div id="tip-page" data-tip-cta="compact"></div>

--- a/interactive-demos/sovereign-vault/templates/emergency-doc.html
+++ b/interactive-demos/sovereign-vault/templates/emergency-doc.html
@@ -828,10 +828,10 @@
 <!-- Analytics, Email Capture & Tip CTAs -->
 <div class="container" style="margin: 2rem auto; max-width: 900px; padding: 0 1.5rem;">
     <!-- Closing CTA: free emergency-access doc -> paid prevention (Family Bitcoin Recovery Kit). funnel: family-education -->
-    <div style="margin-bottom:2rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#f7931a);border-radius:8px;background:rgba(247,147,26,0.06);">
+    <div style="margin-bottom:2rem;padding:1.75rem;border:1px solid var(--color-border,#2a2f3a);border-left:4px solid var(--color-brand,#FF7A00);border-radius:8px;background:rgba(247,147,26,0.06);">
         <h3 style="margin:0 0 .5rem;">This document is step one — not the whole plan.</h3>
         <p style="margin:0 0 1.25rem;color:var(--text-dim,#9aa0aa);">An emergency access document only works inside a tested recovery plan. The <strong>Family Bitcoin Recovery Kit</strong> is that plan: a structured, family-readable recovery sequence your loved ones can actually follow, without ever exposing your keys.</p>
-        <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#f7931a);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
+        <a href="/products/family-bitcoin-recovery-kit/" style="display:inline-block;background:var(--color-brand,#FF7A00);color:#0b0e14;font-weight:700;text-decoration:none;padding:.8rem 1.5rem;border-radius:6px;">Build your recovery plan → Family Bitcoin Recovery Kit</a>
     </div>
     <div id="email-capture-page" data-email-capture="family-education-emergency-doc" data-title="🔐 Keep your family's recovery plan current" data-subtitle="Get our custody &amp; inheritance guides and updates as they ship — for families holding their own keys. No spam, ever." data-button="Keep me updated"></div>
     <div id="tip-page" data-tip-cta="compact"></div>

--- a/nostr/index.html
+++ b/nostr/index.html
@@ -23,12 +23,12 @@
     line-height: 1.55;
     -webkit-font-smoothing: antialiased;
   }
-  a { color: #f7931a; text-decoration: none; }
+  a { color: #FF7A00; text-decoration: none; }
   a:hover, a:focus-visible { text-decoration: underline; }
   .wrap { max-width: 760px; margin: 0 auto; padding: 4rem 1.25rem 6rem; }
   .eyebrow {
     font-size: .8rem; letter-spacing: .14em; text-transform: uppercase;
-    color: #f7931a; margin-bottom: 1rem;
+    color: #FF7A00; margin-bottom: 1rem;
   }
   h1 { font-size: clamp(2rem, 5vw, 3.25rem); line-height: 1.1; margin: 0 0 1.25rem; font-weight: 700; }
   h2 { font-size: 1.35rem; margin: 2.5rem 0 .75rem; font-weight: 700; }
@@ -54,7 +54,7 @@
     color: #f0f0f0; word-break: break-all; flex: 1 1 auto;
   }
   .id-row button {
-    background: #f7931a; color: #0b0e14; border: 0; border-radius: 4px;
+    background: #FF7A00; color: #0b0e14; border: 0; border-radius: 4px;
     padding: .5rem .85rem; font-weight: 700; cursor: pointer;
     font-family: inherit; font-size: .9rem;
   }
@@ -62,9 +62,9 @@
   .ctas { display: flex; flex-wrap: wrap; gap: .75rem; margin: 1.5rem 0 .5rem; }
   .btn {
     display: inline-block; padding: .85rem 1.1rem; border-radius: 4px; font-weight: 700;
-    border: 1px solid #f7931a; color: #f7931a;
+    border: 1px solid #FF7A00; color: #FF7A00;
   }
-  .btn-primary { background: #f7931a; color: #0b0e14; }
+  .btn-primary { background: #FF7A00; color: #0b0e14; }
   .btn:hover, .btn:focus-visible { text-decoration: none; filter: brightness(1.08); }
   .muted { color: #9b9b9b; font-size: .9rem; }
   .pill {

--- a/programa-colombia/semana-10/index.html
+++ b/programa-colombia/semana-10/index.html
@@ -50,12 +50,12 @@
         .asset-card.realestate { border-left-color: var(--orange); }
         .asset-card.equities { border-left-color: var(--green); }
         .asset-card.gold { border-left-color: var(--primary); }
-        .asset-card.bitcoin { border-left-color: #f7931a; }
+        .asset-card.bitcoin { border-left-color: #FF7A00; }
         .asset-card h3 { color: var(--light); font-size: 1.1rem; margin-bottom: 6px; display: flex; align-items: center; gap: 8px; }
         .asset-card h3 .icon { font-size: 1.4rem; }
         .asset-card .tag { display: inline-block; font-size: 0.68rem; letter-spacing: 0.08em; text-transform: uppercase; font-weight: 700; padding: 2px 8px; border-radius: 999px; margin-left: auto; }
         .asset-card .tag.classic { background: rgba(252,209,22,0.12); color: var(--primary); }
-        .asset-card .tag.harder { background: rgba(247,147,26,0.12); color: #f7931a; }
+        .asset-card .tag.harder { background: rgba(247,147,26,0.12); color: #FF7A00; }
         .asset-card p { color: var(--dim); font-size: 0.94rem; line-height: 1.65; margin: 6px 0; }
         .asset-card p strong { color: var(--light); }
         .asset-card .row { display: grid; grid-template-columns: 110px 1fr; gap: 8px 12px; margin-top: 10px; font-size: 0.88rem; }
@@ -136,12 +136,12 @@
 
         /* Bitcoin bridge */
         .bitcoin-bridge { background: linear-gradient(180deg, rgba(247,147,26,0.06), rgba(247,147,26,0.02)); border: 1px solid rgba(247,147,26,0.3); border-radius: 14px; padding: 18px 20px; margin: 1.5rem 0; }
-        .bitcoin-bridge h3 { color: #f7931a; margin-bottom: 8px; }
+        .bitcoin-bridge h3 { color: #FF7A00; margin-bottom: 8px; }
         .bitcoin-bridge p { color: var(--dim); font-size: 0.94rem; line-height: 1.7; margin: 8px 0; }
         .bitcoin-bridge p strong { color: var(--light); }
         .bitcoin-bridge .pills { display: flex; flex-wrap: wrap; gap: 6px; margin: 10px 0; }
-        .bitcoin-bridge .pill { background: rgba(247,147,26,0.1); border: 1px solid rgba(247,147,26,0.3); color: #f7931a; padding: 4px 10px; border-radius: 999px; font-size: 0.78rem; font-weight: 600; }
-        .bitcoin-bridge a { display: inline-block; margin-top: 8px; color: #f7931a; font-weight: 700; text-decoration: none; }
+        .bitcoin-bridge .pill { background: rgba(247,147,26,0.1); border: 1px solid rgba(247,147,26,0.3); color: #FF7A00; padding: 4px 10px; border-radius: 999px; font-size: 0.78rem; font-weight: 600; }
+        .bitcoin-bridge a { display: inline-block; margin-top: 8px; color: #FF7A00; font-weight: 700; text-decoration: none; }
         .bitcoin-bridge a:hover { text-decoration: underline; }
 
         /* Action box */


### PR DESCRIPTION
## Unify the last off-brand orange

Replaces the legacy Bitcoin-orange `#f7931a` with the brand orange `#FF7A00` — 37 occurrences across 8 files (SVG `fill`/`stroke`, `color`/`border`, and `var()` fallbacks). Uses the **literal** `#FF7A00` (not `var(--color-brand)`) so there's **zero breakage risk** on pages that don't link a token sheet.

Verified: every changed line differs *only* by the hex — no structural changes.

### Scope note (the rest of "the tail")
The remaining hardcoded-hex work is **`#FF7A00` in 326 files**. Tokenizing those to `var(--color-brand)` is **zero visual change** (the var equals `#FF7A00`) — pure maintainability — but a large set of those pages (all of `answers/`, `pricing.html`, `account.html`, `404.html`, …) link **no token-defining sheet**, so a blind hex→var swap would leave `var(--color-brand)` undefined and break their color. Recommendation: **do not** do that blanket swap; it's high-risk / near-zero-benefit. The real architectural finish is dissolving `brand.css`'s duplicate `:root` and retiring the `*-brand-fix` sheets (its own carefully-gated effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)