### PR TITLE
fix(sovereign-path): de-gamify stage 2/3/4 indexes

### DIFF
--- a/paths/sovereign/stage-2/index.html
+++ b/paths/sovereign/stage-2/index.html
@@ -84,21 +84,6 @@
             font-weight: 600;
         }
 
-        .progress-bar {
-            width: 100%;
-            height: 8px;
-            background: rgba(212, 175, 55, 0.1);
-            border-radius: 4px;
-            overflow: hidden;
-            margin-top: 1rem;
-        }
-
-        .progress-fill {
-            height: 100%;
-            background: var(--sovereign-gold);
-            transition: width 0.3s ease;
-        }
-
         .main-content {
             padding: 3rem 0;
         }
@@ -386,9 +371,6 @@
                 <h1>🎭 Stage 2: Privacy and Anonymity</h1>
                 <span class="stage-badge">Stage 2 of 4</span>
             </div>
-            <div class="progress-bar">
-                <div class="progress-fill" style="width: 0%" id="stage-progress"></div>
-            </div>
         </div>
     </header>
 
@@ -406,9 +388,7 @@
                         <h3>Bitcoin Privacy Fundamentals</h3>
                         <div class="module-meta">
                             <span><span data-icon="timer"></span> 30 minutes</span>
-                            <span class="security-badge security-medium">🟡 Privacy Focus</span>
-                            <span>📝 Content in development</span>
-                        </div>
+                            <span class="security-badge security-medium">🟡 Privacy Focus</span>                        </div>
                         <p class="module-description">
                             Understand blockchain analysis, address reuse risks, and fundamental privacy concepts in Bitcoin transactions.
                         </p>
@@ -418,39 +398,35 @@
                     </div>
                 </div>
 
-                <div class="module-card locked " id="module-2">
+                <div class="module-card " id="module-2">
                     <div class="module-number">2</div>
                     <div class="module-info">
                         <h3>CoinJoin and Mixing</h3>
                         <div class="module-meta">
                             <span><span data-icon="timer"></span> 30 minutes</span>
-                            <span class="security-badge security-medium">🟡 Privacy Focus</span>
-                            <span>📝 Content in development</span>
-                        </div>
+                            <span class="security-badge security-medium">🟡 Privacy Focus</span>                        </div>
                         <p class="module-description">
                             Master CoinJoin protocols, mixing techniques, and tools for breaking transaction history links.
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 1 first</span>
+                        <a href="module-2.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
-                <div class="module-card locked " id="module-3">
+                <div class="module-card " id="module-3">
                     <div class="module-number">3</div>
                     <div class="module-info">
                         <h3>Running Your Own Node</h3>
                         <div class="module-meta">
                             <span><span data-icon="timer"></span> 30 minutes</span>
-                            <span class="security-badge security-medium">🟡 Privacy Focus</span>
-                            <span>📝 Content in development</span>
-                        </div>
+                            <span class="security-badge security-medium">🟡 Privacy Focus</span>                        </div>
                         <p class="module-description">
                             Set up and run your own Bitcoin full node for maximum privacy and sovereignty in transaction validation.
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 2 first</span>
+                        <a href="module-3.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
@@ -460,70 +436,16 @@
             <div class="stage-navigation">
                 <h3>After Completing This Stage</h3>
                 <p>
-                    You'll earn the <strong>"Privacy Expert"</strong> badge and unlock Stage 3
+                    Next up: <strong>Stage 3: Advanced Operations</strong>. Keep building your sovereignty stack at your own pace.
                 </p>
                 <div class="stage-nav-buttons">
                     <a href="../stage-1/" class="btn-secondary">← Previous Stage</a>
-                    <a href="../stage-3/" class="btn-secondary" style="opacity: 0.5; pointer-events: none;">Next Stage →</a>
+                    <a href="../stage-3/" class="btn-secondary">Next Stage →</a>
                 </div>
             </div>
         </div>
     </main>
 
