### PR TITLE
fix(curious-path): de-gamify stage 1-4 indexes

### DIFF
--- a/paths/curious/stage-1/index.html
+++ b/paths/curious/stage-1/index.html
@@ -89,21 +89,6 @@
             font-weight: 600;
         }
 
-        .progress-bar {
-            width: 100%;
-            height: 8px;
-            background: rgba(255, 122, 0, 0.1);
-            border-radius: 4px;
-            overflow: hidden;
-            margin-top: 1rem;
-        }
-
-        .progress-fill {
-            height: 100%;
-            background: #FF7A00;
-            transition: width 0.3s ease;
-        }
-
         /* Main Content */
         .main-content {
             padding: 3rem 0;
@@ -345,9 +330,6 @@
                 <h1>🌱 Stage 1: Understanding Money</h1>
                 <span class="stage-badge">Stage 1 of 4</span>
             </div>
-            <div class="progress-bar">
-                <div class="progress-fill" style="width: 0%" id="stage-progress"></div>
-            </div>
         </div>
     </header>
 
@@ -387,7 +369,7 @@
                 </div>
 
                 <!-- Module 2 -->
-                <div class="module-card locked" id="module-2">
+                <div class="module-card" id="module-2">
                     <div class="module-number">2</div>
                     <div class="module-info">
                         <h3>Problems with Traditional Money</h3>
@@ -402,13 +384,12 @@
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 1 first
-                        </span>
+                        <a href="module-2.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
                 <!-- Module 2.5 -->
-                <div class="module-card locked" id="module-2-5">
+                <div class="module-card" id="module-2-5">
                     <div class="module-number">2.5</div>
                     <div class="module-info">
                         <h3>From Patches to Principles</h3>
@@ -423,13 +404,12 @@
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 2 first
-                        </span>
+                        <a href="module-2-5.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
                 <!-- Module 3 -->
-                <div class="module-card locked" id="module-3">
+                <div class="module-card" id="module-3">
                     <div class="module-number">3</div>
                     <div class="module-info">
                         <h3>Enter Bitcoin</h3>
@@ -444,8 +424,7 @@
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 2.5 first
-                        </span>
+                        <a href="module-3.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
@@ -481,11 +460,11 @@
             <div class="stage-navigation">
                 <h3>After Completing This Stage</h3>
                 <p>
-                    You'll earn the <strong>"Understanding Money"</strong> badge and unlock Stage 2: Bitcoin Fundamentals
+                    Next up: <strong>Stage 2: Bitcoin Fundamentals</strong>. Keep going at your own pace.
                 </p>
                 <div class="stage-nav-buttons">
                     <a href="../" class="btn-secondary">← Back to Path Overview</a>
-                    <a href="../stage-2/" class="btn-secondary" style="opacity: 0.5; pointer-events: none;">
+                    <a href="../stage-2/" class="btn-secondary">
                         Stage 2: Bitcoin Fundamentals →
                     </a>
                 </div>
@@ -493,83 +472,6 @@
         </div>
     </main>
 
-    <script>
-        // Initialize ProgressManager
-        const progressManager = new ProgressManager();
-        progressManager.init();
-
-        // Progress tracking
-        function updateProgress() {
-            // Check which modules are completed using ProgressManager
-            const module1Complete = progressManager.isModuleComplete('curious', 1, 1);
-            const module2Complete = progressManager.isModuleComplete('curious', 1, 2);
-            const module25Complete = progressManager.isModuleComplete('curious', 1, 2.5);
-            const module3Complete = progressManager.isModuleComplete('curious', 1, 3);
-
-            // Update module states
-            if (module1Complete) {
-                document.getElementById('module-1').classList.remove('current');
-                document.getElementById('module-1').classList.add('completed');
-                document.querySelector('#module-1 .btn').textContent = '✓ Review Module';
-
-                // Unlock module 2
-                document.getElementById('module-2').classList.remove('locked');
-                document.getElementById('module-2').classList.add('current');
-                document.querySelector('#module-2 .module-action').innerHTML =
-                    '<a href="module-2.html" class="btn">Continue →</a>';
-            }
-
-            if (module2Complete) {
-                document.getElementById('module-2').classList.remove('current');
-                document.getElementById('module-2').classList.add('completed');
-                document.querySelector('#module-2 .btn').textContent = '✓ Review Module';
-
-                // Unlock module 2.5
-                document.getElementById('module-2-5').classList.remove('locked');
-                document.getElementById('module-2-5').classList.add('current');
-                document.querySelector('#module-2-5 .module-action').innerHTML =
-                    '<a href="module-2-5.html" class="btn">Continue →</a>';
-            }
-
-            if (module25Complete) {
-                document.getElementById('module-2-5').classList.remove('current');
-                document.getElementById('module-2-5').classList.add('completed');
-                document.querySelector('#module-2-5 .btn').textContent = '✓ Review Module';
-
-                // Unlock module 3
-                document.getElementById('module-3').classList.remove('locked');
-                document.getElementById('module-3').classList.add('current');
-                document.querySelector('#module-3 .module-action').innerHTML =
-                    '<a href="module-3.html" class="btn">Continue →</a>';
-            }
-
-            if (module3Complete) {
-                document.getElementById('module-3').classList.remove('current');
-                document.getElementById('module-3').classList.add('completed');
-                document.querySelector('#module-3 .btn').textContent = '✓ Review Module';
-
-                // Enable stage 2 (Module 3 is now final module of Stage 1)
-                const stage2Link = document.querySelector('[href="../stage-2/"]');
-                if (stage2Link) {
-                    stage2Link.style.opacity = '1';
-                    stage2Link.style.pointerEvents = 'auto';
-                }
-            }
-
-            // Update progress bar
-            let completedCount = 0;
-            if (module1Complete) completedCount++;
-            if (module2Complete) completedCount++;
-            if (module25Complete) completedCount++;
-            if (module3Complete) completedCount++;
-
-            const progressPercent = (completedCount / 4) * 100;
-            document.getElementById('stage-progress').style.width = progressPercent + '%';
-        }
-
-        // Run on page load
-        updateProgress();
-    </script>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/curious/stage-2/index.html
+++ b/paths/curious/stage-2/index.html
@@ -89,20 +89,6 @@
             font-weight: 600;
         }
 