-    <script>
-        function updateProgress() {
-            const progress = JSON.parse(localStorage.getItem('learningProgress') || '{}');
-            const completedModules = progress.completedModules || [];
-
-            const module1Complete = completedModules.includes('sovereign-2-1');
-            const module2Complete = completedModules.includes('sovereign-2-2');
-            const module3Complete = completedModules.includes('sovereign-2-3');
-
-            if (module1Complete) {
-                document.getElementById('module-1').classList.remove('current');
-                document.getElementById('module-1').classList.add('completed');
-                document.querySelector('#module-1 .btn').textContent = '✓ Review Module';
-
-                document.getElementById('module-2').classList.remove('locked');
-                document.getElementById('module-2').classList.add('current');
-                document.querySelector('#module-2 .module-action').innerHTML =
-                    '<a href="module-2.html" class="btn">Continue →</a>';
-            }
-
-            if (module2Complete) {
-                document.getElementById('module-2').classList.remove('current');
-                document.getElementById('module-2').classList.add('completed');
-                document.querySelector('#module-2 .btn').textContent = '✓ Review Module';
-
-                document.getElementById('module-3').classList.remove('locked');
-                document.getElementById('module-3').classList.add('current');
-                document.querySelector('#module-3 .module-action').innerHTML =
-                    '<a href="module-3.html" class="btn">Continue →</a>';
-            }
-
-            if (module3Complete) {
-                document.getElementById('module-3').classList.remove('current');
-                document.getElementById('module-3').classList.add('completed');
-                document.querySelector('#module-3 .btn').textContent = '✓ Review Module';
-
-                const nextStage = document.querySelector('[href="../stage-3/"]');
-                if (nextStage) {
-                    nextStage.style.opacity = '1';
-                    nextStage.style.pointerEvents = 'auto';
-                }
-            }
-
-            let completedCount = 0;
-            if (module1Complete) completedCount++;
-            if (module2Complete) completedCount++;
-            if (module3Complete) completedCount++;
-
-            const progressPercent = (completedCount / 3) * 100;
-            document.getElementById('stage-progress').style.width = progressPercent + '%';
-        }
-
-        updateProgress();
-    </script>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/sovereign/stage-3/index.html
+++ b/paths/sovereign/stage-3/index.html
@@ -84,21 +84,6 @@
             font-weight: 600;
         }
 
-        .progress-bar {
-            width: 100%;
-            height: 8px;
-            background: rgba(212, 175, 55, 0.1);
-            border-radius: 4px;
-            overflow: hidden;
-            margin-top: 1rem;
-        }
-
-        .progress-fill {
-            height: 100%;
-            background: var(--sovereign-gold);
-            transition: width 0.3s ease;
-        }
-
         .main-content {
             padding: 3rem 0;
         }
@@ -386,9 +371,6 @@
                 <h1><span data-icon="lightning"></span> Stage 3: Advanced Operations</h1>
                 <span class="stage-badge">Stage 3 of 4</span>
             </div>
-            <div class="progress-bar">
-                <div class="progress-fill" style="width: 0%" id="stage-progress"></div>
-            </div>
         </div>
     </header>
 
@@ -405,10 +387,6 @@
                     <div class="module-info">
                         <h3>Lightning Network Self-Hosting</h3>
                         <div class="module-meta"><span><span data-icon="timer"></span> 35 minutes</span><span class="security-badge security-medium">🟡 Advanced</span></div>
-                        <div class="module-meta">
-                            <span><span data-icon="timer"></span> 30 minutes</span>
-                            <span>📝 Content in development</span>
-                        </div>
                         <p class="module-description">
                             Learn to run your own Lightning node, manage channels, and route payments independently.
                         </p>
@@ -418,37 +396,33 @@
                     </div>
                 </div>
 
-                <div class="module-card locked " id="module-2">
+                <div class="module-card " id="module-2">
                     <div class="module-number">2</div>
                     <div class="module-info">
                         <h3>Payjoin and PayNym</h3>
                         <div class="module-meta">
-                            <span><span data-icon="timer"></span> 30 minutes</span>
-                            <span>📝 Content in development</span>
-                        </div>
+                            <span><span data-icon="timer"></span> 30 minutes</span>                        </div>
                         <p class="module-description">
                             Master advanced privacy techniques with Payjoin transactions and PayNym identity management.
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 1 first</span>
+                        <a href="module-2.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
-                <div class="module-card locked " id="module-3">
+                <div class="module-card " id="module-3">
                     <div class="module-number">3</div>
                     <div class="module-info">
                         <h3>Emergency Recovery Plans</h3>
                         <div class="module-meta">
-                            <span><span data-icon="timer"></span> 30 minutes</span>
-                            <span>📝 Content in development</span>
-                        </div>
+                            <span><span data-icon="timer"></span> 30 minutes</span>                        </div>
                         <p class="module-description">
                             Create comprehensive disaster recovery plans, test restoration procedures, and prepare for worst-case scenarios.
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 2 first</span>
+                        <a href="module-3.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
@@ -560,70 +534,16 @@
             <div class="stage-navigation">
                 <h3>After Completing This Stage</h3>
                 <p>