-        .progress-bar {
-            width: 100%;
-            height: 8px;
-            background: rgba(255, 122, 0, 0.1);
-            border-radius: 4px;
-            overflow: hidden;
-            margin-top: 1rem;
-        }
-
-        .progress-fill {
-            height: 100%;
-            background: #FF7A00;
-            transition: width 0.3s ease;
-        }
 
         /* Main Content */
         .main-content {
@@ -364,9 +350,6 @@
                 <h1><span data-icon="lightning"></span> Stage 2: Bitcoin Fundamentals</h1>
                 <span class="stage-badge">Stage 2 of 4</span>
             </div>
-            <div class="progress-bar">
-                <div class="progress-fill" style="width: 0%" id="stage-progress"></div>
-            </div>
         </div>
     </header>
 
@@ -383,19 +366,10 @@
                 </p>
             </div>
 
-            <!-- Access Notice (shown if Stage 1 not complete) -->
-            <div class="access-notice" id="access-notice" style="display: none;">
-                <h3><span data-icon="lock"></span> Complete Stage 1 First</h3>
-                <p>
-                    To access Stage 2, you need to complete all modules in Stage 1: Understanding Money.
-                </p>
-                <a href="/paths/curious/stage-1/" class="btn-secondary">← Return to Stage 1</a>
-            </div>
-
             <!-- Modules Grid -->
             <div class="modules-grid">
                 <!-- Module 1 -->
-                <div class="module-card locked" id="module-1">
+                <div class="module-card" id="module-1">
                     <div class="module-number">1</div>
                     <div class="module-info">
                         <h3>How Bitcoin Works</h3>
@@ -410,13 +384,12 @@
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Stage 1 first
-                        </span>
+                        <a href="module-1.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
                 <!-- Module 2 -->
-                <div class="module-card locked" id="module-2">
+                <div class="module-card" id="module-2">
                     <div class="module-number">2</div>
                     <div class="module-info">
                         <h3>Bitcoin's Rules</h3>
@@ -431,13 +404,12 @@
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 1 first
-                        </span>
+                        <a href="module-2.html" class="btn">Start Module →</a>
                     </div>
                 </div>
 
                 <!-- Module 3 -->
-                <div class="module-card locked" id="module-3">
+                <div class="module-card" id="module-3">
                     <div class="module-number">3</div>
                     <div class="module-info">
                         <h3>Who Controls Bitcoin?</h3>
@@ -452,8 +424,7 @@
                         </p>
                     </div>
                     <div class="module-action">
-                        <span class="status-badge locked"><span data-icon="lock"></span> Complete Module 2 first
-                        </span>
+                        <a href="module-3.html" class="btn">Start Module →</a>
                     </div>
                 </div>
             </div>
@@ -462,11 +433,11 @@
             <div class="stage-navigation">
                 <h3>After Completing This Stage</h3>
                 <p>
-                    You'll earn the <strong>"Bitcoin Fundamentals"</strong> badge and unlock Stage 3: Your First Bitcoin
+                    Next up: <strong>Stage 3: Your First Bitcoin</strong>. Keep going at your own pace.
                 </p>
                 <div class="stage-nav-buttons">
                     <a href="/paths/curious/stage-1/" class="btn-secondary">← Back to Stage 1</a>
-                    <a href="/paths/curious/stage-3/" class="btn-secondary" style="opacity: 0.5; pointer-events: none;">
+                    <a href="/paths/curious/stage-3/" class="btn-secondary">
                         Stage 3: Your First Bitcoin →
                     </a>
                 </div>
@@ -474,86 +445,6 @@
         </div>
     </main>
 
-    <script>
-        // Initialize ProgressManager
-        const progressManager = new ProgressManager();
-        progressManager.init();
-
-        // Progress tracking
-        function updateProgress() {
-            // Check if Stage 1 is complete (all 4 modules)
-            const s1m1 = progressManager.isModuleComplete('curious', 1, 1);
-            const s1m2 = progressManager.isModuleComplete('curious', 1, 2);
-            const s1m25 = progressManager.isModuleComplete('curious', 1, 2.5);
-            const s1m3 = progressManager.isModuleComplete('curious', 1, 3);
-            const stage1Complete = s1m1 && s1m2 && s1m25 && s1m3;
-
-            if (!stage1Complete) {
-                // Show access notice and hide modules
-                document.getElementById('access-notice').style.display = 'block';
-                document.querySelector('.modules-grid').style.opacity = '0.5';
-                return;
-            }
-
-            // Stage 1 is complete, enable Module 1
-            document.getElementById('module-1').classList.remove('locked');
-            document.getElementById('module-1').classList.add('current');
-            document.querySelector('#module-1 .module-action').innerHTML =
-                '<a href="module-1.html" class="btn">Start Module →</a>';
-
-            // Check which modules are completed
-            const module1Complete = progressManager.isModuleComplete('curious', 2, 1);
-            const module2Complete = progressManager.isModuleComplete('curious', 2, 2);
-            const module3Complete = progressManager.isModuleComplete('curious', 2, 3);
-
-            // Update module states
-            if (module1Complete) {
-                document.getElementById('module-1').classList.remove('current');
-                document.getElementById('module-1').classList.add('completed');
-                document.querySelector('#module-1 .btn').textContent = '✓ Review Module';
-
-                // Unlock module 2
-                document.getElementById('module-2').classList.remove('locked');
-                document.getElementById('module-2').classList.add('current');
-                document.querySelector('#module-2 .module-action').innerHTML =
-                    '<a href="module-2.html" class="btn">Continue →</a>';
-            }
-
-            if (module2Complete) {
-                document.getElementById('module-2').classList.remove('current');
-                document.getElementById('module-2').classList.add('completed');
-                document.querySelector('#module-2 .btn').textContent = '✓ Review Module';
-
-                // Unlock module 3
-                document.getElementById('module-3').classList.remove('locked');
-                document.getElementById('module-3').classList.add('current');
-                document.querySelector('#module-3 .module-action').innerHTML =
-                    '<a href="module-3.html" class="btn">Continue →</a>';
-            }
-
-            if (module3Complete) {
-                document.getElementById('module-3').classList.remove('current');
-                document.getElementById('module-3').classList.add('completed');
-                document.querySelector('#module-3 .btn').textContent = '✓ Review Module';
-
-                // Enable stage 3
-                document.querySelector('[href="/paths/curious/stage-3/"]').style.opacity = '1';
-                document.querySelector('[href="/paths/curious/stage-3/"]').style.pointerEvents = 'auto';
-            }
-
-            // Update progress bar
-            let completedCount = 0;
-            if (module1Complete) completedCount++;
-            if (module2Complete) completedCount++;
-            if (module3Complete) completedCount++;
-
-            const progressPercent = (completedCount / 3) * 100;
-            document.getElementById('stage-progress').style.width = progressPercent + '%';
-        }
-
-        // Run on page load
-        updateProgress();
-    </script>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/curious/stage-3/index.html
+++ b/paths/curious/stage-3/index.html
@@ -236,7 +236,6 @@
             padding: 2.5rem;
             margin: 3rem 0;
             text-align: center;
-            display: none;
         }
 
         .completion-banner h3 {
@@ -388,7 +387,7 @@
                     </div>
 
                     <!-- Module 2 -->
-                    <div class="module-card locked" data-module="curious-3-2">
+                    <div class="module-card" data-module="curious-3-2">
                         <div class="module-header">
                             <div class="module-title">
                                 <h3>Module 2: Getting Bitcoin</h3>
@@ -418,12 +417,12 @@
                                 <span>📋 Comparison guide</span>
                                 <span>✅ Checklist</span>
                             </div>
-                            <a href="module-2.html" class="module-cta locked">Complete Module 1 First</a>
+                            <a href="module-2.html" class="module-cta">Start Module 2 →</a>
                         </div>
                     </div>
 
                     <!-- Module 3 -->
-                    <div class="module-card locked" data-module="curious-3-3">
+                    <div class="module-card" data-module="curious-3-3">
                         <div class="module-header">
                             <div class="module-title">
                                 <h3>Module 3: Your First Transaction</h3>
@@ -453,7 +452,7 @@
                                 <span><span data-icon="game"></span> Interactive demo</span>
                                 <span>✅ Practice exercise</span>
                             </div>
-                            <a href="module-3.html" class="module-cta locked">Complete Module 2 First</a>
+                            <a href="module-3.html" class="module-cta">Start Module 3 →</a>
                         </div>
                     </div>
                 </div>
@@ -461,81 +460,16 @@
 
             <!-- Completion Banner -->
             <div class="completion-banner" id="completion-banner">
-                <div class="badge-display">₿</div>
-                <h3>Congratulations! Stage 3 Complete!</h3>
+                <h3>Where this leads</h3>
                 <p>
-                    You've earned the <strong>"First Bitcoin"</strong> badge! You now understand wallets, know how to
-                    acquire Bitcoin, and have the skills to send and receive Bitcoin safely.
+                    Once you understand wallets, how to acquire Bitcoin, and how to send and receive it safely,
+                    the next step is keeping it safe.
                 </p>
                 <a href="/paths/curious/stage-4/" class="next-stage-btn">Continue to Stage 4: Staying Safe →</a>
             </div>
         </div>
     </main>
 
-    <script>
-        // Initialize ProgressManager
-        const progressManager = new ProgressManager();
-        progressManager.init();
-
-        // Check progress and update UI
-        function updateProgress() {
-            // Check which stage 3 modules are completed
-            const module1Complete = progressManager.isModuleComplete('curious', 3, 1);
-            const module2Complete = progressManager.isModuleComplete('curious', 3, 2);
-            const module3Complete = progressManager.isModuleComplete('curious', 3, 3);
-
-            // Update module cards
-            if (module1Complete) {
-                const card = document.querySelector('[data-module="curious-3-1"]');
-                if (card) {
-                    card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = '#101010';
-                }
-            }
-            if (module2Complete) {
-                const card = document.querySelector('[data-module="curious-3-2"]');
-                if (card) {
-                    card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = '#101010';
-                }
-            }
-            if (module3Complete) {
-                const card = document.querySelector('[data-module="curious-3-3"]');
-                if (card) {
-                    card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = '#101010';
-                }
-            }
-
-            // Unlock next module
-            if (module1Complete) {
-                const module2 = document.querySelector('[data-module="curious-3-2"]');
-                if (module2) {
-                    module2.classList.remove('locked');
-                    module2.querySelector('.module-cta').classList.remove('locked');
-                    module2.querySelector('.module-cta').textContent = 'Start Module 2 →';
-                }
-            }
-
-            if (module2Complete) {
-                const module3 = document.querySelector('[data-module="curious-3-3"]');
-                module3.classList.remove('locked');
-                module3.querySelector('.module-cta').classList.remove('locked');
-                module3.querySelector('.module-cta').textContent = 'Start Module 3 →';
-            }
-
-            // Check if stage completed
-            const stageComplete = completedModules.includes('curious-3-1') &&
-                                completedModules.includes('curious-3-2') &&
-                                completedModules.includes('curious-3-3');
-
-            if (stageComplete) {
-                document.getElementById('completion-banner').style.display = 'block';
-            }
-        }
-
-        updateProgress();
-    </script>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>

--- a/paths/curious/stage-4/index.html
+++ b/paths/curious/stage-4/index.html
@@ -260,7 +260,6 @@
             padding: 2.5rem;
             margin: 3rem 0;
             text-align: center;
-            display: none;
         }
 
         .completion-banner h3 {
@@ -452,7 +451,7 @@
                     </div>
 
                     <!-- Module 2 -->
-                    <div class="module-card locked" data-module="curious-4-2">
+                    <div class="module-card" data-module="curious-4-2">
                         <div class="module-header">
                             <div class="module-title">
                                 <h3>Module 2: Protecting Your Bitcoin</h3>
@@ -482,12 +481,12 @@
                                 <span>✅ Security checklist</span>
                                 <span>📝 Practice scenarios</span>
                             </div>
-                            <a href="module-2.html" class="module-cta locked">Complete Module 1 First</a>
+                            <a href="module-2.html" class="module-cta">Start Module 2 →</a>
                         </div>
                     </div>
 
                     <!-- Module 3 -->
-                    <div class="module-card locked" data-module="curious-4-3">
+                    <div class="module-card" data-module="curious-4-3">
                         <div class="module-header">
                             <div class="module-title">
                                 <h3>Module 3: Recovery Planning</h3>
@@ -517,7 +516,7 @@
                                 <span>📋 Recovery plan template</span>
                                 <span>✅ Action items</span>
                             </div>
-                            <a href="module-3.html" class="module-cta locked">Complete Module 2 First</a>
+                            <a href="module-3.html" class="module-cta">Start Module 3 →</a>
                         </div>
                     </div>
                 </div>
@@ -525,14 +524,10 @@
 
             <!-- Completion Banner -->
             <div class="completion-banner" id="completion-banner">
-                <div class="badge-display"><span data-icon="lock"></span> </div>
-                <h3>🎉 Congratulations! The Curious Path Complete!</h3>
-                <p style="margin: 1rem 0;">
-                    You've earned the <strong>"Bitcoin Security"</strong> badge and completed The Curious Path!
-                </p>
+                <h3>Where this leads next</h3>
                 <p style="margin-bottom: 1.5rem;">
-                    You now have the knowledge to safely own, use, and protect Bitcoin. But your journey doesn't
-                    have to end here...
+                    You now have the knowledge to safely own, use, and protect Bitcoin. Your journey does not
+                    have to end here.
                 </p>
 
                 <div style="display: grid; gap: 1rem; max-width: 600px; margin: 2rem auto 0;">
@@ -555,72 +550,6 @@
         </div>
     </main>
 
-    <script>
-        // Initialize ProgressManager
-        const progressManager = new ProgressManager();
-        progressManager.init();
-
-        // Check progress and update UI
-        function updateProgress() {
-            // Check which stage 4 modules are completed
-            const module1Complete = progressManager.isModuleComplete('curious', 4, 1);
-            const module2Complete = progressManager.isModuleComplete('curious', 4, 2);
-            const module3Complete = progressManager.isModuleComplete('curious', 4, 3);
-
-            // Update module cards
-            if (module1Complete) {
-                const card = document.querySelector('[data-module="curious-4-1"]');
-                if (card) {
-                    card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = '#101010';
-                }
-            }
-            if (module2Complete) {
-                const card = document.querySelector('[data-module="curious-4-2"]');
-                if (card) {
-                    card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = '#101010';
-                }
-            }
-            if (module3Complete) {
-                const card = document.querySelector('[data-module="curious-4-3"]');
-                if (card) {
-                    card.style.borderColor = 'var(--accent-green)';
-                    card.style.background = '#101010';
-                }
-            }
-
-            // Unlock next module
-            if (module1Complete) {
-                const module2 = document.querySelector('[data-module="curious-4-2"]');
-                if (module2) {
-                    module2.classList.remove('locked');
-                    module2.querySelector('.module-cta').classList.remove('locked');
-                    module2.querySelector('.module-cta').textContent = 'Start Module 2 →';
-                }
-            }
-
-            if (module2Complete) {
-                const module3 = document.querySelector('[data-module="curious-4-3"]');
-                if (module3) {
-                    module3.classList.remove('locked');
-                    module3.querySelector('.module-cta').classList.remove('locked');
-                    module3.querySelector('.module-cta').textContent = 'Start Module 3 →';
-                }
-            }
-
-            // Check if stage and path completed
-            const stageComplete = completedModules.includes('curious-4-1') &&
-                                completedModules.includes('curious-4-2') &&
-                                completedModules.includes('curious-4-3');
-
-            if (stageComplete) {
-                document.getElementById('completion-banner').style.display = 'block';
-            }
-        }
-
-        updateProgress();
-    </script>
 
     <!-- Animated Icon Library -->
     <script src="/js/icon-library.js"></script>


### PR DESCRIPTION
Removes the progress bar, the updateProgress localStorage scripts, and the sequential 'Complete Module N first' locks across all four Curious stage indexes, unlocking the real modules. Reframes badge/unlock footer language to plain next-step text. Also fixes a navigation bug: stages 3 and 4 had their onward links (Stage 4, and the Builder/Sovereign/First-Principles paths) trapped in a display:none completion banner that a broken script never revealed — those are now always visible. Matches the already-merged Sovereign Path work and the unbounded-mode voice spec.

Scope: 4 files (paths/curious/stage-1..4/index.html), 30 insertions / 374 deletions. Paid-access gate (module-gate.js) untouched; module-gate test passes 6/6. No new html-validate errors.