-                    You'll earn the <strong>"Advanced Operator"</strong> badge and unlock Stage 4
+                    Next up: <strong>Stage 4: Total Sovereignty</strong>. Keep building your sovereignty stack at your own pace.
                 </p>
                 <div class="stage-nav-buttons">
                     <a href="../stage-2/" class="btn-secondary">← Previous Stage</a>
-                    <a href="../stage-4/" class="btn-secondary" style="opacity: 0.5; pointer-events: none;">Next Stage →</a>
+                    <a href="../stage-4/" class="btn-secondary">Next Stage →</a>
                 </div>
             </div>
         </div>
     </main>
 
-    <script>
-        function updateProgress() {
-            const progress = JSON.parse(localStorage.getItem('learningProgress') || '{}');
-            const completedModules = progress.completedModules || [];
-
-            const module1Complete = completedModules.includes('sovereign-3-1');
-            const module2Complete = completedModules.includes('sovereign-3-2');
-            const module3Complete = completedModules.includes('sovereign-3-3');
-
-            if (module1Complete) {
-                document.getElementById('module-1').classList.remove('current');
-                document.getElementById('module-1').classList.add('completed');
-                document.querySelector('#module-1 .btn').textContent = '✓ Review Module';
-
-                document.getElementById('module-2').classList.remove('locked');
-                document.getElementById('module-2').classList.add('current');
-                document.querySelector('#module-2 .module-action').innerHTML =
-                    '<a href="module-2.html" class="btn">Continue →</a>';
-            }
-
-            if (module2Complete) {
-                document.getElementById('module-2').classList.remove('current');
-                document.getElementById('module-2').classList.add('completed');
-                document.querySelector('#module-2 .btn').textContent = '✓ Review Module';
-
-                document.getElementById('module-3').classList.remove('locked');
-                document.getElementById('module-3').classList.add('current');
-                document.querySelector('#module-3 .module-action').innerHTML =
-                    '<a href="module-3.html" class="btn">Continue →</a>';
-            }
-
-            if (module3Complete) {
-                document.getElementById('module-3').classList.remove('current');
-                document.getElementById('module-3').classList.add('completed');
-                document.querySelector('#module-3 .btn').textContent = '✓ Review Module';
-
-                const nextStage = document.querySelector('[href="../stage-4/"]');
-                if (nextStage) {
-                    nextStage.style.opacity = '1';
-                    nextStage.style.pointerEvents = 'auto';
-                }
-            }
-
-            let completedCount = 0;
-            if (module1Complete) completedCount++;
-            if (module2Complete) completedCount++;
-            if (module3Complete) completedCount++;
-
-            const progressPercent = (completedCount / 3) * 100;
-            document.getElementById('stage-progress').style.width = progressPercent + '%';
-        }
-
-        updateProgress();
-    </script>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/sovereign/stage-4/index.html
+++ b/paths/sovereign/stage-4/index.html
@@ -84,21 +84,6 @@
             font-weight: 600;
         }
 
-        .progress-bar {
-            width: 100%;
-            height: 8px;
-            background: rgba(212, 175, 55, 0.1);
-            border-radius: 4px;
-            overflow: hidden;
-            margin-top: 1rem;
-        }
-
-        .progress-fill {
-            height: 100%;
-            background: var(--sovereign-gold);
-            transition: width 0.3s ease;
-        }
-
         .main-content {
             padding: 3rem 0;
         }
@@ -386,9 +371,6 @@
                 <h1>🏰 Stage 4: Total Sovereignty</h1>
                 <span class="stage-badge">Stage 4 of 4</span>
             </div>
-            <div class="progress-bar">
-                <div class="progress-fill" style="width: 0%" id="stage-progress"></div>
-            </div>
         </div>
     </header>
 
@@ -405,9 +387,7 @@
                     <div class="module-info">
                         <h3>Building Your Bitcoin Citadel</h3>
                         <div class="module-meta">
-                            <span><span data-icon="timer"></span> 30 minutes</span>
-                            <span>📝 Content in development</span>
-                        </div>
+                            <span><span data-icon="timer"></span> 30 minutes</span>                        </div>
                         <p class="module-description">
                             Design a comprehensive sovereignty stack: nodes, wallets, backup systems, and operational security.
                         </p>
@@ -417,37 +397,33 @@
                     </div>
                 </div>
 
-                <div class="module-card locked " id="module-2">
+                <div class="module-card " id="module-2">
                     <div class="module-number">2</div>
                     <div class="module-info">
                         <h3>Inheritance Planning</h3>
                         <div class="module-meta">
-                            <span><span data-icon="timer"></span> 30 minutes</span>
-                            <span>📝 Content in development</span>
-                        </div>
+                            <span><span data-icon="timer"></span> 30 minutes</span>                        </div>
                         <p class="module-description">
                             Create secure inheritance plans, multisig setups for heirs, and time-locked recovery mechanisms.
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 1 first</span>
+                        <a href="module-2.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
-                <div class="module-card locked " id="module-3">
+                <div class="module-card " id="module-3">
                     <div class="module-number">3</div>
                     <div class="module-info">
                         <h3>Living on Bitcoin Standard</h3>
                         <div class="module-meta">
-                            <span><span data-icon="timer"></span> 30 minutes</span>
-                            <span>📝 Content in development</span>
-                        </div>
+                            <span><span data-icon="timer"></span> 30 minutes</span>                        </div>
                         <p class="module-description">
                             Transition to living on Bitcoin: earning, spending, and maintaining privacy while using Bitcoin daily.
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 2 first</span>
+                        <a href="module-3.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
@@ -455,9 +431,9 @@
             </div>
 
             <div class="stage-navigation">
-                <h3>After Completing This Stage</h3>
+                <h3>Where this leads</h3>
                 <p>
-                    You'll earn the <strong>"Bitcoin Sovereign"</strong> badge
+                    This is the final stage of the Sovereign Path. From here the work is ongoing: keep verifying your setup, keep refining it as your needs change.
                 </p>
                 <div class="stage-nav-buttons">
                     <a href="../stage-3/" class="btn-secondary">← Previous Stage</a>
@@ -467,60 +443,6 @@
         </div>
     </main>
 
-    <script>
-        function updateProgress() {
-            const progress = JSON.parse(localStorage.getItem('learningProgress') || '{}');
-            const completedModules = progress.completedModules || [];
-
-            const module1Complete = completedModules.includes('sovereign-4-1');
-            const module2Complete = completedModules.includes('sovereign-4-2');
-            const module3Complete = completedModules.includes('sovereign-4-3');
-
-            if (module1Complete) {
-                document.getElementById('module-1').classList.remove('current');
-                document.getElementById('module-1').classList.add('completed');
-                document.querySelector('#module-1 .btn').textContent = '✓ Review Module';
-
-                document.getElementById('module-2').classList.remove('locked');
-                document.getElementById('module-2').classList.add('current');
-                document.querySelector('#module-2 .module-action').innerHTML =
-                    '<a href="module-2.html" class="btn">Continue →</a>';
-            }
-
-            if (module2Complete) {
-                document.getElementById('module-2').classList.remove('current');
-                document.getElementById('module-2').classList.add('completed');
-                document.querySelector('#module-2 .btn').textContent = '✓ Review Module';
-
-                document.getElementById('module-3').classList.remove('locked');
-                document.getElementById('module-3').classList.add('current');
-                document.querySelector('#module-3 .module-action').innerHTML =
-                    '<a href="module-3.html" class="btn">Continue →</a>';
-            }
-
-            if (module3Complete) {
-                document.getElementById('module-3').classList.remove('current');
-                document.getElementById('module-3').classList.add('completed');
-                document.querySelector('#module-3 .btn').textContent = '✓ Review Module';
-
-                const nextStage = document.querySelector('[href="../stage-4/"]');
-                if (nextStage) {
-                    nextStage.style.opacity = '1';
-                    nextStage.style.pointerEvents = 'auto';
-                }
-            }
-
-            let completedCount = 0;
-            if (module1Complete) completedCount++;
-            if (module2Complete) completedCount++;
-            if (module3Complete) completedCount++;
-
-            const progressPercent = (completedCount / 3) * 100;
-            document.getElementById('stage-progress').style.width = progressPercent + '%';
-        }
-
-        updateProgress();
-    </script>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>


### PR DESCRIPTION
Unlock the 9 real modules (were locked behind sequential gating and mislabeled 'Content in development'), remove the badge/unlock footer language, and delete the 0% progress bar plus the updateProgress localStorage script. Brings the Sovereign Path into unbounded mode, matching the voice spec and the Curious Path.