### PR TITLE
Feat/bitcoin vs banking tradeoff sim

### DIFF
--- a/PLAN-bitcoin-vs-banking-upgrade.md
+++ b/PLAN-bitcoin-vs-banking-upgrade.md
@@ -1,0 +1,226 @@
+# IMPLEMENTATION PLAN: Bitcoin vs Banking tradeoff simulator (v1)
+
+Status: plan for sign-off. No code written. No tool modified. Nothing staged or committed.
+
+Companion to `SPEC-bitcoin-vs-banking-upgrade.md` (now revised to keep cash out of v1). This plan describes how to build the three-rail tradeoff simulator inside the existing page without touching routes, gates, or surrounding infrastructure. It is a plan only; implementation waits for approval.
+
+Scope reminder: V1 rails are Bank or card, Bitcoin self-custody, Bitcoin with a service provider. No cash. No altcoins. No advice. No real-time price or fee claims. No seed or key fields. No em dashes in shipped strings. EN/ES parity from the start.
+
+---
+
+## 1. Git branch recommendation
+
+- Branch: `feat/bitcoin-vs-banking-tradeoff-sim`, created from a fresh `origin/main`.
+- Because the repo runs many parallel worktrees on one checkout, create an isolated worktree off origin/main rather than editing the shared tree:
+  - `git fetch origin`
+  - `git worktree add .worktrees/btc-vs-banking -b feat/bitcoin-vs-banking-tradeoff-sim origin/main`
+- One writer per working tree. Commit early on the feature branch so the work survives any parallel session. Do not branch or checkout on the shared tree while another session is active.
+- No pushing, staging, or committing until the user asks.
+
+## 2. File(s) to change
+
+Primary, and ideally only:
+
+- `interactive-demos/bitcoin-vs-banking/index.html` — rebuild the content inside `<main id="main-content" class="container">` and replace the inline `<script>` that currently runs `calculateCosts()`. Everything else in the file stays byte-for-byte.
+
+Approach: keep the tool self-contained in `index.html` exactly as it is today (inline `<style>`, inline logic). This is the lowest-risk path because it adds no new file, no new route, and no new external `src`, so the mount contract and the QA "no external API / no hidden route" checks pass by construction. A sibling `simulator.js` is possible but rejected for v1 to avoid widening the surface; revisit only if the inline script grows hard to maintain.
+
+New file (tests, additive, not part of the page):
+
+- `tests/interactive-tools.bitcoin-vs-banking.test.mjs` — new `node:test` + jsdom test file (section 11).
+
+Explicitly not changed: `vercel.json`, any gate or membership script, analytics, email, tip, demo-nav, reflect-widget, navigation-context, icon-library, config, demo-lock, subdomain-access-control. No CSS token files. No new design tokens.
+
+## 3. Component structure
+
+All within `#main-content`. Sections top to bottom, replacing the current header / level-switcher / calculator / table / pros-cons / use-cases / conclusion stack:
+
+1. **Header** (reuse existing `.header`): new title and subtitle strings, and the core-question line. Keep the gradient style already in the file.
+2. **Level switcher** (reuse existing `.level-switcher` and its `?level=` script verbatim). Only the per-level visibility of inputs and the matrix changes (section 8 of spec).
+3. **Situation panel** (`#situation-form`): the ten input controls, grouped "The transfer" and "What you need" (section 4 below). Pure form, no submit button.
+4. **Result header** (`#fit-summary`): one calm sentence naming the fit per rail, plus the persistent `no_winner_note` line.
+5. **Rail scorecards** (`#rail-cards`): three cards, one per rail, each with band chip, "meets N of your M priorities" line, the per-priority met/partial/missed list, the explanation sentence, what-you-gain, what-you-give-up.
+6. **Risk flags** (`#risk-flags`): zero or more short warnings for the current situation.
+7. **Capability matrix** (`#capability-matrix`, advanced level only): the static three-rail matrix shown verbatim so a curious learner can audit the logic.
+8. **Illustrative note** (`#illustrative-note`): the one-line disclaimer, always visible if any monetary figure is shown.
+9. **Reflect widget**: existing block, only `data-title` copy updated (keep `data-topic="money"` unless a matching seed already exists).
+10. **Back link** and all footer blocks: unchanged.
+
+Internal logic modules (conceptual, all inside the inline script):
+
+- `STATE`: current input values.
+- `DIMENSIONS`: the eleven dimension keys.
+- `CAPABILITY`: the rail-by-dimension matrix (section 6).
+- `deriveActivePriorities(STATE)`: returns the active priorities with importance (section 5).
+- `scoreRail(rail, priorities)`: returns band, metCount, partialCount, per-priority results.
+- `buildExplanation(rail, result, lang)`, `buildFlags(STATE)`, `buildGainGiveUp(rail)`: string builders pulling from the dictionary.
+- `render()`: reads STATE, recomputes, writes the DOM. Called on every input event and once on load.
+
+## 4. Input controls
+
+All controls are native elements (number input, button-group toggles styled as `.level-btn` siblings, or selects) for accessibility and zero dependencies. Each has a `<label>`, a one-line helper, and an `aria-describedby` to its helper. Defaults give a coherent first-load result with zero clicks.
+
+Group A, "The transfer":
+- `amount`: number input, default 1000, min 1. Units described as illustrative local currency, not a live price.
+- `scope`: toggle, values `domestic` (default) and `cross_border`.
+- `urgency`: 3-state, `days` (default), `within_day`, `now`.
+- `horizon`: 3-state, `spend_soon` (default), `months`, `years`.
+
+Group B, "What you need":
+- `reversibility`: 3-state, `not` (default), `nice`, `essential`.
+- `selfcustody`: 3-state, `not` (default), `nice`, `essential`.
+- `privacy`: 3-state, `low` (default), `med`, `high`.
+- `trust`: 3-state, `trust` (default), `mixed`, `distrust`.
+- `polrisk`: 3-state, `low` (default), `med`, `high`.
+- `techcomfort`: 3-state, `new` (default), `some`, `high`.
+
+Level gating: beginner shows `amount`, `scope`, `urgency`, `selfcustody` and a simplified result; intermediate and advanced show all ten; advanced additionally renders the capability matrix. Hidden inputs keep their default value so scoring stays valid.
+
+Each control fires `render()` on `input` or `change`. No `onclick="..."` inline handlers that depend on globals; attach listeners in the script for testability.
+
+## 5. Input-to-dimension mapping
+
+`deriveActivePriorities(STATE)` produces a set of `{ dimension, importance }` where importance is `matters` or `essential`. Rules (additive; the strongest importance wins if a dimension is set twice):
+
+| Input and value | Activates dimension(s) | Importance |
+|-----------------|------------------------|------------|
+| reversibility = nice | reversibility | matters |
+| reversibility = essential | reversibility | essential |
+| selfcustody = nice | self_custody | matters |
+| selfcustody = essential | self_custody | essential |
+| selfcustody = nice or essential | censorship_resistance, settlement_finality | matters |
+| privacy = med | privacy | matters |
+| privacy = high | privacy | essential |
+| polrisk = med | censorship_resistance, self_custody | matters |
+| polrisk = high | censorship_resistance, self_custody | essential |
+| trust = mixed | self_custody, settlement_finality | matters |
+| trust = distrust | self_custody, settlement_finality | essential |
+| scope = cross_border | borderless, low_cost_cross_border | matters |
+| scope = cross_border AND amount >= 5000 (illustrative threshold) | low_cost_cross_border | essential |
+| urgency = within_day | short_term | matters |
+| urgency = now | short_term | essential |
+| horizon = spend_soon | familiar_ux, short_term | matters |
+| horizon = years | monetary_policy | essential |
+| amount >= 5000 (illustrative threshold) | settlement_finality | matters |
+| techcomfort = new | familiar_ux, short_term | matters |
+
+Technical-comfort handling (no silent special-case): `techcomfort = new` simply activates `familiar_ux` and `short_term` as priorities. The self-custody rail is only `partial` on those, so its fit drops naturally. Separately, `selfcustody = essential` combined with `techcomfort = new` emits the `flag_no_recovery` risk flag rather than hiding the tension.
+
+The illustrative amount threshold (5000) is a teaching device, documented in the UI helper as illustrative, never tied to a real fee or price.
+
+## 6. Capability matrix
+
+The fixed v1 matrix (`full` / `partial` / `none`), identical to the revised spec. This is the editorial core, shown verbatim at advanced level.
+
+| Dimension | Bank / card | BTC self-custody | BTC w/ provider |
+|-----------|-------------|------------------|-----------------|
+| reversibility | full | none | partial |
+| familiar_ux | full | partial | full |
+| short_term | full | partial | full |
+| settlement_finality | partial | full | partial |
+| self_custody | none | full | none |
+| censorship_resistance | none | full | partial |
+| borderless | partial | full | full |
+| monetary_policy | none | full | full |
+| privacy | none | partial | none |
+| recourse | full | none | partial |
+| low_cost_cross_border | partial | full | full |
+
+Honesty invariant (enforced by test): the bank rail is the sole `full` on `reversibility` and `recourse`, so situations that make those essential will rank the bank first.
+
+## 7. Output logic
+
+For each rail, `scoreRail` walks the active priorities:
+
+- capability `full` on the dimension: priority is **met** (counts toward N).
+- capability `partial`: priority is **partially met** (counts toward partial display; never fully satisfies an `essential`).
+- capability `none`: priority is **missed**.
+
+Band assignment per rail:
+- **Poor fit** if the rail has `none` on any `essential` priority.
+- **Workable** if it covers every essential at least partially but misses one or more `matters`, or meets an essential only partially.
+- **Strong fit** if it meets every essential at `full` and meets the majority of `matters` at `full`.
+
+Display per card:
+- Band chip (`band_strong` / `band_workable` / `band_poor`).
+- `meets_count` line: "Meets N of your M priorities", where M is the active-priority count and N is the fully-met count. If partials exist, append "plus K partially" using a parallel `meets_partial` key.
+- The per-priority list with a met / partial / missed marker and the dimension's plain-language label.
+- Explanation sentence from `buildExplanation`: names the strongest met priority and the most important missed priority, assembled from dictionary fragments so EN and ES stay parallel.
+- What you gain: the rail's `full` dimensions among active priorities. What you give up: the rail's `none` dimensions among active priorities.
+
+Ranking for the summary header: sort rails by band (Strong, Workable, Poor), then by N met, then by fewest essential misses. Ties are allowed and surfaced honestly ("both are a strong fit here"). The summary never uses the word "winner" and always shows `no_winner_note`.
+
+Numeric safety: `amount` parsed with a fallback to the default when empty, NaN, negative, or non-finite. No division by user input. Counts are integers. No percentage with decimals anywhere.
+
+## 8. EN/ES dictionary plan
+
+- A single in-file constant `STRINGS = { en: {...}, es: {...} }`, seeded from the spec section 8 table plus the dimension labels, band labels, explanation fragments, gain/give-up labels, flag strings, and the illustrative and no-winner notes.
+- Language selection: read an existing site language signal if one is already present on the page or in `localStorage`; otherwise default to `en` with a simple `?lang=es` override. Do not introduce a new global i18n framework and do not touch `js/i18n.js` (noted dead in memory).
+- Every visible string flows through a `t(key, vars)` helper that interpolates `{n}`, `{m}`, `{k}` placeholders. No hardcoded user-facing text in the DOM-building code.
+- Parity is a build-time invariant: the test diffs `Object.keys(STRINGS.en)` against `Object.keys(STRINGS.es)` and fails on any asymmetry.
+- Explanation sentences are assembled from fragment keys (subject, because-clause, give-up-clause), never by string concatenation that would force English word order onto Spanish. Each fragment has both languages.
+- No em dashes in any string in either language. En dashes allowed only inside numeric ranges.
+
+## 9. Accessibility notes (WCAG 2.1 AA, matching existing demo standards)
+
+- Every input has a programmatic `<label for>` and a helper referenced via `aria-describedby`.
+- Toggle button-groups use `role="radiogroup"` with `role="radio"` and `aria-checked`, keyboard operable with arrow keys and Enter or Space. Reuse the existing `.level-btn` focus-visible styling.
+- Live region: the result summary (`#fit-summary`) is an `aria-live="polite"` region so screen readers announce the new fit when an input changes, without stealing focus.
+- Color is never the only signal: met / partial / missed use a text label or symbol plus color, not color alone (avoids the current table's check-vs-cross color-only pattern).
+- Keep the existing skip-link, `:focus-visible` outlines, 44px minimum touch targets, and `prefers-reduced-motion` block already in the file.
+- Contrast: keep body text at the existing high-contrast values; do not use gradient-clipped transparent text for any result string (verify computed contrast, not screenshots).
+
+## 10. Mobile layout notes
+
+- Reuse the existing breakpoints (`max-width: 968px`, `max-width: 360px`) and the demo-shell styles already linked.
+- Input groups: two columns on desktop, single column under 768px. Button-group toggles wrap and stay 44px tall.
+- Rail scorecards: three across on wide screens, stacking to one column under 968px. No fixed pixel widths; use the existing grid `minmax` patterns.
+- Capability matrix (advanced): on narrow screens, allow horizontal scroll within its own container rather than forcing the page to overflow; never let the page scroll sideways (the `overflow-x: hidden` at 360px stays).
+- No canvas, no SVG diagram in v1, so there is no responsive-viewBox risk.
+- Verify at 360px, 768px, and desktop that nothing overflows and the live region still reads.
+
+## 11. Test file plan
+
+New file `tests/interactive-tools.bitcoin-vs-banking.test.mjs`, `node:test` + jsdom, matching the style of `tests/interactive-tools.measure-drift.test.mjs`. Where the scoring logic needs to be unit-tested in isolation, expose the pure functions (`deriveActivePriorities`, `scoreRail`) on a guarded global (for example `window.__bvbTest`) only when running under test, so production behavior is unchanged. Cases:
+
+1. **Tool mounts.** Page parses under jsdom, `#main-content` exists, the ten inputs and three rail cards render, no script throws on load.
+2. **Inputs update outputs.** Changing each input changes at least one rail result. Assert specifically: `reversibility = essential` raises the bank rail to at least the band of both Bitcoin rails; `polrisk = high` plus `selfcustody = essential` makes self-custody a Strong fit and triggers `flag_freeze` on the bank rail.
+3. **Bank can win (honesty invariant).** With `reversibility = essential`, `selfcustody = not`, `horizon = spend_soon`, `scope = domestic`, the bank rail ranks first. Assert it.
+4. **Bitcoin self-custody can win.** With `polrisk = high`, `selfcustody = essential`, `scope = cross_border`, `horizon = years`, `reversibility = not`, self-custody ranks first. Assert it.
+5. **EN/ES key parity.** `Object.keys(STRINGS.en)` equals `Object.keys(STRINGS.es)`; fail on any difference.
+6. **No em dashes.** Scan every string in both language dictionaries and the rendered DOM for U+2014; assert zero. En dashes in numeric ranges permitted.
+7. **No NaN / Infinity.** Across a grid of input combinations including `amount` of 0, empty, very large, and negative, every numeric output is finite, every band is one of the three allowed values, and no "NaN" or "Infinity" string reaches the DOM.
+8. **No external calls.** Source contains no `fetch`, `XMLHttpRequest`, `WebSocket`, or external `src` beyond the already-approved footer scripts.
+9. **Mount contract intact.** The preserved scripts and links (config, demo-lock, subdomain-access-control, icon-library, navigation-context, reflect-widget, membership-gate, analytics, email-capture, tip-cta, demo-nav, the six stylesheet links, the back link) are still present, with no gate, analytics, email, or payment script added or removed.
+
+Manual QA before any merge request: live preview console sweep with zero errors, keyboard-only pass (all inputs reachable, focus visible, live region announces), and mobile and desktop screenshots for the sign-off thread.
+
+## 12. Exact safety boundaries
+
+- **No financial advice.** Output describes tradeoffs only. No "you should", no allocation guidance, no "best investment" language.
+- **No universal winner.** The UI must be able to rank the bank rail first; test case 3 enforces it. The summary never says "winner".
+- **No real-time or real price and fee claims.** The tool makes zero network calls. Any monetary figure is round, obviously illustrative, and carries `illustrative_note`. The amount input drives only band logic, not a fee computation.
+- **No custody instructions that move funds.** The tool never tells the learner to send, withdraw, or transfer anything.
+- **No seed phrase or private key fields.** No input accepts a key, seed, address, or credential. There is no place to paste one.
+- **No altcoins, no "crypto" framing.** The subject is Bitcoin and banking rails only.
+- **No TBA insertion.** This page is not about collaborative security; do not add a TBA mention or upsell.
+- **Honest tone in both languages.** Each rail has at least one genuinely positive line; the bank is treated as a reasonable choice for its strengths; Bitcoin self-custody names its real costs (no recovery, no chargeback, learning curve) plainly.
+
+## 13. Acceptance checklist
+
+- [ ] Route unchanged: `/interactive-demos/bitcoin-vs-banking/` still serves the same `index.html`.
+- [ ] Mount contract intact: `#main-content`, `?level=` switcher, six stylesheet links, all footer scripts, reflect widget, email and tip blocks, back link, all present and unchanged.
+- [ ] Exactly three rails (bank/card, Bitcoin self-custody, Bitcoin with provider); no cash; future-extension note only.
+- [ ] Bank rail can rank first in at least one situation (test passes).
+- [ ] Bitcoin self-custody ranks first where it is genuinely strongest (test passes).
+- [ ] No external network calls; no new route, gate, analytics, email, or payment wiring.
+- [ ] EN and ES dictionaries reach full key parity (test passes).
+- [ ] Zero em dashes in shipped strings, comments, and this plan's outputs (test passes).
+- [ ] No NaN or Infinity reaches the DOM under edge-case inputs (test passes).
+- [ ] No seed, key, address, or credential field anywhere.
+- [ ] No financial advice; no "winner"; illustrative figures labeled.
+- [ ] Accessibility: labels, live region, keyboard-operable toggles, non-color-only status, 44px targets, focus-visible.
+- [ ] Mobile: reflows to one column under 968px, no horizontal overflow at 360px.
+- [ ] Reflect widget `data-title` updated; `data-topic` left as `money` unless a matching seed exists.
+
+Next step after sign-off: build on the `feat/bitcoin-vs-banking-tradeoff-sim` worktree, commit early to the feature branch, and open for review. Do not start coding until this plan is approved.

--- a/SPEC-bitcoin-vs-banking-upgrade.md
+++ b/SPEC-bitcoin-vs-banking-upgrade.md
@@ -1,0 +1,227 @@
+# SPEC: Bitcoin vs Banking upgrade
+
+Status: draft for sign-off. No code written. No files modified. Nothing staged or committed.
+
+Route (unchanged): `/interactive-demos/bitcoin-vs-banking/`
+Source (unchanged location): `interactive-demos/bitcoin-vs-banking/index.html`
+Audit reference: `TOOLS-INVENTORY-AUDIT.md` (item 24, Needs repair, P1) and `TOOLS-UPGRADE-QUEUE.md` (rank 1).
+
+Goal: turn the current persuasion table into a first-principles tradeoff simulator. The learner chooses a situation, sets what they need, and sees which rail fits and what they give up to get it. The tool never declares a universal winner.
+
+## Mount contract to preserve (do not change)
+
+The rebuild is content-internal only. These stay exactly as they are:
+
+- Route and directory; the page remains a single `index.html` at the same path.
+- Main container `<main id="main-content" class="container">` and the `#main-content` skip-link target.
+- Level switcher driven by the `?level=` URL param (`beginner` / `intermediate` / `advanced`) and the `.level-btn` / `#current-level-name` / `#level-description` elements.
+- Stylesheet links: `/css/tokens.css`, `/css/brand.css`, `/css/widgets.css`, `/css/icons.css`, `/css/interactive-demos.css`, `/css/demo-shell.css`.
+- Reflect widget block (`.reflect-widget`, `/js/reflect-widget.js`). Only its `data-title` copy changes; see section 8. Topic key may move from `money` to a more specific seed only if a matching `SEED_QUESTIONS` entry already exists; otherwise leave `data-topic="money"`.
+- All footer infrastructure untouched: `/js/config.js`, `/js/demo-lock-subdomain.js`, `/js/subdomain-access-control.js`, `/js/icon-library.js`, `/js/navigation-context.js`, `/js/membership-gate.js`, `/js/analytics.js`, `/js/email-capture.js`, `/js/tip-cta.js`, `/js/demo-nav.js`, and the email-capture and tip-CTA placeholder divs.
+- Back link to `../index.html`.
+
+Out of scope by rule: no route, gate, membership, analytics, email, payment, or TBA changes.
+
+---
+
+## 1. Current problem
+
+The existing page is a verdict, not a tool. Three things make it too persuasive and not interactive enough:
+
+1. **The feature table pre-loads the conclusion.** Twelve rows of check / cross marks score Bitcoin ahead in roughly nine of twelve. Bank-only strengths (chargebacks, FDIC insurance, support) are shown as crosses against Bitcoin rather than as legitimate reasons a learner might choose a bank. The learner reads a scoreboard someone else filled in.
+2. **The only interactive piece is a remittance calculator rigged to one answer.** It hardcodes a flat `$2.50` Bitcoin fee against a `3% + $15 + 3% FX` bank cost and always prints "Savings with Bitcoin." There is no situation in which the bank comes out ahead, so the interaction teaches nothing the table did not already assert.
+3. **No situation, no tradeoff, no reflection.** The learner never states what they are trying to do, so they never discover that the right rail depends on the goal. This conflicts directly with the locked voice spec (inform, do not convince) on a page beginners often meet early.
+
+The result reads as advocacy. It also leans on a fixed fee figure presented as if current, which is the kind of unlabeled claim the brand rules forbid.
+
+## 2. Learning goal
+
+After using the upgraded tool, a beginner should be able to say, in their own words:
+
+- Different money rails are good at different things. None is best at everything.
+- Bitcoin is strongest for final settlement, holding your own keys, resisting censorship, predictable issuance, borderless transfer, and long-horizon sovereignty.
+- Banks and cards are strongest for reversible payments, familiar everyday use, short-term convenience, credit, payroll, and a regulated dispute process.
+- Choosing a rail means accepting a tradeoff. The honest question is not "which is better" but "which fits this situation, and what am I giving up."
+
+## 3. Core learner question
+
+> "Which rail fits this situation best, and what tradeoff am I accepting?"
+
+This sentence is shown near the top of the tool and framed as the thing the tool helps answer. It replaces the current "The Best Approach?" conclusion block.
+
+## 4. Interactive model
+
+The learner describes one situation at a time using ten inputs. Each input is a plain control with a short label and a one-line helper. Inputs are grouped so the form does not feel long.
+
+Group A, the transfer:
+1. **Amount** (number, illustrative units, default 1000). Helper: "Roughly how much, in your local currency."
+2. **Domestic vs cross-border** (toggle: Same country / Across borders).
+3. **Urgency** (3-step: Can wait days / Within a day / Right now).
+4. **Time horizon** (3-step: Spend soon / Hold months / Hold years). Frames whether this is a payment or savings.
+
+Group B, what you need:
+5. **Need for reversibility** (3-step: Not important / Nice to have / Essential). "Can a mistaken or disputed payment be undone."
+6. **Need for self-custody** (3-step: Not important / Nice to have / Essential). "Do you want to hold the keys yourself, with no one able to freeze it."
+7. **Privacy sensitivity** (3-step: Low / Medium / High). "How much you want to limit what third parties can see."
+8. **Counterparty trust** (3-step: I trust the institutions involved / Mixed / I do not trust them). "How much you trust the bank, exchange, or custodian in this situation."
+9. **Political or banking risk** (3-step: Low / Medium / High). "Risk of account freezes, capital controls, or an unstable local banking system."
+10. **Technical comfort** (3-step: New to this / Some experience / Very comfortable). "How comfortable you are managing keys and backups."
+
+All inputs have sensible defaults so the tool shows a coherent result on first load with zero clicks. Changing any input recomputes outputs live (no submit button). Inputs map cleanly to the EN/ES key table in section 8.
+
+Level switcher behavior:
+- Beginner: shows inputs 1, 2, 3, 6 and a simplified result. Hides privacy, counterparty trust, political risk, time-horizon nuance.
+- Intermediate: all ten inputs, full scorecards.
+- Advanced: all ten inputs plus the per-dimension capability matrix (section 7) shown openly so the learner can inspect the reasoning.
+
+## 5. Outputs
+
+Everything below updates live on input change.
+
+1. **Suggested fit by situation, not a universal winner.** A short ranked list of the three rails for this situation, each labeled with a qualitative band: **Strong fit**, **Workable**, or **Poor fit**. Ties are allowed and expected. The header reads, for example, "For this situation: Bitcoin self-custody is a strong fit; a bank or card is workable." Never "Bitcoin wins."
+2. **Tradeoff scorecards**, one card per rail. Each card lists the learner's stated priorities and marks, per priority, whether the rail satisfies it (met / partial / not met), using the transparent matrix. The card shows "meets N of your M priorities" with the list visible. No hidden percentage.
+3. **Explanation sentence**, one calm sentence per rail explaining the fit in plain language, generated from which priorities were met or missed. Example: "A bank fits because you need reversibility and fast familiar support, but it cannot give you self-custody or protect against account freezes."
+4. **Risk flags**, zero or more short warnings triggered by the situation. Examples: high political risk plus bank rail flags "Accounts can be frozen under capital controls." Self-custody plus low technical comfort flags "Holding your own keys means no one can recover them for you." Essential reversibility plus any Bitcoin rail flags "On-chain payments cannot be charged back."
+5. **What you gain** and **What you give up**, two short lists for the top-fit rail, phrased as accepted tradeoffs rather than wins and losses.
+
+No output ever shows a fabricated live price or live fee. Any monetary illustration is labeled "illustrative" (section 9).
+
+## 6. Rails compared
+
+V1 compares exactly three rails, no more:
+
+1. **Bank or card rail.** Checking account, debit, credit card, wire, ACH, card networks.
+2. **Bitcoin, self-custody.** The learner holds the keys. On-chain or Lightning from a wallet they control.
+3. **Bitcoin, with a service provider.** A custodial exchange or payment app holds keys on the learner's behalf. This is the honest middle: easier and with some recourse, but custodial and more exposed to freezes and KYC.
+
+These three match the tool title and the learning goal, and keep the first rebuild focused. No altcoins. No "crypto" framing anywhere. The word is Bitcoin.
+
+**Future extension (not in v1):** a fourth rail, **cash**, could be added later to teach the privacy and in-person settlement tradeoff (strong for local privacy and in-person finality, useless across borders, exposed to physical loss and inflation). It is intentionally out of v1 so the first implementation stays scoped to the three rails above. The capability matrix and scoring in this spec are written for three rails; adding cash later means adding one matrix column and one rail card, with no change to the input model.
+
+## 7. Scoring logic
+
+Simple, additive, and fully inspectable. No machine-learning, no opaque weights, no false precision.
+
+**Step 1, a fixed capability matrix.** Each rail has a known capability on each dimension: `full`, `partial`, or `none`. This is editorial and honest, and at advanced level it is shown to the learner verbatim. V1 matrix (three rails):
+
+| Dimension | Bank / card | BTC self-custody | BTC w/ provider |
+|-----------|-------------|------------------|-----------------|
+| Reversibility / chargebacks | full | none | partial |
+| Familiar everyday UX | full | partial | full |
+| Short-term convenience | full | partial | full |
+| Settlement finality | partial | full | partial |
+| Self-custody (you hold keys) | none | full | none |
+| Censorship resistance | none | full | partial |
+| Borderless transfer | partial | full | full |
+| Predictable monetary policy | none | full | full |
+| Privacy from third parties | none | partial | none |
+| Regulated recourse / support | full | none | partial |
+| Low cost across borders | partial | full | full |
+
+(A future cash column would slot in here without changing any other rule.)
+
+**Step 2, learner priorities select the dimensions that count.** The ten inputs turn specific dimensions on or off and set their importance to "matters" or "essential":
+- Need for reversibility -> Reversibility dimension.
+- Need for self-custody -> Self-custody, and raises Censorship resistance and Settlement finality.
+- Privacy sensitivity -> Privacy dimension.
+- Political or banking risk -> Censorship resistance and Self-custody.
+- Counterparty trust low -> raises Self-custody and Settlement finality, lowers value of provider and bank recourse.
+- Cross-border -> Borderless transfer and Low cost across borders.
+- Urgency high -> weights Short-term convenience and Settlement-speed reading.
+- Time horizon years -> Predictable monetary policy.
+- Time horizon spend soon -> Familiar UX, Short-term convenience.
+- Technical comfort low -> penalizes rails whose self-custody dimension is `full` unless the learner marked self-custody essential (then it becomes a risk flag, not a silent penalty).
+
+**Step 3, fit per rail.** For each rail, count how many of the learner's active priorities it meets. `full` meets the priority, `partial` half-meets (counts toward "partial" display, not a full point), `none` misses. The displayed number is "meets N of your M priorities," with the per-priority list shown. Bands derive from the ratio with named thresholds, stated in the UI:
+- Strong fit: meets all or all-but-one essential priority and the majority of the rest.
+- Workable: meets the essentials but misses several nice-to-haves, or meets most with one essential only partially.
+- Poor fit: misses one or more essential priorities.
+
+**Transparency rules:**
+- No decimal scores. No "92% vs 48%." If a numeric appears it is an integer count of the learner's own priorities ("3 of 5"), with the list visible.
+- The bands and thresholds are written on the page (intermediate and advanced).
+- The full matrix is viewable at advanced level so a curious learner can audit every judgment.
+- Editorial honesty check: the matrix must keep at least one dimension where the bank rail is the sole `full` (Reversibility, Regulated recourse) so the bank genuinely wins some situations.
+
+## 8. Copy rules
+
+Calm, honest, specific. No hype. No em dashes (use comma, colon, parentheses, or period). No "banks are evil." No "Bitcoin solves everything." Bitcoin-positive means showing Bitcoin's real strengths plainly, not stacking the deck.
+
+EN and ES must reach parity: every visible string has both. Below is the seed string set with paired keys. Implementation should keep these in a single in-file dictionary keyed by language, mirroring how other bilingual demos store copy, so a parity test can diff the key sets.
+
+| key | EN | ES |
+|-----|----|----|
+| `title` | Bitcoin and banking: which rail fits? | Bitcoin y banca: ¿qué vía encaja? |
+| `subtitle` | Pick a situation. See which rail fits and what you give up to get it. | Elige una situación. Mira qué vía encaja y qué cedes a cambio. |
+| `core_question` | Which rail fits this situation best, and what tradeoff am I accepting? | ¿Qué vía encaja mejor en esta situación y qué compensación estoy aceptando? |
+| `input_amount` | Amount | Monto |
+| `input_scope` | Same country or across borders? | ¿Mismo país o entre países? |
+| `input_urgency` | How soon does it need to arrive? | ¿Qué tan pronto debe llegar? |
+| `input_horizon` | Spend soon or hold for the long term? | ¿Gastar pronto o guardar a largo plazo? |
+| `input_reversibility` | How much do you need to undo a payment? | ¿Cuánto necesitas poder revertir un pago? |
+| `input_selfcustody` | How much do you want to hold the keys yourself? | ¿Cuánto quieres custodiar tú mismo las llaves? |
+| `input_privacy` | How private does this need to be? | ¿Qué tan privado necesita ser esto? |
+| `input_trust` | How much do you trust the institutions involved? | ¿Cuánto confías en las instituciones involucradas? |
+| `input_polrisk` | Risk of account freezes or capital controls? | ¿Riesgo de congelamiento de cuentas o controles de capital? |
+| `input_techcomfort` | How comfortable are you managing keys and backups? | ¿Qué tan cómodo te sientes gestionando llaves y respaldos? |
+| `rail_bank` | Bank or card | Banco o tarjeta |
+| `rail_btc_self` | Bitcoin, self-custody | Bitcoin, autocustodia |
+| `rail_btc_provider` | Bitcoin, with a service provider | Bitcoin, con un proveedor de servicio |
+| `rail_cash` | Cash | Efectivo |
+| `band_strong` | Strong fit | Encaja bien |
+| `band_workable` | Workable | Funcional |
+| `band_poor` | Poor fit | Encaja mal |
+| `gain_label` | What you gain | Lo que ganas |
+| `give_up_label` | What you give up | Lo que cedes |
+| `meets_count` | Meets {n} of your {m} priorities | Cumple {n} de tus {m} prioridades |
+| `flag_freeze` | Accounts on this rail can be frozen under capital controls. | Las cuentas en esta vía pueden congelarse bajo controles de capital. |
+| `flag_no_recovery` | Holding your own keys means no one can recover them for you. | Custodiar tus llaves significa que nadie puede recuperarlas por ti. |
+| `flag_no_chargeback` | On-chain payments cannot be charged back if something goes wrong. | Los pagos en cadena no se pueden revertir si algo sale mal. |
+| `illustrative_note` | Figures are illustrative, for learning only, not current prices or fees. | Las cifras son ilustrativas, solo para aprender, no son precios ni comisiones actuales. |
+| `no_winner_note` | There is no single best rail. The right choice depends on your situation. | No hay una sola vía mejor. La elección correcta depende de tu situación. |
+| `reflect_title` | Reflect: when would you choose a different rail? | Reflexiona: ¿cuándo elegirías otra vía? |
+
+Sample generated explanation sentences (templates, both languages):
+- EN bank, strong: "A bank or card fits here because you need reversibility and familiar everyday use. You give up self-custody and protection from account freezes."
+- ES bank, strong: "Un banco o tarjeta encaja aquí porque necesitas reversibilidad y uso cotidiano familiar. Cedes la autocustodia y la protección frente a congelamientos de cuenta."
+- EN self-custody, strong: "Bitcoin self-custody fits here because you want to hold the keys and resist censorship across borders. You give up chargebacks and a support line."
+- ES self-custody, strong: "La autocustodia de Bitcoin encaja aquí porque quieres tener las llaves y resistir la censura entre países. Cedes las devoluciones de cargo y una línea de soporte."
+
+Tone guardrails baked into copy review:
+- Every rail must have at least one genuinely positive sentence somewhere in the experience.
+- The bank rail is described as a reasonable choice for its strengths, never mocked.
+- Bitcoin self-custody names its real costs (no recovery, no chargeback, learning curve) without softening.
+
+## 9. Safety boundaries
+
+- **No financial advice.** The tool describes tradeoffs, never tells the learner what to do with money. No "you should," no allocation suggestions.
+- **No universal winner.** The UI must be capable of ranking the bank rail first, and the test plan asserts at least one input combination where it does.
+- **No real fee or price claims.** Any monetary illustration carries the `illustrative_note` string and uses round, clearly fake example figures. No live price or fee fetch (the tool makes no network calls; see section 10).
+- **No custody instructions that move funds.** The tool never tells the user to send, withdraw, or transfer anything. It is a thinking aid, not a wallet.
+- **No seed phrase or private key fields.** No input anywhere accepts a key, seed, address, or credential.
+- **No TBA promotion.** Collaborative security is not the subject here. Do not insert TBA. The existing boundary-note convention elsewhere does not apply to this page.
+- **Bitcoin-positive but honest.** Strengths shown where real; weaknesses named where real.
+
+## 10. Test plan
+
+Add a Node `node:test` + `jsdom` test file under `tests/` (for example `tests/interactive-tools.bitcoin-vs-banking.test.mjs`), matching the existing test style. No live server required for the logic tests. Cases:
+
+1. **Tool mounts.** The page parses, `#main-content` exists, the inputs and three rail cards render, and no script throws during load under jsdom.
+2. **Inputs update outputs.** Changing each input changes the computed fit for at least one rail. Specifically assert: setting reversibility to Essential makes the bank rail rank at least as high as both Bitcoin rails; setting political risk to High with self-custody Essential makes Bitcoin self-custody a Strong fit and triggers the freeze flag on the bank rail.
+3. **No universal winner.** Assert at least one input set where the bank rail is the top fit, and at least one where Bitcoin self-custody is the top fit. This guards against regressing into a persuasion table.
+4. **EN/ES key parity.** The EN and ES dictionaries have identical key sets (no key present in one and missing in the other). Fail on any asymmetry.
+5. **No em dashes.** Scan the rendered strings and the source file for U+2014; assert zero. (En dashes in numeric ranges allowed.)
+6. **No NaN / Infinity.** For a grid of input combinations (including amount 0, amount very large, empty amount), every numeric output is finite and every band is one of the three allowed values. No "NaN" or "Infinity" string reaches the DOM.
+7. **Mobile layout.** Manual or jsdom-assisted check that at <=360px and <=968px the input groups and rail cards reflow to a single column and nothing overflows horizontally. Reuse the existing media-query breakpoints.
+8. **No external API.** Assert the source contains no `fetch`, `XMLHttpRequest`, `WebSocket`, or external `src` beyond the already-approved shared scripts. The tool computes entirely client-side.
+9. **No hidden route or gate changes.** Assert the preserved mount-contract scripts and links (section "Mount contract") are still present and unchanged in count and path, and that no gate, analytics, email, or payment script was added or removed.
+
+Lightweight manual QA before merge: live preview console sweep (zero errors), keyboard-only pass (all inputs reachable, focus visible), and a screenshot at mobile and desktop widths for the sign-off thread.
+
+## 11. Upgrade decision
+
+**Recommendation: full interactive rebuild** of the page body, within the preserved mount contract.
+
+Rationale: the core defect is structural, not cosmetic. The persuasion comes from the feature table and the rigged calculator, which are the page's main content. A small cleanup (softening copy, relabeling the fee as illustrative) would leave the verdict-shaped experience intact and still fail the voice spec. A medium rebuild that kept the table would keep fighting the table. The honest, on-brand version is a different artifact: a situation-driven tradeoff simulator. The rebuild is bounded and low-risk because it touches only the content inside `#main-content`, adds no network calls, and changes no routes, gates, analytics, email, payment, or TBA wiring. Estimated size: medium effort in calendar terms (new state model plus transparent scorecard rendering plus EN/ES dictionary and tests), but a full conceptual rebuild of the learner experience.
+
+Next step after sign-off: write the implementation plan (component structure, the input-to-dimension mapping table as code, the EN/ES dictionary, and the test file), then build behind the existing route. Do not start coding until this spec is approved.

--- a/TOOLS-BRAINSTORMING-PASS.md
+++ b/TOOLS-BRAINSTORMING-PASS.md
@@ -1,0 +1,387 @@
+# TOOLS-BRAINSTORMING-PASS
+
+Brainstorming pass on the learner experience for every P1 and P2 tool. Input: `TOOLS-INVENTORY-AUDIT.md`, `TOOLS-UPGRADE-QUEUE.md`, `TOOLS-QA-REPORT.md`. No code written, no files modified, nothing staged.
+
+Lens applied to each tool: Understandability (clear in 10 seconds), Usability (desktop and mobile), Relatability (connects to a felt situation), Learning outcome (clearer mental model, not click-through), First-principles (reason from scarcity, tradeoffs, incentives, trust, custody, verification, time, risk, rules).
+
+Voice rules honored throughout: Bitcoin-positive but honest, Bitcoin does not win every situation, no altcoin framing, no investment advice, no real-time data unless justified, no field that could lead a learner to paste a seed phrase, no em dashes, EN/ES parity considered from the start, calm and concrete.
+
+Effort key: cleanup = copy and small UI, days. medium = new state model or consequence rendering, ~1 to 2 weeks. full rebuild = new experience or data integration.
+
+---
+
+# P1 tools
+
+## 1. Bitcoin vs Banking (P1)
+URL: /interactive-demos/bitcoin-vs-banking/ . A full design spec already exists at `SPEC-bitcoin-vs-banking-upgrade.md`; this block is a summary so the set is complete.
+
+- Current learner confusion: The check-vs-cross table looks like a settled scoreboard, so a beginner does not learn to reason, they just absorb a verdict.
+- Best first-principles question: "Which rail fits this situation best, and what tradeoff am I accepting?"
+- Learner should control: amount, domestic vs cross-border, urgency, reversibility need, self-custody need, privacy, counterparty trust, political risk, time horizon, technical comfort.
+- Should change live: a fit ranking (Strong fit, Workable, Poor fit) per rail, tradeoff scorecards, an honest explanation sentence, risk flags, what you gain, what you give up.
+- Misconception to correct: "Bitcoin is strictly better than a bank." Replace with "different rails have different failure modes; the right one depends on what you are protecting against."
+- Relatable scenario: sending money to family across a border quickly, versus buying coffee with a card you can dispute.
+- Better title: "Bitcoin and banking: which rail fits?"
+- Better opening sentence: "Pick a situation. See which rail fits and what you give up to get it."
+- Cleanup idea: relabel the fixed fee as illustrative and soften the table copy.
+- Medium upgrade idea: replace the rigged calculator with a situation form that can rank a bank first.
+- Full rebuild idea: the situation-driven tradeoff simulator in the spec.
+- Recommendation: full rebuild (per spec).
+
+## 2. Sovereign Vault (P1)
+URL: /interactive-demos/sovereign-vault/
+
+- Current learner confusion: It looks like it might be a wallet, and a free-text field can tempt a learner to type a real seed location or phrase. The "zero-knowledge encryption" label also overstates what the tool does.
+- Best first-principles question: "If you disappeared today, could the people you trust actually recover your bitcoin?"
+- Learner should control: their documented setup (wallets, backups, heirs), then a set of failure events thrown at it.
+- Should change live: a recovery outcome and a resilience reading that is explained factor by factor, not asserted.
+- Misconception to correct: "Writing my setup down is the plan" and "one backup is enough."
+- Relatable scenario: the only paper backup is in a drawer at home, and there is a house fire while you are traveling.
+- Better title: "Could your family recover your bitcoin?"
+- Better opening sentence: "Map your setup, then watch what happens when one piece fails."
+- Cleanup idea (do first, safety and accuracy): reword "zero-knowledge" to "client-side encrypted," add input validation and a clear warning so no real seed is ever entered.
+- Medium upgrade idea: a recovery stress test (fire, lost device, sudden death) that shows single points of failure.
+- Full rebuild idea: a custody scenario lab where the resilience score is the visible sum of survived failures.
+- Recommendation: medium upgrade, but ship the safety and wording cleanup immediately regardless of the larger rebuild timeline.
+
+## 3. Difficulty Calculator (P1)
+URL: /interactive-demos/difficulty-calculator/
+
+- Current learner confusion: It shows Jan-2025 numbers as if current and a "live data..." placeholder that never resolves, so a beginner cannot tell what is real, and the payout math hides the actual lesson.
+- Best first-principles question: "If more miners join and blocks would come faster, how does Bitcoin keep them near 10 minutes?"
+- Learner should control: add or remove network hashrate, then advance time.
+- Should change live: the difficulty response and how long the network takes to settle back toward 10-minute blocks.
+- Misconception to correct: "Someone sets the difficulty" and "blocks are always 10 minutes."
+- Relatable scenario: after a price rise many new miners switch on; blocks speed up for a while, then the network corrects.
+- Better title: "Why Bitcoin blocks stay near 10 minutes."
+- Better opening sentence: "Add miners and watch the network defend its rhythm."
+- Cleanup idea: fetch current difficulty with a clearly labeled fallback, and remove the misleading placeholder string.
+- Medium upgrade idea: a feedback-loop visual where the learner moves hashrate and sees the 2016-block adjustment respond.
+- Full rebuild idea: not needed; the medium upgrade carries the idea.
+- Recommendation: medium upgrade (with the stale-data cleanup folded in).
+
+## 4. UTXO Visualizer (P1)
+URL: /interactive-demos/utxo-visualizer-enhanced/
+
+- Current learner confusion: A beginner does not know what a UTXO is or why a wallet is not just one balance, and the privacy score moves without explaining why.
+- Best first-principles question: "Your wallet is not one balance, it is a pile of separate coins. Which ones do you spend, and what does that reveal?"
+- Learner should control: which coins to combine to make a payment.
+- Should change live: fee, change created, and a privacy reading that shows the actual reason (combining coins from different sources links them).
+- Misconception to correct: "A wallet is a single balance like a bank account."
+- Relatable scenario: paying rent from a wallet holding many small gift amounts, deciding whether to combine them.
+- Better title: keep "UTXO Visualizer," add a plain subtitle: "How your wallet really holds coins."
+- Better opening sentence: "Your balance is really many separate coins. Pick which to spend."
+- Cleanup idea: surface the privacy calculation inline instead of an unexplained bar.
+- Medium upgrade idea: add short "why" annotations to each consequence (fee, change, privacy) as the learner selects coins.
+- Full rebuild idea: a consequence-narrated scenario set where each choice explains its tradeoff aloud.
+- Recommendation: medium upgrade (surface the reasoning; the interaction is already strong).
+
+## 5. Address Format Explorer (P1)
+URL: /interactive-demos/address-format-explorer/
+
+- Current learner confusion: It is unclear why there are four address types, and whether the generated addresses are real (they are intentionally fake, but weakly labeled, which is a safety gap).
+- Best first-principles question: "Same keys, different envelopes. Why does the format change the fee and what can receive it?"
+- Learner should control: pick a format, see its fee and compatibility tradeoff.
+- Should change live: fee comparison and a plain "which to use and why" readout.
+- Misconception to correct: "There is one real Bitcoin address type" or "the format is random."
+- Relatable scenario: your wallet shows a bc1 address, but a sender's older service only lets them paste an address starting with 1.
+- Better title: "Bitcoin address formats: same keys, different envelopes."
+- Better opening sentence: "These are demo addresses for learning. See why the format changes the fee."
+- Cleanup idea (safety): a prominent "demo addresses, do not fund" banner near the generator.
+- Medium upgrade idea: a short "which format should I use" decision with reasons.
+- Full rebuild idea: not needed.
+- Recommendation: cleanup (safety label first), then the small decision add.
+
+## 6. Security Risk Simulator (P1)
+URL: /interactive-demos/security-risk-simulator.html
+
+- Current learner confusion: Little; it is already strong. The main gap is no Spanish for a high-value tool.
+- Best first-principles question: "Every security choice trades convenience for control. What are you actually optimizing for, and against which threat?"
+- Learner should control: storage method, backup strategy, and operational habits, as now.
+- Should change live: the risk profile, as now, with outcomes that distinguish a spending stash from life savings.
+- Misconception to correct: "More security is always better" and "one setup fits everyone."
+- Relatable scenario: protecting a small everyday amount versus protecting a decade of savings calls for different setups.
+- Better title: keep it.
+- Better opening sentence: "Make security choices and see the risk you are accepting."
+- Cleanup idea: minor copy polish only.
+- Medium upgrade idea: Spanish localization, plus a few more granular outcome combinations (for example multisig paired with a weak backup).
+- Full rebuild idea: not warranted.
+- Recommendation: medium upgrade (primarily EN/ES parity).
+
+## 7. Multisig Security Demo (P1)
+URL: /multisig-security-demo.html
+
+- Current learner confusion: Multisig is abstract, and the page carries 14 em dashes. The collaborative-security framing is already correct and should be preserved.
+- Best first-principles question: "If a single key can be stolen, why trust a single key? What changes when no one key can move funds alone?"
+- Learner should control: experience level and which attack to launch.
+- Should change live: whether the attack drains funds, with the single-key and 2-of-3 outcomes side by side.
+- Misconception to correct: "Multisig is only for experts" and "sharing key duties means giving up custody." (You still self-custody; no single party can move funds alone.)
+- Relatable scenario: a laptop catches malware; a single-key wallet is emptied, a 2-of-3 setup is not.
+- Better title: keep it.
+- Better opening sentence: "Launch a real attack and see which setup survives it."
+- Cleanup idea: remove the em dashes; keep the framing.
+- Medium upgrade idea: optional, a short "build your own quorum" step.
+- Full rebuild idea: not needed.
+- Recommendation: cleanup.
+
+## 8. Security Training Lab, Dojo (P1)
+URL: /interactive-demos/security-dojo-enhanced/
+
+- Current learner confusion: The security score appears without explaining how it was reached, so the learner cannot act on it.
+- Best first-principles question: "Where is your setup actually weakest right now?"
+- Learner should control: the assessment answers (wallet type, backup method, recovery testing, phishing response).
+- Should change live: the score, broken down into the choices that moved it.
+- Misconception to correct: "Owning a hardware wallet means I am safe," when an untested recovery is the real risk.
+- Relatable scenario: someone confident in their hardware wallet who has never checked that the backup actually restores.
+- Better title: keep it.
+- Better opening sentence: "Answer a few questions and find your weakest link."
+- Cleanup idea: show the score breakdown in the results.
+- Medium upgrade idea: route each weak answer to the matching training station automatically.
+- Full rebuild idea: not needed.
+- Recommendation: cleanup (score transparency), then the small routing add.
+
+## 9. Emergency Kit (P1)
+URL: /emergency-kit.html
+
+- Current learner confusion: Thirteen scenarios at once can overwhelm a panicking beginner, and the page carries 10 user-facing em dashes.
+- Best first-principles question: "What exactly went wrong, and is the money lost or only stuck?"
+- Learner should control: which emergency they are facing, answered in plain words.
+- Should change live: a calm, targeted set of steps for that one situation, instead of the full menu.
+- Misconception to correct: "A stuck transaction means my money is gone."
+- Relatable scenario: a payment sent with too low a fee that has been pending for hours while the learner refreshes anxiously.
+- Better title: keep "Bitcoin Emergency Kit."
+- Better opening sentence: "Tell us what happened. We will walk you through it calmly."
+- Cleanup idea: remove the em dashes and add a one-line reassurance at the top of each branch.
+- Medium upgrade idea: a two-question triage that routes to the right branch (lost access vs stuck payment vs suspected scam).
+- Full rebuild idea: not needed; this is already a strong reference.
+- Recommendation: cleanup (it is Strong; the P1 is the em dashes and a light triage).
+
+---
+
+# P2 tools
+
+## 10. On-Ramp Chooser (P2)
+URL: /interactive-demos/onramp-chooser/
+
+- Current learner confusion: Little; it is already strong. Fee and method data are hardcoded (Dec 2025) and there is no Spanish for a LATAM-critical tool.
+- Best first-principles question: "Every way to buy trades off privacy, speed, cost, and who holds the coins. Which of those matters most to you?"
+- Learner should control: country, amount, KYC tolerance, speed, payment method.
+- Should change live: a ranked shortlist with the tradeoff each option carries.
+- Misconception to correct: "All the ways to buy are basically the same."
+- Relatable scenario: a first-time buyer in Colombia weighing a large exchange against a peer-to-peer option.
+- Better title: keep it.
+- Better opening sentence: "Answer a few questions and see which way to buy fits you."
+- Cleanup idea: schedule a quarterly data refresh and label the "as of" date.
+- Medium upgrade idea: Spanish localization (high value for the audience).
+- Full rebuild idea: not needed.
+- Recommendation: cleanup plus EN/ES (medium).
+
+## 11. DCA Time Machine (P2)
+URL: /interactive-demos/bitcoin-dca-time-machine/
+
+- Current learner confusion: Little; it is the strongest tool. The guess-reveal mechanic is used once and the behavior question is left on the table. Network failure can leave it blank.
+- Best first-principles question: "Could you have actually held through a fall of more than half?"
+- Learner should control: the buying plan, and what they say they would have done at the marked drawdowns.
+- Should change live: the realized outcome of their stated behavior versus disciplined buying.
+- Misconception to correct: "I would obviously have held."
+- Relatable scenario: someone who started buying at a peak and watched the value fall hard the next year.
+- Better title: keep it.
+- Better opening sentence: keep the reality-check framing.
+- Cleanup idea: a clear offline and retry message so a failed fetch never strands the learner.
+- Medium upgrade idea: add the behavioral hold-or-sell loop on top of the existing guess-reveal.
+- Full rebuild idea: not needed.
+- Recommendation: medium upgrade. (No investment advice: frame it as behavior and history, not a recommendation to buy.)
+
+## 12. KYC Best Practices (P2)
+URL: /interactive-demos/kyc-best-practices/
+
+- Current learner confusion: It hands a recommendation without showing any consequence, so the learner does not reason.
+- Best first-principles question: "Once a company links your name to your coins, what can it, or a future data leak, see about you?"
+- Learner should control: the path they pick (KYC exchange, peer-to-peer, hybrid) and what they do after buying.
+- Should change live: a privacy trace of what each party can see under each choice.
+- Misconception to correct: "KYC is just paperwork with no lasting effect."
+- Relatable scenario: buying on a verified exchange, then sending to a friend, and seeing what the exchange can now link.
+- Better title: "What buying choices reveal about you."
+- Better opening sentence: "Pick how you buy and see who learns what."
+- Cleanup idea: copy polish and an "as of" date on the platform notes.
+- Medium upgrade idea: the privacy consequence trace.
+- Full rebuild idea: a decision game over privacy hygiene.
+- Recommendation: medium upgrade. (No advice to evade law; frame as informed privacy, not avoidance.)
+
+## 13. Transaction Builder (P2)
+URL: /interactive-demos/transaction-builder/
+
+- Current learner confusion: It builds a transaction but shows no consequence for the fee choice, and "change" is unexplained.
+- Best first-principles question: "A payment is not one number. Where do the leftover coins go, and what does the fee actually buy you?"
+- Learner should control: which inputs to use, the outputs, and the fee rate.
+- Should change live: an estimated confirmation time and queue position, plus where the change goes, plus an optional raw view.
+- Misconception to correct: "The fee is an arbitrary tax" and "leftover money is lost."
+- Relatable scenario: paying for something small and getting change back to your own wallet, like cash.
+- Better title: keep it.
+- Better opening sentence: "Assemble a payment and see what your fee buys."
+- Cleanup idea: label change clearly and explain it in one line.
+- Medium upgrade idea: tie the fee slider to a simulated mempool placement and confirmation estimate.
+- Full rebuild idea: a build-to-mempool simulator.
+- Recommendation: medium upgrade. (All data stays demo; never construct or broadcast a real transaction, no real keys.)
+
+## 14. Advisor Readiness Kit, preview (P2)
+URL: /institutional/wealth-advisors/kit/
+
+- Current learner confusion: It reads as a sales catalog, not a tool, and carries 4 em dashes. Audience is professionals, so ES parity is a lower priority than for consumer tools.
+- Best first-principles question (advisor-facing): "What do you need to ask a client before their bitcoin becomes your responsibility?"
+- Learner should control: little today; it is a landing page that links two free tools.
+- Should change live: not applicable in its current form.
+- Misconception to correct: "An advisor can ignore a client's bitcoin."
+- Relatable scenario: an advisor whose client just inherited bitcoin and has no plan for it.
+- Better title: keep it.
+- Better opening sentence: "Two free tools to help you serve clients who own bitcoin."
+- Cleanup idea: remove the em dashes and surface the free Seed-Phrase Red-Flag tool in the hero.
+- Medium upgrade idea: make the client-discovery questionnaire interactive on the page rather than a download.
+- Full rebuild idea: not warranted.
+- Recommendation: cleanup. (Keep the TBA boundary note; do not turn the kit into a TBA upsell.)
+
+## 15. Wallet Security Workshop (P2)
+URL: /interactive-demos/wallet-security-workshop/
+
+- Current learner confusion: The passphrase field reads as if it might want a real passphrase, which is a safety ambiguity even though it is client-side only.
+- Best first-principles question: "Your seed phrase is your wallet. What happens to it changes everything about who can spend."
+- Learner should control: generating a demo seed with real randomness, then practicing a backup drill.
+- Should change live: backup verification feedback (did you record it correctly).
+- Misconception to correct: "The app holds my coins," and the idea that you should type a real passphrase anywhere.
+- Relatable scenario: practicing the backup and recovery drill before ever funding a real wallet.
+- Better title: keep it.
+- Better opening sentence: "Practice the riskiest part of self-custody with nothing at stake."
+- Cleanup idea (safety): relabel the passphrase field as "demo only, not saved" or add a banner.
+- Medium upgrade idea: a short "what could go wrong with this backup" prompt after the drill.
+- Full rebuild idea: not needed.
+- Recommendation: cleanup (safety label first).
+
+## 16. Bitcoin Key Generator Visual (P2)
+URL: /interactive-demos/bitcoin-key-generator-visual/
+
+- Current learner confusion: Strong tool, but jargon like "point at infinity" appears unexplained, there are 13 em dashes in the JS, and the curve canvas is not tuned for mobile.
+- Best first-principles question: "How does pure randomness become an address that only you can spend from?"
+- Learner should control: flipping entropy bits and watching the cascade.
+- Should change live: the full pipeline from bits to key to address updating as bits change.
+- Misconception to correct: "Keys are assigned by someone," or "two people could get the same key."
+- Relatable scenario: understanding why a 12-word phrase is effectively impossible to guess.
+- Better title: keep it.
+- Better opening sentence: "Flip a few bits and watch randomness become your address."
+- Cleanup idea: remove em dashes, add a one-line tooltip for jargon, and a mobile pass for the canvas.
+- Medium upgrade idea: an optional "how unguessable is this" scale to make the size of the keyspace felt.
+- Full rebuild idea: not needed.
+- Recommendation: cleanup.
+
+## 17. Testnet Practice Guide (P2)
+URL: /interactive-demos/testnet-practice-guide/
+
+- Current learner confusion: It is a reading checklist that sends the learner to external tools, so they read more than they do.
+- Best first-principles question: "What if you could make every beginner mistake with zero money at risk?"
+- Learner should control: today, only a level toggle; ideally an embedded practice step.
+- Should change live: little today.
+- Misconception to correct: "Practicing with Bitcoin means risking real money."
+- Relatable scenario: a nervous first send, done first on testnet where a mistake costs nothing.
+- Better title: "Practice Bitcoin with zero money at risk."
+- Better opening sentence: "Make your first mistakes where they cost nothing."
+- Cleanup idea: tighten the steps and clarify which testnet to use.
+- Medium upgrade idea: embed a small sandbox or a live testnet explorer step so the learner does, not just reads.
+- Full rebuild idea: an interactive testnet transaction simulator.
+- Recommendation: medium upgrade.
+
+## 18. Mining Simulator (P2)
+URL: /interactive-demos/mining-simulator/
+
+- Current learner confusion: The learner mostly watches the nonce iterate, the realistic mode is mysteriously slow, and the stats are stale (Nov 2024). One user-facing em dash.
+- Best first-principles question: "Mining is guessing. What are miners actually paid for, and who decides the winner?"
+- Learner should control: which transactions to include from a mempool given a block-size budget, and their share of hashrate.
+- Should change live: reward plus fees earned, whether their block is found before a competitor, and how difficulty responds.
+- Misconception to correct: "Miners create coins at will" and "the block subsidy is the only pay."
+- Relatable scenario: choosing which pending transactions to pack into a block when space is limited and fees compete.
+- Better title: keep it.
+- Better opening sentence: "Mining is a guessing race. See what the winner actually earns."
+- Cleanup idea: replace the em dash with a colon and fetch live difficulty with a labeled fallback.
+- Medium upgrade idea: an embedded fee-market mini-game on top of the real SHA-256 engine.
+- Full rebuild idea: a fuller proof-of-work plus fee-market simulator.
+- Recommendation: medium upgrade.
+
+## 19. Supply Schedule and Halvings (P2)
+URL: /interactive-demos/bitcoin-supply-schedule/
+
+- Current learner confusion: It is a spectator chart with controls, and a beginner is not told what to take away. The "19.6M" current supply is hardcoded and stale.
+- Best first-principles question: "What happens to your share when more money can always be printed, versus when it cannot?"
+- Learner should control: a counterfactual policy, try to print more, change the halving interval, or remove the cap, and run it forward.
+- Should change live: the dilution of a holder under the learner's policy next to the real fixed 21M schedule.
+- Misconception to correct: "21 million is arbitrary" and "an issuer could just promise to be disciplined." (Enforced scarcity differs from promised scarcity.)
+- Relatable scenario: a savings balance that holds its share versus one quietly diluted as more units are created.
+- Better title: "What fixed supply actually protects."
+- Better opening sentence: "Try to print more bitcoin. See what it would do to everyone's share."
+- Cleanup idea: pull current supply live and replace the generic reflect topic with a halving-specific prompt.
+- Medium upgrade idea: a policy sandbox comparing the learner's issuance against the real schedule.
+- Full rebuild idea: a full issuance simulator.
+- Recommendation: medium upgrade.
+
+## 20. Time Chain Explorer (P2)
+URL: /interactive-demos/time-chain-explorer/
+
+- Current learner confusion: The data is simulated with a stale hardcoded height, so the learner cannot tell what is real or change anything.
+- Best first-principles question: "Why can blocks never be exactly 10 minutes apart?"
+- Learner should control: a hashrate lever and a live-sync toggle.
+- Should change live: the block-time distribution and the next-block countdown as conditions change.
+- Misconception to correct: "Blocks arrive every 10 minutes, exactly."
+- Relatable scenario: waiting for a confirmation that takes 2 minutes one time and 40 the next, and wondering why.
+- Better title: "Why blocks are not exactly 10 minutes apart."
+- Better opening sentence: "Ten minutes is an average, not a clock. See the spread."
+- Cleanup idea: sync real recent block times via the existing data helper, with a labeled fallback.
+- Medium upgrade idea: a variance experiment where the learner changes hashrate and watches the distribution and the difficulty response.
+- Full rebuild idea: not needed.
+- Recommendation: medium upgrade.
+
+## 21. Money Properties Comparison (P2)
+URL: /interactive-demos/money-properties-comparison/
+
+- Current learner confusion: Little; it is strong. The learner reads pre-filled star ratings rather than forming a judgment first, and there is no Spanish.
+- Best first-principles question: "What makes something good money in the first place?"
+- Learner should control: their own 1 to 5 rating of each asset on each property, before any answer is shown.
+- Should change live: a reveal comparing the learner's ratings to the reasoned baseline, with the gaps explained.
+- Misconception to correct: "Money is just whatever the government says," or "gold and dollars are the same kind of thing."
+- Relatable scenario: why seashells once worked as money and then stopped.
+- Better title: keep it.
+- Better opening sentence: "Before we score them, you score them."
+- Cleanup idea: add the Spanish version (Curious-path concept).
+- Medium upgrade idea: the rate-it-yourself-first prediction mode (predict then reveal).
+- Full rebuild idea: not needed.
+- Recommendation: medium upgrade (self-score mode plus EN/ES).
+
+---
+
+# Summary recommendations
+
+## 1. Top 3 to improve first for brand trust
+
+These are where the platform currently looks biased, inaccurate, or unsafe, which is what erodes trust fastest.
+
+1. **Bitcoin vs Banking.** The persuasion table is the clearest place the site argues instead of informs. Fixing it proves the platform reasons honestly.
+2. **Sovereign Vault.** A "zero-knowledge" overclaim plus a field that could tempt real seed entry is both an accuracy and a safety problem. Reword and validate now.
+3. **Difficulty Calculator.** Stale numbers shown as if current quietly tell a careful reader the site is not maintained. Live data with a labeled fallback restores credibility.
+
+Cheap safety companions to do in the same pass: the Address Format Explorer demo-address banner and the Wallet Security Workshop passphrase relabel.
+
+## 2. Top 3 to improve first for learning impact
+
+The foundational first-principles trio, where a better mechanic changes the mental model the most.
+
+1. **Supply Schedule and Halvings.** Owns scarcity, the single most important idea, and is currently spectator-only.
+2. **Bitcoin vs Banking.** Teaches that money choices are tradeoffs, the reasoning habit the whole site depends on.
+3. **Money Properties Comparison.** Teaches what money even is, and a small predict-then-reveal upgrade turns a strong explainer into active reasoning.
+
+## 3. Top 3 to improve first for easiest implementation
+
+Small effort, real gain, low risk.
+
+1. **Money Properties Comparison.** Add a rate-it-yourself-first step to an already strong tool.
+2. **Security Training Lab (Dojo).** Show the score breakdown that the logic already computes.
+3. **Address Format Explorer.** Add a prominent demo-address banner and a short "which format to use" readout.
+
+## 4. Single best template mechanic to reuse
+
+**Predict, then reveal.** Ask the learner to commit to a guess or a choice before the tool resolves the consequence, then show the gap between their expectation and what actually happens. It already exists in the DCA Time Machine and is the cheapest way to convert the shallow explainers into reasoning tools. It maps directly onto Money Properties (rate the assets first), Supply Schedule (predict what printing more does), Difficulty Calculator (predict the effect of more miners), Bitcoin vs Banking (guess which rail fits before seeing the scorecards), KYC (predict what an exchange can see), and Mining (predict what the winner earns). Building it once as a small shared pattern, with EN/ES strings from the start, would lift many tools at once and give the library a consistent, honest learning rhythm.

--- a/TOOLS-INVENTORY-AUDIT.md
+++ b/TOOLS-INVENTORY-AUDIT.md
@@ -1,0 +1,132 @@
+# TOOLS-INVENTORY-AUDIT
+
+Audit date: 2026-06-23. Audit only, no code changed. Branch at audit time: `feat/m4-measure-drift-clean`.
+
+## Scope
+
+The "Tools Library" page at `/tools/index.html` is a curated catalog of 25 learner-facing tool cards. Those 25 cards are the audit scope. They point mostly to `/interactive-demos/<name>/` plus a handful of standalone pages.
+
+Out of scope (noted, not audited as learner tools): the other files in `/tools/` are devops and build scripts, not learner experiences: `deploy-automation.js`, `domain-config.js`, `domain-monitor.js`, `domain-test-suite.js`, `seo-optimizer.js`, `security-headers.js`, `site-enhancer.js`, `content-validator.js`, `registry.js`, `bundle-assets.js`, `check-unique-ids.js`, `test-tenants.js`, `test-domain.sh`, `vercel-weekly-maintenance.sh`, plus `domain-dashboard.html` and `bitcoin-recovery-binder.html` (the binder is a standalone utility, not linked from the Tools Library grid).
+
+## Scoring rubric
+
+Each tool scored 1 to 5. For the three RISK dimensions, **5 means highest risk** (worst). For the other five, **5 means best**.
+
+- Ped = Pedagogical strength
+- Int = Interactivity
+- Acc = Bitcoin accuracy
+- Clar = Beginner clarity
+- MobR = Mobile usability RISK (5 = most likely to break on mobile)
+- SafeR = Safety / advice RISK (5 = most concerning)
+- ESR = EN/ES parity RISK (5 = bilingual audience most underserved by missing ES)
+- Reuse = Reuse potential across BSA / FSA / TSA
+
+Classification key: **Strong** = learner makes meaningful choices, sees consequences, understands the mechanism. **Useful but shallow** = mostly calculates, compares, reveals, or explains without making the learner reason. **Needs repair** = broken behavior, weak/persuasive copy, stale assumptions, or unclear outcome. **Upgrade candidate** = teaches an important idea but should be rebuilt into choice to consequence to reflection.
+
+Priority key: **P0** broken/wrong/safety blocker · **P1** high value (fix or upgrade soon) · **P2** useful cleanup or mid upgrade · **P3** already strong, leave alone.
+
+## Headline counts
+
+- 25 tools, all 25 routes resolve on disk.
+- Classification: **Strong 12**, **Useful but shallow 9**, **Needs repair 2**, **Upgrade candidate 2**.
+- Priority: **P0 0**, **P1 9**, **P2 12**, **P3 4**.
+- 0 of 25 have a Spanish (ES) version or any i18n keying. This is the single most systemic gap given the locked "Bilingual. LATAM-fluent." identity.
+- 0 of 25 have a dedicated test file. (`tests/interactive-tools.measure-drift.test.mjs` covers a different tool; `tests/wealth-advisor-course.test.mjs` and `tests/check-wealth-advisor-module.mjs` touch the advisor area but not the kit-preview page directly.)
+
+## Master table
+
+| # | Tool | URL | Category | Classification | Priority | Main issue | Recommended action |
+|---|------|-----|----------|----------------|----------|-----------|--------------------|
+| 1 | On-Ramp Chooser | /interactive-demos/onramp-chooser/ | Essential | Strong | P2 | Fee/method data hardcoded (Dec 2025), no ES for a LATAM-critical tool | Schedule a quarterly data refresh; plan ES |
+| 2 | Bitcoin Emergency Kit | /emergency-kit.html | Essential | Strong | P1 | 10 em dashes in body copy | Em-dash cleanup; otherwise keep |
+| 3 | Bitcoin Unit Converter | /interactive-demos/bitcoin-unit-converter/ | Essential | Useful but shallow | P3 | Pure calculator, no reasoning | Add a reflect prompt (when sats vs BTC?) |
+| 4 | Sat Stacking Calculator | /interactive-demos/sat-stacking-calculator/ | Essential | Strong | P3 | None blocking | Optional: show sats accumulated |
+| 5 | DCA Time Machine | /interactive-demos/bitcoin-dca-time-machine/ | Essential | Upgrade candidate | P2 | Strong guess-reveal mechanic underused | Add behavioral "would you have held?" loop |
+| 6 | KYC Best Practices | /interactive-demos/kyc-best-practices/ | Essential | Useful but shallow | P2 | Recommends, never shows consequence | Add privacy-leak consequence trace |
+| 7 | Fee Master Tool | /interactive-demos/fee-master-tool/ | Transaction | Strong | P3 | Decide-tab logic opaque | Optional: expose threshold formula |
+| 8 | UTXO Visualizer | /interactive-demos/utxo-visualizer-enhanced/ | Transaction | Strong | P1 | Privacy score is a black box | Surface the privacy calculation inline |
+| 9 | Transaction Builder | /interactive-demos/transaction-builder/ | Transaction | Useful but shallow | P2 | Builds but shows no consequence of fee choice | Add raw-tx view or mempool placement |
+| 10 | Address Format Explorer | /interactive-demos/address-format-explorer/ | Transaction | Strong | P1 | Generated addresses are fake but weakly labeled | Add a prominent "demo addresses" banner |
+| 11 | Advisor Readiness Kit (preview) | /institutional/wealth-advisors/kit/ | Security | Useful but shallow | P2 | Catalog page, not a tool; 4 em dashes | Surface the free Seed-Phrase tool; em-dash cleanup |
+| 12 | Security Risk Simulator | /interactive-demos/security-risk-simulator.html | Security | Strong | P1 | EN only; high-value, high reuse | Plan ES localization |
+| 13 | Multisig Security Demo | /multisig-security-demo.html | Security | Strong | P1 | 14 em dashes; framing is correct | Em-dash cleanup; keep framing |
+| 14 | Wallet Security Workshop | /interactive-demos/wallet-security-workshop/ | Security | Strong | P2 | Passphrase field reads ambiguously as real-entry | Relabel field as demo-only / add banner |
+| 15 | Security Training Lab (Dojo) | /interactive-demos/security-dojo-enhanced/ | Security | Strong | P1 | Security score formula hidden | Add score breakdown to results |
+| 16 | Bitcoin Key Generator Visual | /interactive-demos/bitcoin-key-generator-visual/ | Security | Strong | P2 | 13 em dashes in JS comments; canvas not mobile-tuned | Em-dash cleanup; mobile pass |
+| 17 | Testnet Practice Guide | /interactive-demos/testnet-practice-guide/ | Security | Useful but shallow | P2 | Learn-by-reading, no embedded doing | Embed a sandbox or live explorer step |
+| 18 | Sovereign Vault | /interactive-demos/sovereign-vault/ | Security | Useful but shallow | P1 | "Zero-knowledge" overclaim + a field that could tempt real seed entry | Fix claim to "client-side encrypted"; validate inputs |
+| 19 | Lightning Network Lab | /interactive-demos/lightning-network-demo/ | Lightning | Useful but shallow | P3 | SVG network has no responsive viewBox | Add responsive viewBox; "what breaks?" section |
+| 20 | Mining Simulator | /interactive-demos/mining-simulator/ | Mining | Upgrade candidate | P2 | Stale Nov-2024 stats; 1 user-facing em dash | Live difficulty fetch; add fee-market mini-game |
+| 21 | Supply Schedule & Halvings | /interactive-demos/bitcoin-supply-schedule/ | Analysis | Useful but shallow | P2 | Hardcoded "19.6M" supply is stale; spectator-only | Live supply; add scarcity reasoning prompt |
+| 22 | Time Chain Explorer | /interactive-demos/time-chain-explorer/ | Analysis | Useful but shallow | P2 | Simulated data, no live sync, no "what if" | Sync live block times; add variance reasoning |
+| 23 | Difficulty Calculator | /interactive-demos/difficulty-calculator/ | Analysis | Needs repair | P1 | Stale Jan-2025 data + confusing "live data..." fallback | Live difficulty; fix fallback; add "why adjust?" |
+| 24 | Bitcoin vs Banking | /interactive-demos/bitcoin-vs-banking/ | Analysis | Needs repair | P1 | Strawman comparison reads as persuasion, not information | Rebuild as a use-case decision tree (inform-not-convince) |
+| 25 | Money Properties Comparison | /interactive-demos/money-properties-comparison/ | Analysis | Strong | P2 | None major; ES missing | Plan ES; optional self-score-first mode |
+
+## Scores matrix
+
+5 = best, except MobR / SafeR / ESR where 5 = highest risk.
+
+| # | Tool | Ped | Int | Acc | Clar | MobR | SafeR | ESR | Reuse |
+|---|------|-----|-----|-----|------|------|-------|-----|-------|
+| 1 | On-Ramp Chooser | 5 | 5 | 5 | 5 | 1 | 1 | 5 | 4 |
+| 2 | Emergency Kit | 5 | 4 | 5 | 5 | 1 | 1 | 5 | 3 |
+| 3 | Unit Converter | 3 | 4 | 5 | 5 | 1 | 1 | 5 | 4 |
+| 4 | Sat Stacking Calculator | 5 | 5 | 5 | 4 | 1 | 1 | 5 | 5 |
+| 5 | DCA Time Machine | 4 | 5 | 5 | 4 | 1 | 1 | 5 | 4 |
+| 6 | KYC Best Practices | 3 | 3 | 4 | 5 | 1 | 2 | 5 | 2 |
+| 7 | Fee Master Tool | 4 | 5 | 5 | 5 | 1 | 1 | 4 | 4 |
+| 8 | UTXO Visualizer | 5 | 5 | 4 | 4 | 2 | 1 | 4 | 3 |
+| 9 | Transaction Builder | 3 | 4 | 4 | 4 | 1 | 2 | 4 | 3 |
+| 10 | Address Format Explorer | 5 | 4 | 4 | 5 | 1 | 3 | 4 | 4 |
+| 11 | Advisor Readiness Kit | 2 | 1 | 4 | 5 | 2 | 1 | 2 | 3 |
+| 12 | Security Risk Simulator | 5 | 5 | 5 | 4 | 2 | 1 | 5 | 3 |
+| 13 | Multisig Security Demo | 5 | 5 | 5 | 4 | 2 | 1 | 5 | 4 |
+| 14 | Wallet Security Workshop | 5 | 5 | 5 | 4 | 3 | 2 | 5 | 4 |
+| 15 | Security Training Lab (Dojo) | 5 | 5 | 4 | 5 | 2 | 1 | 5 | 4 |
+| 16 | Bitcoin Key Generator Visual | 5 | 5 | 5 | 4 | 2 | 1 | 4 | 5 |
+| 17 | Testnet Practice Guide | 3 | 3 | 4 | 5 | 2 | 2 | 5 | 2 |
+| 18 | Sovereign Vault | 2 | 4 | 4 | 4 | 3 | 3 | 5 | 3 |
+| 19 | Lightning Network Lab | 3 | 4 | 4 | 4 | 3 | 1 | 5 | 3 |
+| 20 | Mining Simulator | 3 | 4 | 4 | 5 | 2 | 1 | 5 | 4 |
+| 21 | Supply Schedule & Halvings | 2 | 4 | 5 | 3 | 3 | 1 | 5 | 3 |
+| 22 | Time Chain Explorer | 2 | 3 | 4 | 4 | 3 | 1 | 5 | 2 |
+| 23 | Difficulty Calculator | 2 | 3 | 4 | 3 | 2 | 2 | 5 | 3 |
+| 24 | Bitcoin vs Banking | 1 | 3 | 3 | 3 | 2 | 3 | 5 | 2 |
+| 25 | Money Properties Comparison | 4 | 4 | 5 | 5 | 1 | 1 | 5 | 4 |
+
+## Files found per tool
+
+| # | Tool | Files |
+|---|------|-------|
+| 1 | On-Ramp Chooser | index.html, onramp-data.js, onramp-logic.js |
+| 2 | Emergency Kit | emergency-kit.html (self-contained) |
+| 3 | Unit Converter | index.html (inline JS) |
+| 4 | Sat Stacking Calculator | index.html, btc-monthly-history.json |
+| 5 | DCA Time Machine | index.html (+ index.html.backup, stale) |
+| 6 | KYC Best Practices | index.html |
+| 7 | Fee Master Tool | index.html (uses /js/widgets/api-handler.js, /js/icon-library.js) |
+| 8 | UTXO Visualizer | index.html (uses /js/icon-library.js) |
+| 9 | Transaction Builder | index.html, transaction-builder-enhanced.js |
+| 10 | Address Format Explorer | index.html, main.js, address-generator.js, fee-calculator.js, styles.css |
+| 11 | Advisor Readiness Kit | kit/index.html (links tools/seed-phrase-red-flags.html, tools/client-script-builder.html) |
+| 12 | Security Risk Simulator | security-risk-simulator.html (uses membership-gate.js, demo-nav.js, demo-cta-footer) |
+| 13 | Multisig Security Demo | multisig-security-demo.html (uses icon-library, nav-context, demo-cta-footer) |
+| 14 | Wallet Security Workshop | index.html (uses config.js, demo-lock-subdomain.js, subdomain-access-control.js, icon-library.js) |
+| 15 | Security Training Lab (Dojo) | index.html (uses config.js, demo-lock-subdomain.js, subdomain-access-control.js) |
+| 16 | Bitcoin Key Generator Visual | index.html, bitcoin-crypto.js |
+| 17 | Testnet Practice Guide | index.html |
+| 18 | Sovereign Vault | index.html, js/, css/, templates/emergency-doc.html (+ index.html.backup, stale) |
+| 19 | Lightning Network Lab | index.html |
+| 20 | Mining Simulator | index.html, mining-enhanced.js |
+| 21 | Supply Schedule & Halvings | index.html (uses bitcoin-data-reliable.js, membership-gate.js) |
+| 22 | Time Chain Explorer | index.html (uses bitcoin-data-reliable.js) |
+| 23 | Difficulty Calculator | index.html (uses bitcoin-data-reliable.js) |
+| 24 | Bitcoin vs Banking | index.html |
+| 25 | Money Properties Comparison | index.html |
+
+## Notes on data freshness and external APIs
+
+Live or external data (good, keep): Unit Converter (CoinGecko), Fee Master Tool (mempool.space + CoinGecko via api-handler), Address Format Explorer (mempool.space + Blockstream fee rate), DCA Time Machine (CryptoCompare histoday), Sat Stacking (bundled blockchain.info monthly history, refreshed on load). Supply Schedule / Time Chain / Difficulty Calculator attempt live values via `bitcoin-data-reliable.js` but fall back to stale hardcoded snapshots that are user-visible.
+
+Stale hardcoded values presented to the learner (fix in any upgrade): Supply Schedule "19.6M" current supply; Time Chain block height 880k; Difficulty Calculator Jan-2025 difficulty/hashrate with a confusing "live data..." placeholder; Mining Simulator Nov-2024 hashrate (~400 EH/s). Fallback prices in Unit Converter, Fee Master, and Sat Stacking are labeled and only show on API failure, which is acceptable.

--- a/TOOLS-QA-REPORT.md
+++ b/TOOLS-QA-REPORT.md
@@ -1,0 +1,99 @@
+# TOOLS-QA-REPORT
+
+Audit date: 2026-06-23. Lightweight static QA across the 25 Tools Library entries. Checks were performed by reading source and route resolution on disk, plus targeted scans (em-dash byte counts, API references, DOM-target sanity). No dev server runtime was driven for every tool; "mounts cleanly" reflects static inspection of script references and DOM target IDs, not a live console capture for all 25. Items that warrant a live console check are flagged.
+
+## Summary
+
+| Check | Result |
+|-------|--------|
+| Route exists (resolves on disk) | 25 / 25 pass |
+| Mounts cleanly (static: DOM targets + script refs present) | 25 / 25 pass, no broken refs found |
+| No literal em dash (U+2014) in file | 18 / 25 pass, **7 files fail** (see below) |
+| No obvious missing DOM target | 25 / 25 pass |
+| Mobile layout: no high risk | 21 / 25 low, **4 flagged** |
+| ES translation present | 0 / 25 (systemic gap) |
+| Dedicated test coverage | 0 / 25 |
+| Uses live data / external API | 6 / 25 |
+
+No P0 runtime breakage was found. The recurring real problems are: em dashes, zero Spanish coverage, stale hardcoded data shown as current, and a couple of safety/labeling issues.
+
+## 1. Route exists
+
+All 25 card targets resolve to a file on disk (verified 2026-06-23). Standalone pages confirmed: `/emergency-kit.html`, `/multisig-security-demo.html`, `/interactive-demos/security-risk-simulator.html`. Directory tools resolve via `index.html`. The Advisor Readiness Kit card resolves to `/institutional/wealth-advisors/kit/index.html`.
+
+## 2. Mounts cleanly / DOM targets
+
+Static inspection found no broken script `src` references and no JS `getElementById` / query targets missing from the markup across the 25 tools. Shared dependencies referenced and present include `/js/icon-library.js`, `/js/widgets/api-handler.js`, `/js/bitcoin-data-reliable.js`, `/js/reflect-widget.js`, `/js/membership-gate.js`, and the subdomain/demo-lock scripts.
+
+Recommend a live console pass (preview server) for the API-driven tools specifically, since their happy path depends on network responses: Unit Converter, Fee Master Tool, Address Format Explorer, DCA Time Machine, and the three `bitcoin-data-reliable.js` consumers (Supply Schedule, Time Chain, Difficulty Calculator).
+
+## 3. Em dashes (U+2014) — FAIL on 7 files
+
+Authoritative count via Python (U+2014 only; en dashes U+2013 excluded). The no-em-dash rule applies to shipped strings, comments, and specs, so JS-comment occurrences count.
+
+| File | Tool | U+2014 count | Where |
+|------|------|--------------|-------|
+| multisig-security-demo.html | Multisig Security Demo | 14 | data attributes + explanatory text |
+| interactive-demos/bitcoin-key-generator-visual/bitcoin-crypto.js | Key Generator Visual | 13 | code comments |
+| emergency-kit.html | Emergency Kit | 10 | body copy (user-facing) |
+| institutional/wealth-advisors/kit/index.html | Advisor Readiness Kit | 4 | title, subtitle, headers |
+| interactive-demos/sovereign-vault/templates/emergency-doc.html | Sovereign Vault | 2 | generated-document template (user-facing) |
+| interactive-demos/transaction-builder/transaction-builder-enhanced.js | Transaction Builder | 1 | string/comment |
+| interactive-demos/mining-simulator/mining-enhanced.js | Mining Simulator | 1 | user-facing stat string |
+
+Total: 45 em dashes across 7 files. Highest priority for cleanup are the user-facing ones: Emergency Kit (10), Sovereign Vault template (2), Mining Simulator (1). Replace with comma, colon, parentheses, or period; preserve en dashes in numeric ranges.
+
+The other 18 tool files are clean of U+2014.
+
+## 4. Missing DOM target
+
+None found. Where tools build UI from data arrays (UTXO Visualizer scenarios, Money Properties cards, Security Dojo stations), the container targets exist and the JS guards are present.
+
+## 5. Mobile layout risk — 4 flagged
+
+Most tools are responsive (media queries, 44px touch targets, single-column reflow under 768px). Flagged for a mobile pass:
+
+- **Lightning Network Lab** (P3): SVG network diagram is a fixed 350px height with no responsive `viewBox`; risk of horizontal scroll on small screens.
+- **Supply Schedule & Halvings** (P2): canvas chart relies on mouse pan/zoom; no touch gesture support.
+- **Time Chain Explorer** (P2): scrollable block-stream is narrow and busy on small screens.
+- **Bitcoin Key Generator Visual** (P2): bit grid reflows, but the curve canvas (~350px) is not tuned for landscape mobile.
+- Minor: **Sovereign Vault** sticky sidebar can overlap content under 600px (watch during any rework).
+
+No tool uses a fixed pixel-width layout that traps content.
+
+## 6. Missing translation keys / ES parity — systemic
+
+0 of 25 tools have a Spanish version or any i18n keying (no `data-i18n`, no `es/` subdir, no language toggle). There are therefore no "missing translation keys" in the technical sense, because no tool is wired for translation at all. Given the locked "Bilingual. LATAM-fluent." identity, the highest-value ES candidates are the beginner/LATAM-facing tools: On-Ramp Chooser, KYC Best Practices, Money Properties Comparison, Bitcoin vs Banking (post-rebuild), Unit Converter, and the Security Risk Simulator.
+
+## 7. Test coverage
+
+No dedicated test exists for any of the 25 tools. Related tests in `tests/` cover other surfaces: `interactive-tools.measure-drift.test.mjs` (a different interactive tool), `wealth-advisor-course.test.mjs` and `check-wealth-advisor-module.mjs` (advisor course/module gating, not the kit-preview page), plus `module-gate`, `premium-routes`, `premium-route-access`, and `youth-engine` tests. The interactive tools are entirely uncovered. Lightweight smoke tests worth adding: data-fetch success/fallback for the API tools, and score-calculation determinism for the assessment tools (Security Dojo, Security Risk Simulator, Sovereign Vault resilience score).
+
+## 8. Live data / external APIs
+
+| Tool | Source | Fallback behavior |
+|------|--------|-------------------|
+| Bitcoin Unit Converter | CoinGecko (5-min refresh) | Labeled hardcoded fallback prices |
+| Fee Master Tool | mempool.space + CoinGecko (via api-handler, 30s) | Hardcoded ~$95k price fallback, not user-prominent |
+| Address Format Explorer | mempool.space + Blockstream (fee rate) | 5s timeout to 20 sat/vB default |
+| DCA Time Machine | CryptoCompare histoday (24h localStorage cache) | Retry button; no fake prices shown |
+| Sat Stacking Calculator | bundled blockchain.info monthly JSON (24h cache) | Labeled stale fallback ($97k) |
+| Supply Schedule / Time Chain / Difficulty Calculator | attempt bitcoin-data-reliable.js | **Falls back to stale hardcoded values shown as current** (see below) |
+
+The first five degrade gracefully and label fallbacks. The three `bitcoin-data-reliable.js` consumers do not: they display stale snapshots (Supply "19.6M", height 880k, Jan-2025 difficulty, ~400 EH/s) as if current. This is the main accuracy QA concern.
+
+## 9. Bitcoin accuracy and safety flags
+
+No altcoin or generic-crypto framing found in any of the 25 tools. No financial advice found; risk-bearing tools carry disclaimers. Collaborative-security framing in the Multisig Demo and Security Risk Simulator is correct ("self-custody with guardrails", "no single party moves funds alone"), not framed as a path toward custody. Specific items to address:
+
+- **Sovereign Vault — accuracy + safety (P1):** "zero-knowledge encryption" is an overclaim; the implementation is client-side AES-GCM with PBKDF2, which is not zero-knowledge. Reword to "client-side encrypted." Separately, free-text fields could tempt a learner to paste a real seed phrase; add input validation and an explicit warning. Vault data stays in localStorage (no network send observed), which is good.
+- **Address Format Explorer — safety (P1):** generated addresses are intentionally fake (acknowledged in code) but the "demo only, do not fund" warning is weak; make it prominent so a learner cannot mistake them for real addresses.
+- **Wallet Security Workshop — UX/safety (P2):** the passphrase field (`type="password"`, client-side only, no exfiltration risk) reads ambiguously as a real-entry field; relabel as demo-only or add a banner.
+- **Stale-data accuracy (P1/P2):** Difficulty Calculator (P1), Supply Schedule, Time Chain, Mining Simulator show outdated figures as current. Fix via live fetch with a clearly labeled fallback.
+
+## Suggested QA follow-ups (not done in this pass)
+
+1. Run a live preview console-error sweep on the 6 API-driven tools (and confirm fallback paths render without throwing).
+2. Em-dash cleanup across the 7 files in section 3, user-facing strings first.
+3. Add data-fetch and score-determinism smoke tests for the API and assessment tools.
+4. Decide ES rollout order for the LATAM-facing beginner tools.

--- a/TOOLS-UPGRADE-QUEUE.md
+++ b/TOOLS-UPGRADE-QUEUE.md
@@ -1,0 +1,127 @@
+# TOOLS-UPGRADE-QUEUE
+
+Audit date: 2026-06-23. Ranked list of the top 10 tools that deserve a real interactive upgrade, that is, a rebuild toward choice to consequence to reflection. This is a prioritization pass only. No upgrades implemented.
+
+Ranking weighs three things: how important the underlying Bitcoin idea is, how weak the current experience is at teaching it, and how much an upgrade would unlock relative to effort. Tools that are already Strong (Security Risk Simulator, Multisig Demo, UTXO Visualizer, Money Properties, Sat Stacking, Fee Master, Key Generator) are intentionally not here; they need cleanup, not rebuilds. Pure repairs with no pedagogy gain (em-dash sweeps, stale-data fixes alone) live in the QA report, not here.
+
+Complexity key: small = copy + one interaction, days. medium = new state model + consequence rendering, ~1 to 2 weeks. large = new data integration or simulation engine.
+
+---
+
+## 1. Bitcoin vs Banking
+URL: /interactive-demos/bitcoin-vs-banking/ · current classification: Needs repair · complexity: medium
+
+- **Why it matters:** It is a beginner-facing, homepage-adjacent comparison and often a learner's first framing of "why Bitcoin." It shapes whether the whole platform reads as education or as a sales pitch.
+- **What is weak now:** A 12-row check/cross table that scores Bitcoin ahead in roughly 9 of 12 rows, plus a calculator with a fixed ~$2.50 Bitcoin fee vs 3% + $15 + FX banking fee. It delivers a verdict instead of a question. This directly conflicts with the locked voice spec (inform, do not convince).
+- **What the learner should control:** Their own priority and situation: amount, frequency, cross-border or domestic, what they value most (cost, speed, custody, reversibility, regulatory recourse).
+- **What consequence should update live:** A genuine trade-off readout where banking sometimes wins (small domestic payment with chargeback protection, or a user with poor key hygiene) and Bitcoin sometimes wins (censorship resistance, cross-border, self-custody). Show "it depends," not "Bitcoin wins."
+- **Misconception it should correct:** "Bitcoin is strictly better than banks." Replace with "different tools have different failure modes; the right choice depends on what you are protecting against."
+- **Form:** Decision game / scenario lab.
+- **Risk notes:** Must avoid financial advice and avoid the inverse strawman against banks. Keep fee figures as illustrative ranges, not fake live prices. No altcoin framing.
+
+## 2. Supply Schedule & Halvings
+URL: /interactive-demos/bitcoin-supply-schedule/ · current classification: Useful but shallow · complexity: medium
+
+- **Why it matters:** Fixed supply is the single most important first-principles idea in Bitcoin. This tool owns it.
+- **What is weak now:** A spectator chart with zoom/pan/playback and a hardcoded, already-stale "19.6M" current supply. The learner watches; they never reason.
+- **What the learner should control:** A counterfactual issuance policy: let them try to "print" more, change the halving interval, or remove the cap, and run it forward.
+- **What consequence should update live:** Side-by-side emission and dilution against the real 21M schedule, so the learner sees what a discretionary money supply does to holders versus a fixed one.
+- **Misconception it should correct:** "21 million is an arbitrary number" and "a central issuer could just decide to be disciplined." Show why credible, enforced scarcity differs from promised scarcity.
+- **Form:** Simulator (policy sandbox) plus a scarcity reflection prompt; retire the generic `data-topic="money"` for a halving-specific one.
+- **Risk notes:** Keep the real schedule mathematically exact (210k-block halvings, 21M cap). Pull current supply live instead of hardcoding.
+
+## 3. Mining Simulator
+URL: /interactive-demos/mining-simulator/ · current classification: Upgrade candidate · complexity: medium to large
+
+- **Why it matters:** Proof-of-work and the fee market are where most learners' mental models break. The SHA-256 engine here is already real, which is a strong foundation.
+- **What is weak now:** The learner mostly watches the nonce iterate. Stats are hardcoded to Nov 2024 (~400 EH/s, now stale). One user-facing em dash.
+- **What the learner should control:** Which transactions to include from a mempool given a block size budget, and their own hashrate share.
+- **What consequence should update live:** Block reward plus fees earned, whether their block is found before a competitor's, and how difficulty responds when total hashrate changes.
+- **Misconception it should correct:** "Miners get paid only the block subsidy" and "more hashrate makes blocks faster." Show fees as a real revenue line and difficulty as the regulator that holds ~10-minute spacing.
+- **Form:** Simulator with an embedded fee-market mini-game.
+- **Risk notes:** Fetch live difficulty (mempool.space) with a labeled fallback. Keep "real SHA-256" claim honest by explaining why browser mining is slow.
+
+## 4. Difficulty Calculator
+URL: /interactive-demos/difficulty-calculator/ · current classification: Needs repair · complexity: medium
+
+- **Why it matters:** The difficulty adjustment is Bitcoin's self-regulating heartbeat; few tools explain it well.
+- **What is weak now:** Stale Jan-2025 difficulty and hashrate are shown as if current, and a "live data..." placeholder confuses beginners. It computes payout, it does not teach the feedback loop.
+- **What the learner should control:** Add or remove network hashrate and advance epochs.
+- **What consequence should update live:** The resulting difficulty change and the time it takes the network to re-converge on ~10-minute blocks, plus the lag before adjustment.
+- **Misconception it should correct:** "Difficulty is set by someone" and "blocks are always 10 minutes." Show it as an automatic response to hashrate over a 2016-block window.
+- **Form:** Visualizer with a feedback-loop interaction.
+- **Risk notes:** Replace stale snapshot with live fetch; drop the misleading fallback string. Avoid implying mining is profitable advice (omit or clearly bracket electricity cost).
+
+## 5. DCA Time Machine
+URL: /interactive-demos/bitcoin-dca-time-machine/ · current classification: Upgrade candidate · complexity: small to medium
+
+- **Why it matters:** It already has the platform's best pedagogical mechanic (predict, then reveal) on real historical data, and it teaches behavior, not just numbers.
+- **What is weak now:** The guess-reveal is used once for final value. Drawdown psychology is shown but not made consequential. Relies on a live API with thin offline messaging.
+- **What the learner should control:** Not just the buy plan, but whether they would have held or sold at the marked peak-to-trough drawdowns.
+- **What consequence should update live:** The realized outcome of their stated behavior versus disciplined DCA, so panic-selling shows its cost.
+- **Misconception it should correct:** "I would obviously have held." Surface survivorship bias and emotional selling explicitly.
+- **Form:** Scenario lab building on the existing guess-reveal.
+- **Risk notes:** Strong disclaimer already present; keep "not financial advice." Preload/cache so a network failure does not strand the learner.
+
+## 6. KYC Best Practices
+URL: /interactive-demos/kyc-best-practices/ · current classification: Useful but shallow · complexity: medium
+
+- **Why it matters:** Privacy trade-offs at the on-ramp are a genuine, consequential decision for the LATAM and privacy-conscious audience.
+- **What is weak now:** The learner answers three dropdowns and reads a recommendation. No consequence, no reasoning.
+- **What the learner should control:** The path they pick (KYC exchange, no-KYC P2P, hybrid) and follow-on choices about how they split and store.
+- **What consequence should update live:** A traced privacy outcome, what an exchange, a chain analyst, or a data breach can see about them under each choice.
+- **Misconception it should correct:** "KYC vs no-KYC is purely about convenience" and "once you are KYC'd it does not matter what you do next."
+- **Form:** Decision game with a privacy-consequence trace.
+- **Risk notes:** No advice to evade law; frame as informed privacy hygiene. Platform list decays fast, so keep it data-light. ES strongly wanted here.
+
+## 7. Transaction Builder
+URL: /interactive-demos/transaction-builder/ · current classification: Useful but shallow · complexity: medium
+
+- **Why it matters:** Inputs, outputs, change, and fees are core literacy, and this tool is the place learners assemble that model.
+- **What is weak now:** The learner builds with fixed demo UTXOs and a fee slider, then sees a static success summary. No consequence to the fee choice.
+- **What the learner should control:** Fee rate and input selection, as now, but tied to a live or simulated mempool state.
+- **What consequence should update live:** Estimated confirmation time and queue position, plus the raw transaction structure, so the fee slider has a visible payoff.
+- **Misconception it should correct:** "Fee is an arbitrary tax" and "a transaction is one indivisible thing." Show fee as a bid for block space and the tx as inputs/outputs/change.
+- **Form:** Simulator (build to mempool placement).
+- **Risk notes:** Keep all data clearly demo; never construct or broadcast a real transaction. No real keys.
+
+## 8. Time Chain Explorer
+URL: /interactive-demos/time-chain-explorer/ · current classification: Useful but shallow · complexity: medium
+
+- **Why it matters:** Block-time variance and the Poisson nature of mining are widely misunderstood ("blocks come every 10 minutes, exactly").
+- **What is weak now:** Fully simulated stream with a stale hardcoded height; the learner cannot change anything or sync reality.
+- **What the learner should control:** A "what if hashrate jumps or drops" lever, and a live-sync toggle.
+- **What consequence should update live:** How the distribution and the next-block countdown shift, and why the average holds near 10 minutes only after difficulty adjusts.
+- **Misconception it should correct:** "Each block takes 10 minutes." Replace with "10 minutes is the average of a memoryless process; individual blocks vary widely."
+- **Form:** Visualizer with a variance experiment.
+- **Risk notes:** Sync real block times via mempool.space; keep the simulation labeled when live data is unavailable.
+
+## 9. Sovereign Vault
+URL: /interactive-demos/sovereign-vault/ · current classification: Useful but shallow · complexity: medium to large
+
+- **Why it matters:** Custody documentation and inheritance planning sit at the center of BSA's family-and-advisor identity.
+- **What is weak now:** It is a metadata form that emits a resilience score by an opaque formula, and it does not teach why diversification matters. It also has two correctness issues that must be fixed in any rebuild (see risk).
+- **What the learner should control:** Their setup, then a set of failure events to throw at it.
+- **What consequence should update live:** A recovery stress test, "your house with the only backup burns; can your heirs still recover?", with the resilience score explained rather than asserted.
+- **Misconception it should correct:** "Writing down my setup is the plan" and "one backup is enough." Show single points of failure concretely.
+- **Form:** Scenario lab (custody stress test) layered onto the existing vault.
+- **Risk notes:** Two real defects: the "zero-knowledge encryption" claim is inaccurate (it is client-side AES-GCM, not a zero-knowledge proof system) and must be reworded; and free-text fields could tempt a learner to paste a real seed phrase, so add validation and a hard warning. Keep everything client-side; no network send of vault contents.
+
+## 10. Money Properties Comparison
+URL: /interactive-demos/money-properties-comparison/ · current classification: Strong · complexity: small
+
+- **Why it matters:** It already teaches the properties-of-money lens well; a light upgrade converts a strong explainer into active reasoning.
+- **What is weak now:** The learner reads pre-assigned star ratings rather than forming their own judgment first.
+- **What the learner should control:** Their own 1 to 5 rating of each asset on each property before any answer is shown.
+- **What consequence should update live:** A reveal comparing the learner's scores against the reasoned baseline, with the gaps explained (this is the same predict-then-reveal pattern that makes the DCA tool strong).
+- **Misconception it should correct:** "Good money is whatever I am used to." Force the learner to weigh scarcity, durability, divisibility, portability, verifiability, fungibility explicitly.
+- **Form:** Decision/prediction game on top of the current comparison.
+- **Risk notes:** Lowest-risk item on this list; it is already accurate and on-brand. Pair the upgrade with the ES version since this is a Curious-path concept.
+
+---
+
+## Cross-queue themes
+
+- The strongest single lever across the queue is the **predict-then-reveal** pattern. It already exists in the DCA Time Machine and is the cheapest way to turn the shallow explainers (Money Properties, Supply Schedule, KYC) into reasoning tools.
+- Three queue items (Mining, Difficulty, Time Chain, Supply Schedule) share a **live-data plus what-if** shape. A shared block/difficulty data helper (`bitcoin-data-reliable.js` already exists) would let several upgrades reuse one integration.
+- Two items carry **correctness fixes that should not wait for the full upgrade**: Sovereign Vault's "zero-knowledge" overclaim and seed-entry risk, and Difficulty Calculator's stale data shown as current. These are also tracked in the QA report.

--- a/interactive-demos/bitcoin-vs-banking/index.html
+++ b/interactive-demos/bitcoin-vs-banking/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html><html lang="en"><head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Compare Bitcoin vs traditional banking for cost, speed, and sovereignty">
-    <title>Bitcoin vs Banking | Bitcoin Sovereign Academy</title>
-    
+    <meta name="description" content="Pick a real situation and see which money rail fits: a bank or card, Bitcoin self-custody, or Bitcoin with a service provider. Honest tradeoffs, not a verdict.">
+    <title>Bitcoin and Banking: Which Rail Fits? | Bitcoin Sovereign Academy</title>
+
     <!-- Styles -->
     <link rel="stylesheet" href="/css/tokens.css">
     <link rel="stylesheet" href="/css/brand.css">
     <link rel="stylesheet" href="/css/widgets.css">
-    
+
     <style>
         body {
             background: #0f0f0f;
@@ -17,250 +17,97 @@
             line-height: 1.6;
             padding: 2rem;
         }
-        
-        /* Multi-Level Support */
+
+        /* Multi-Level Support (kept from prior version) */
         body.level-beginner .intermediate-only { display: none; }
         body.level-beginner .advanced-only { display: none; }
         body.level-intermediate .beginner-only { display: none; }
         body.level-intermediate .advanced-only { display: none; }
         body.level-advanced .beginner-only { display: none; }
         body.level-advanced .intermediate-only { display: none; }
-        
+
+        /* New level gating: int-up shows on intermediate and advanced; adv-only on advanced */
+        body.level-beginner .lvl-int-up { display: none; }
+        body.level-beginner .lvl-adv-only { display: none; }
+        body.level-intermediate .lvl-adv-only { display: none; }
+
         .container {
-            max-width: 1400px;
+            max-width: 1100px;
             margin: 0 auto;
         }
-        
+
         .header {
             text-align: center;
-            margin-bottom: 3rem;
-            padding: 3rem 2rem;
+            margin-bottom: 2rem;
+            padding: 2.5rem 1.5rem;
             background: linear-gradient(135deg, #1a1a1a 0%, #242424 100%);
             border-radius: 16px;
         }
-        
+
         .header h1 {
-            font-size: 2.5rem;
-            margin-bottom: 1rem;
-            background: var(--brand-gradient);
+            font-size: 2.1rem;
+            margin-bottom: 0.75rem;
+            background: var(--brand-gradient, linear-gradient(135deg, #FF7A00, #FFD400));
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
         }
-        
-        .comparison-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 1rem;
-            margin: 2rem 0;
-        }
-        
-        .column {
-            background: #1a1a1a;
-            border-radius: 12px;
-            padding: 2rem;
-        }
-        
-        .column.bitcoin {
-            border-top: 4px solid #FF7A00;
-        }
-        
-        .column.banking {
-            border-top: 4px solid #2196f3;
-        }
-        
-        .column-header {
-            display: flex;
-            align-items: center;
-            gap: 1rem;
-            margin-bottom: 1.5rem;
-        }
-        
-        .column-icon {
-            font-size: 2.5rem;
-        }
-        
-        .column-title {
-            font-size: 1.5rem;
-            font-weight: 700;
-        }
-        
-        .comparison-section {
-            margin: 3rem 0;
-        }
-        
-        .section-title {
-            text-align: center;
-            color: #FF7A00;
-            font-size: 1.75rem;
-            margin-bottom: 2rem;
-        }
-        
-        .metric-row {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 1rem;
-            margin: 1rem 0;
-        }
-        
-        .metric-card {
-            background: #242424;
-            padding: 1.5rem;
-            border-radius: 8px;
-        }
-        
-        .metric-label {
-            font-size: 0.875rem;
-            color: #b0b0b0;
-            margin-bottom: 0.5rem;
-        }
-        
-        .metric-value {
-            font-size: 1.5rem;
-            font-weight: 700;
-            margin: 0.5rem 0;
-        }
-        
-        .bitcoin .metric-value {
-            color: #FF7A00;
-        }
-        
-        .banking .metric-value {
-            color: #2196f3;
-        }
-        
-        .metric-detail {
-            font-size: 0.875rem;
+
+        .header .subtitle {
             color: #d0d0d0;
+            max-width: 640px;
+            margin: 0 auto 0.75rem;
         }
-        
-        .calculator {
-            background: #1a1a1a;
-            border-radius: 12px;
-            padding: 2rem;
-            margin: 2rem 0;
+
+        .header .core-question {
+            color: #b3b3b3;
+            font-style: italic;
+            max-width: 640px;
+            margin: 0.5rem auto 0;
+            font-size: 0.95rem;
         }
-        
-        .form-group {
-            margin-bottom: 1.5rem;
+
+        .lang-toggle {
+            display: inline-flex;
+            gap: 0.4rem;
+            margin-top: 1rem;
+            align-items: center;
+            justify-content: center;
         }
-        
-        .form-group label {
-            display: block;
-            margin-bottom: 0.5rem;
-            color: #FF7A00;
-            font-weight: 600;
+
+        .lang-toggle .lang-label {
+            color: #b3b3b3;
+            font-size: 0.85rem;
+            margin-right: 0.25rem;
         }
-        
-        .form-group input .form-group select {
-            width: 100%;
-            padding: 0.75rem;
-            background: #242424;
-            border: 2px solid #333;
+
+        .lang-btn {
+            padding: 0.35rem 0.8rem;
+            background: rgba(255, 122, 0, 0.1);
+            border: 2px solid rgba(255, 122, 0, 0.3);
             border-radius: 8px;
             color: #ffffff;
-            font-size: 1rem;
-        }
-        
-        .form-group input:focus .form-group select:focus {
-            outline: none;
-            border-color: #FF7A00;
-        }
-        
-        .pros-cons {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 2rem;
-            margin: 2rem 0;
-        }
-        
-        .pros-list .cons-list {
-            background: #242424;
-            padding: 1.5rem;
-            border-radius: 8px;
-        }
-        
-        .pros-list {
-            border-left: 3px solid #00c853;
-        }
-        
-        .cons-list {
-            border-left: 3px solid #ff1744;
-        }
-        
-        .pros-list h4 .cons-list h4 {
-            margin-bottom: 1rem;
-            color: #FF7A00;
-        }
-        
-        .pros-list li {
-            color: #00c853;
-            margin: 0.5rem 0;
-        }
-        
-        .cons-list li {
-            color: #ff1744;
-            margin: 0.5rem 0;
-        }
-        
-        .winner-badge {
-            display: inline-block;
-            padding: 0.5rem 1rem;
-            background: rgba(0, 200, 83, 0.2);
-            border: 2px solid #00c853;
-            border-radius: 20px;
-            color: #00c853;
-            font-weight: 700;
-            font-size: 0.875rem;
-        }
-        
-        .feature-comparison {
-            width: 100%;
-            border-collapse: collapse;
-            margin: 2rem 0;
-        }
-        
-        .feature-comparison th {
-            background: #242424;
-            padding: 1rem;
-            text-align: left;
-            color: #FF7A00;
+            cursor: pointer;
             font-weight: 600;
+            font-size: 0.85rem;
         }
-        
-        .feature-comparison td {
-            padding: 1rem;
-            border-bottom: 1px solid #333;
+
+        .lang-btn.active {
+            background: #FF7A00;
+            border-color: #FF7A00;
+            color: #0f0f0f;
         }
-        
-        .feature-comparison tr:hover {
-            background: rgba(255, 122, 0, 0.05);
-        }
-        
-        .check {
-            color: #00c853;
-            font-size: 1.25rem;
-        }
-        
-        .cross {
-            color: #ff1744;
-            font-size: 1.25rem;
-        }
-        
-        .partial {
-            color: #FF7A00;
-            font-size: 1.25rem;
-        }
-        
+
+        /* Level switcher (kept) */
         .level-switcher {
             background: #1a1a1a;
             border: 2px solid #FF7A00;
             border-radius: 12px;
             padding: 1rem;
-            margin-bottom: 2rem;
+            margin-bottom: 1.5rem;
             text-align: center;
         }
-        
+
         .level-buttons {
             display: flex;
             gap: 0.75rem;
@@ -268,7 +115,7 @@
             flex-wrap: wrap;
             margin-top: 0.75rem;
         }
-        
+
         .level-btn {
             padding: 0.6rem 1.2rem;
             background: rgba(255, 122, 0, 0.1);
@@ -279,43 +126,254 @@
             font-weight: 600;
             transition: all 0.3s ease;
         }
-        
+
         .level-btn.active {
             background: #FF7A00;
             border-color: #FF7A00;
             color: #0f0f0f;
         }
-        
+
         .level-btn:hover {
             transform: translateY(-2px);
         }
 
-        @media (max-width: 968px) {
-            .comparison-grid .pros-cons {
-                grid-template-columns: 1fr;
-            }
+        /* Situation form */
+        .bvb-section {
+            background: #1a1a1a;
+            border-radius: 12px;
+            padding: 1.75rem;
+            margin: 1.5rem 0;
+        }
 
-            .metric-row {
-                grid-template-columns: 1fr;
-            }
+        .bvb-section h2 {
+            color: #FF7A00;
+            font-size: 1.3rem;
+            margin-bottom: 1rem;
+        }
+
+        .bvb-group-title {
+            color: #f0f0f0;
+            font-size: 1.05rem;
+            font-weight: 700;
+            margin: 1.25rem 0 0.75rem;
+        }
+
+        .bvb-fields {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1.25rem;
+        }
+
+        .bvb-field {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .bvb-label {
+            color: #ffffff;
+            font-weight: 600;
+            margin-bottom: 0.35rem;
+            font-size: 0.95rem;
+        }
+
+        .bvb-help {
+            color: #b3b3b3;
+            font-size: 0.8rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .bvb-field input[type="number"] {
+            width: 100%;
+            padding: 0.7rem;
+            background: #242424;
+            border: 2px solid #333;
+            border-radius: 8px;
+            color: #ffffff;
+            font-size: 1rem;
+        }
+
+        .bvb-field input[type="number"]:focus {
+            outline: none;
+            border-color: #FF7A00;
+        }
+
+        .bvb-toggle {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4rem;
+        }
+
+        .bvb-opt {
+            flex: 1 1 auto;
+            min-width: 90px;
+            padding: 0.55rem 0.6rem;
+            background: #242424;
+            border: 2px solid #333;
+            border-radius: 8px;
+            color: #e8e8e8;
+            cursor: pointer;
+            font-size: 0.85rem;
+            font-weight: 600;
+            text-align: center;
+        }
+
+        .bvb-opt[aria-checked="true"] {
+            background: rgba(255, 122, 0, 0.18);
+            border-color: #FF7A00;
+            color: #ffffff;
+        }
+
+        /* Results */
+        .bvb-summary {
+            font-size: 1.05rem;
+            color: #f0f0f0;
+            margin-bottom: 0.5rem;
+        }
+
+        .bvb-no-winner {
+            color: #b3b3b3;
+            font-size: 0.9rem;
+            margin-bottom: 1.25rem;
+        }
+
+        .bvb-rails {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 1rem;
+        }
+
+        .bvb-card {
+            background: #242424;
+            border-radius: 10px;
+            padding: 1.25rem;
+            border-top: 4px solid #444;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .bvb-card .rail-name {
+            font-size: 1.05rem;
+            font-weight: 700;
+            color: #ffffff;
+            margin-bottom: 0.5rem;
+        }
+
+        .bvb-band {
+            display: inline-block;
+            align-self: flex-start;
+            padding: 0.25rem 0.7rem;
+            border-radius: 20px;
+            font-size: 0.78rem;
+            font-weight: 700;
+            margin-bottom: 0.6rem;
+            border: 2px solid;
+        }
+
+        .band-strong { color: #FF7A00; border-color: #FF7A00; background: rgba(255, 122, 0, 0.12); }
+        .band-workable { color: #cfcfcf; border-color: #6a6a6a; background: rgba(160, 160, 160, 0.1); }
+        .band-poor { color: #b9b9b9; border-color: #8a8a8a; background: rgba(120, 120, 120, 0.08); }
+
+        .bvb-card.is-strong { border-top-color: #FF7A00; }
+
+        .bvb-meets {
+            font-size: 0.85rem;
+            color: #d0d0d0;
+            margin-bottom: 0.6rem;
+        }
+
+        .bvb-prio-list {
+            list-style: none;
+            margin: 0 0 0.75rem;
+            padding: 0;
+        }
+
+        .bvb-prio-list li {
+            font-size: 0.84rem;
+            margin: 0.25rem 0;
+            color: #dcdcdc;
+        }
+
+        .marker {
+            font-weight: 700;
+            margin-right: 0.35rem;
+        }
+
+        .marker.met { color: #FF7A00; }
+        .marker.partial { color: #d0d0d0; }
+        .marker.missed { color: #9a9a9a; }
+
+        .bvb-explain {
+            font-size: 0.88rem;
+            color: #e6e6e6;
+            margin-bottom: 0.75rem;
+        }
+
+        .bvb-gaingive {
+            font-size: 0.82rem;
+            color: #c8c8c8;
+        }
+
+        .bvb-gaingive .gg-label {
+            color: #f0f0f0;
+            font-weight: 700;
+        }
+
+        .bvb-flags {
+            margin-top: 1.25rem;
+        }
+
+        .bvb-flags h2 {
+            color: #FF7A00;
+            font-size: 1.1rem;
+            margin-bottom: 0.6rem;
+        }
+
+        .bvb-flags ul {
+            margin: 0;
+            padding-left: 1.1rem;
+        }
+
+        .bvb-flags li {
+            color: #e0e0e0;
+            font-size: 0.88rem;
+            margin: 0.3rem 0;
+        }
+
+        .bvb-matrix-wrap {
+            overflow-x: auto;
+        }
+
+        .bvb-matrix {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 0.5rem;
+            min-width: 460px;
+        }
+
+        .bvb-matrix th, .bvb-matrix td {
+            padding: 0.6rem 0.7rem;
+            border-bottom: 1px solid #333;
+            text-align: left;
+            font-size: 0.85rem;
+        }
+
+        .bvb-matrix th {
+            color: #FF7A00;
+            font-weight: 600;
+        }
+
+        .cap-full { color: #FF7A00; font-weight: 600; }
+        .cap-partial { color: #cfcfcf; }
+        .cap-none { color: #9a9a9a; }
+
+        .bvb-note {
+            color: #b3b3b3;
+            font-size: 0.8rem;
+            margin-top: 1rem;
+            font-style: italic;
         }
 
         /* ===== ACCESSIBILITY ENHANCEMENTS (WCAG 2.1 AA) ===== */
-
-        /* 1. Improved Color Contrast (WCAG 1.4.3) */
-        .metric-label
-        .level-info span:first-child,
-        #level-description {
-            color: #b3b3b3; /* Changed from #b0b0b0 for better contrast (4.6:1) */
-        }
-
-        /* 2. Touch Targets (WCAG 2.5.5) */
-        button, a, [role="button"], input[type="button"], input[type="submit"], select .level-btn {
-            min-height: 44px;
-            min-width: 44px;
-        }
-
-        /* 3. Focus Indicators (WCAG 2.4.7) */
         *:focus-visible {
             outline: 3px solid var(--primary-orange, #FF7A00);
             outline-offset: 2px;
@@ -327,7 +385,10 @@
             box-shadow: 0 0 0 4px rgba(255, 122, 0, 0.2);
         }
 
-        /* 4. Reduced Motion (WCAG 2.3.3) */
+        button, a, [role="button"], input[type="button"], input[type="submit"], .level-btn, .bvb-opt, .lang-btn {
+            min-height: 44px;
+        }
+
         @media (prefers-reduced-motion: reduce) {
             *, *::before, *::after {
                 animation-duration: 0.01ms !important;
@@ -336,11 +397,16 @@
             }
         }
 
-        /* 5. Mobile Reflow (WCAG 1.4.10) */
+        @media (max-width: 968px) {
+            .bvb-rails { grid-template-columns: 1fr; }
+        }
+
+        @media (max-width: 768px) {
+            .bvb-fields { grid-template-columns: 1fr; }
+        }
+
         @media (max-width: 360px) {
-            body {
-                overflow-x: hidden;
-            }
+            body { overflow-x: hidden; padding: 1rem; }
         }
     </style>
     <link rel="stylesheet" href="/css/icons.css">
@@ -379,330 +445,136 @@
     <main id="main-content" class="container">
         <!-- Header -->
         <div class="header">
-            <h1>⚖️ Bitcoin vs Banking</h1>
-            <p style="color: #b0b0b0;">
-                A comprehensive comparison of costs, speed, and control
-            </p>
+            <h1 id="bvb-title">Bitcoin and banking: which rail fits?</h1>
+            <p class="subtitle" id="bvb-subtitle">Pick a situation. See which rail fits and what you give up to get it.</p>
+            <p class="core-question" id="bvb-core">Which rail fits this situation best, and what tradeoff am I accepting?</p>
+            <div class="lang-toggle" role="group" aria-label="Language">
+                <span class="lang-label" id="bvb-lang-label">Language</span>
+                <button type="button" class="lang-btn active" data-lang="en" aria-pressed="true">EN</button>
+                <button type="button" class="lang-btn" data-lang="es" aria-pressed="false">ES</button>
+            </div>
         </div>
-        
-        <!-- Level Switcher -->
+
+        <!-- Level Switcher (mount contract: ?level=) -->
         <div class="level-switcher">
             <div style="color: #b0b0b0; font-size: 0.9rem;">Complexity Level:</div>
             <div style="color: #FF7A00; font-weight: bold; font-size: 1.1rem; margin: 0.5rem 0;" id="current-level-name">Beginner Mode</div>
             <div class="level-buttons">
                 <button class="level-btn active" data-level="beginner">🌱 Beginner</button>
-                <button class="level-btn" data-level="intermediate"><span data-icon="lightning"></span> Intermediate</button>
-                <button class="level-btn" data-level="advanced"><span data-icon="tool"></span> Advanced</button>
+                <button class="level-btn" data-level="intermediate">⚡ Intermediate</button>
+                <button class="level-btn" data-level="advanced">🛠️ Advanced</button>
             </div>
             <div style="color: #b0b0b0; font-size: 0.85rem; margin-top: 0.75rem;" id="level-description">
                 Simplified comparison for newcomers
             </div>
         </div>
-        
-        <!-- Transaction Cost Calculator -->
-        <div class="calculator">
-            <h2 style="color: #FF7A00; margin-bottom: 1.5rem;"><span data-icon="money-flow"></span> Transaction Cost Calculator</h2>
-            <p style="color: #b0b0b0; margin-bottom: 1.5rem;" class="beginner-only">
-                See how much you save with Bitcoin when sending money internationally
-            </p>
-            <p style="color: #b0b0b0; margin-bottom: 1.5rem;" class="intermediate-only">
-                Compare real costs including fees, exchange rate markups, and time value
-            </p>
-            <p style="color: #b0b0b0; margin-bottom: 1.5rem;" class="advanced-only">
-                Full cost analysis including opportunity cost, capital efficiency, and settlement finality
-            </p>
-            
-            <div class="form-group">
-                <label for="amount">Amount to Send</label>
-                <input type="number" id="amount" value="1000" min="1" oninput="calculateCosts()">
-            </div>
-            
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem;">
-                <div class="form-group">
-                    <label for="from-country">From</label>
-                    <select id="from-country" onchange="calculateCosts()">
-                        <option value="US">United States</option>
-                        <option value="UK">United Kingdom</option>
-                        <option value="EU">European Union</option>
-                        <option value="CA">Canada</option>
-                        <option value="AU">Australia</option>
-                    </select>
-                </div>
-                
-                <div class="form-group">
-                    <label for="to-country">To</label>
-                    <select id="to-country" onchange="calculateCosts()">
-                        <option value="MX">Mexico</option>
-                        <option value="PH">Philippines</option>
-                        <option value="IN">India</option>
-                        <option value="NG">Nigeria</option>
-                        <option value="BR">Brazil</option>
-                    </select>
-                </div>
-            </div>
-            
-            <!-- Results -->
-            <div class="metric-row" style="margin-top: 2rem;">
-                <div class="metric-card bitcoin">
-                    <div class="metric-label">Bitcoin Cost</div>
-                    <div class="metric-value num-fade" id="btc-cost">$2.50</div>
-                    <div class="metric-detail">
-                        <div>Fee: <span id="btc-fee">$2.50</span></div>
-                        <div>Time: <span id="btc-time">10 minutes</span></div>
-                        <div>You send: <span id="btc-received">$997.50</span></div>
+
+        <!-- Situation form -->
+        <div class="bvb-section">
+            <h2 data-i18n="situation_heading">Describe your situation</h2>
+            <form id="bvb-form" autocomplete="off" onsubmit="return false;">
+                <div class="bvb-group-title" data-i18n="group_transfer">The transfer</div>
+                <div class="bvb-fields">
+                    <div class="bvb-field">
+                        <label class="bvb-label" for="bvb-amount" data-i18n="in_amount">Amount</label>
+                        <span class="bvb-help" id="help-amount" data-i18n="help_amount">Illustrative only. Used to weigh the comparison, not to calculate fees or prices.</span>
+                        <input type="number" id="bvb-amount" value="1000" min="1" step="1" aria-describedby="help-amount">
+                    </div>
+                    <div class="bvb-field">
+                        <label class="bvb-label" data-i18n="in_scope">Is this within one country or across borders?</label>
+                        <div class="bvb-toggle" role="radiogroup" aria-label="scope" data-input="scope"></div>
+                    </div>
+                    <div class="bvb-field">
+                        <label class="bvb-label" data-i18n="in_urgency">How soon does it need to arrive?</label>
+                        <div class="bvb-toggle" role="radiogroup" aria-label="urgency" data-input="urgency"></div>
+                    </div>
+                    <div class="bvb-field lvl-int-up">
+                        <label class="bvb-label" data-i18n="in_horizon">Spend soon or hold for the long term?</label>
+                        <div class="bvb-toggle" role="radiogroup" aria-label="horizon" data-input="horizon"></div>
                     </div>
                 </div>
-                
-                <div class="metric-card banking">
-                    <div class="metric-label">Traditional Banking Cost</div>
-                    <div class="metric-value" id="bank-cost">$75.00</div>
-                    <div class="metric-detail">
-                        <div>Fees: <span id="bank-fee">$45</span></div>
-                        <div>FX markup: <span id="bank-fx">$30</span></div>
-                        <div>Time: <span id="bank-time">3-5 days</span></div>
-                        <div>They receive: <span id="bank-received">$925</span></div>
+
+                <div class="bvb-group-title" data-i18n="group_need">What you need</div>
+                <div class="bvb-fields">
+                    <div class="bvb-field lvl-int-up">
+                        <label class="bvb-label" data-i18n="in_reversibility">Do you need to be able to undo a payment?</label>
+                        <div class="bvb-toggle" role="radiogroup" aria-label="reversibility" data-input="reversibility"></div>
+                    </div>
+                    <div class="bvb-field">
+                        <label class="bvb-label" data-i18n="in_selfcustody">Do you want to hold the keys yourself?</label>
+                        <div class="bvb-toggle" role="radiogroup" aria-label="selfcustody" data-input="selfcustody"></div>
+                    </div>
+                    <div class="bvb-field lvl-int-up">
+                        <label class="bvb-label" data-i18n="in_privacy">How private does this need to be?</label>
+                        <div class="bvb-toggle" role="radiogroup" aria-label="privacy" data-input="privacy"></div>
+                    </div>
+                    <div class="bvb-field lvl-int-up">
+                        <label class="bvb-label" data-i18n="in_trust">How much do you trust the institutions involved?</label>
+                        <div class="bvb-toggle" role="radiogroup" aria-label="trust" data-input="trust"></div>
+                    </div>
+                    <div class="bvb-field lvl-int-up">
+                        <label class="bvb-label" data-i18n="in_polrisk">Risk of account freezes or capital controls?</label>
+                        <div class="bvb-toggle" role="radiogroup" aria-label="polrisk" data-input="polrisk"></div>
+                    </div>
+                    <div class="bvb-field lvl-int-up">
+                        <label class="bvb-label" data-i18n="in_techcomfort">How comfortable are you managing keys and backups?</label>
+                        <div class="bvb-toggle" role="radiogroup" aria-label="techcomfort" data-input="techcomfort"></div>
                     </div>
                 </div>
+            </form>
+        </div>
+
+        <!-- Results -->
+        <div class="bvb-section">
+            <h2 data-i18n="results_heading">For this situation</h2>
+            <p class="bvb-summary" id="bvb-summary" aria-live="polite"></p>
+            <p class="bvb-no-winner" data-i18n="no_winner_note">There is no single best rail. The right choice depends on your situation.</p>
+            <div class="bvb-rails" id="bvb-rails"></div>
+            <div class="bvb-flags" id="bvb-flags" hidden>
+                <h2 data-i18n="flags_heading">Things to keep in mind</h2>
+                <ul id="bvb-flags-list"></ul>
             </div>
-            
-            <div style="text-align: center; margin-top: 1.5rem; padding: 1rem; background: rgba(0, 200, 83, 0.1); border-radius: 8px;">
-                <strong style="color: #00c853;">Savings with Bitcoin: <span id="savings">$72.50 (7.25%)</span></strong>
+            <p class="bvb-note" data-i18n="illustrative_note">Figures here are illustrative, for learning only. This tool makes no price or fee claims.</p>
+        </div>
+
+        <!-- Capability matrix (advanced) -->
+        <div class="bvb-section lvl-adv-only">
+            <h2 data-i18n="matrix_heading">How each rail compares (the reasoning)</h2>
+            <div class="bvb-matrix-wrap">
+                <table class="bvb-matrix" id="bvb-matrix"></table>
             </div>
         </div>
-        
-        <!-- Feature Comparison Table -->
-        <div class="comparison-section">
-            <h2 class="section-title">Feature Comparison</h2>
-            
-            <table class="feature-comparison">
-                <thead>
-                    <tr>
-                        <th style="width: 40%;">Feature</th>
-                        <th style="text-align: center;">Bitcoin</th>
-                        <th style="text-align: center;">Traditional Banking</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td><strong>24/7 Availability</strong></td>
-                        <td style="text-align: center;"><span class="check">✓</span> Always</td>
-                        <td style="text-align: center;"><span class="cross">✗</span> Business hours only</td>
-                    </tr>
-                    <tr>
-                        <td><strong>International Transfers</strong></td>
-                        <td style="text-align: center;"><span class="check">✓</span> 10-60 minutes</td>
-                        <td style="text-align: center;"><span class="cross">✗</span> 3-5 business days</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Transaction Fees</strong></td>
-                        <td style="text-align: center;"><span class="check">✓</span> $1-10 flat</td>
-                        <td style="text-align: center;"><span class="cross">✗</span> 3-7% + fees</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Account Required</strong></td>
-                        <td style="text-align: center;"><span class="check">✓</span> No</td>
-                        <td style="text-align: center;"><span class="cross">✗</span> Yes (ID, address, etc.)</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Censorship Resistance</strong></td>
-                        <td style="text-align: center;"><span class="check">✓</span> Hard to block</td>
-                        <td style="text-align: center;"><span class="cross">✗</span> Can freeze accounts</td>
-                    </tr>
-                    <tr>
-                        <td><strong>You Control Funds</strong></td>
-                        <td style="text-align: center;"><span class="check">✓</span> Full custody</td>
-                        <td style="text-align: center;"><span class="cross">✗</span> Bank controls</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Inflation Protection</strong></td>
-                        <td style="text-align: center;"><span class="check">✓</span> Fixed 21M supply</td>
-                        <td style="text-align: center;"><span class="cross">✗</span> Currency devaluation</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Privacy</strong></td>
-                        <td style="text-align: center;"><span class="partial">~</span> Pseudonymous</td>
-                        <td style="text-align: center;"><span class="cross">✗</span> Full surveillance</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Ease of Use</strong></td>
-                        <td style="text-align: center;"><span class="partial">~</span> Learning curve</td>
-                        <td style="text-align: center;"><span class="check">✓</span> Familiar</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Customer Support</strong></td>
-                        <td style="text-align: center;"><span class="cross">✗</span> Community only</td>
-                        <td style="text-align: center;"><span class="check">✓</span> Phone/email support</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Chargebacks</strong></td>
-                        <td style="text-align: center;"><span class="cross">✗</span> Irreversible</td>
-                        <td style="text-align: center;"><span class="check">✓</span> Yes (60-90 days)</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Insurance</strong></td>
-                        <td style="text-align: center;"><span class="cross">✗</span> Self-responsible</td>
-                        <td style="text-align: center;"><span class="check">✓</span> FDIC insured (up to $250k)</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        
-        <!-- Detailed Comparison -->
-        <div class="comparison-grid">
-            <div class="column bitcoin">
-                <div class="column-header">
-                    <span class="column-icon">₿</span>
-                    <span class="column-title">Bitcoin</span>
-                </div>
-                
-                <div class="pros-cons">
-                    <div class="pros-list">
-                        <h4>✓ Advantages</h4>
-                        <ul>
-                            <li>Complete financial sovereignty</li>
-                            <li>No intermediaries or permissions needed</li>
-                            <li>Works 24/7/365</li>
-                            <li>Global, borderless transfers</li>
-                            <li>Fixed supply (anti-inflation)</li>
-                            <li>Programmable money</li>
-                            <li>Transparent monetary policy</li>
-                            <li>Low fees for any amount</li>
-                            <li>Fast settlement (10-60 min)</li>
-                        </ul>
-                    </div>
-                    
-                    <div class="cons-list">
-                        <h4>✗ Challenges</h4>
-                        <ul>
-                            <li>Price volatility</li>
-                            <li>Learning curve required</li>
-                            <li>You're responsible for security</li>
-                            <li>Irreversible transactions</li>
-                            <li>Limited merchant adoption</li>
-                            <li>Regulatory uncertainty</li>
-                            <li>No customer support line</li>
-                            <li>Can't recover lost keys</li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="column banking">
-                <div class="column-header">
-                    <span class="column-icon">🏦</span>
-                    <span class="column-title">Traditional Banking</span>
-                </div>
-                
-                <div class="pros-cons">
-                    <div class="pros-list">
-                        <h4>✓ Advantages</h4>
-                        <ul>
-                            <li>Familiar and easy to use</li>
-                            <li>Customer support available</li>
-                            <li>FDIC insurance (up to $250k)</li>
-                            <li>Chargebacks possible</li>
-                            <li>Wide merchant acceptance</li>
-                            <li>Established legal framework</li>
-                            <li>Stable currency value</li>
-                            <li>Account recovery options</li>
-                        </ul>
-                    </div>
-                    
-                    <div class="cons-list">
-                        <h4>✗ Challenges</h4>
-                        <ul>
-                            <li>Bank controls your money</li>
-                            <li>Can freeze/seize accounts</li>
-                            <li>High international fees (3-7%)</li>
-                            <li>Slow transfers (3-5 days)</li>
-                            <li>Only during business hours</li>
-                            <li>Requires extensive KYC</li>
-                            <li>Currency devaluation risk</li>
-                            <li>Surveillance of transactions</li>
-                            <li>Geographic restrictions</li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <!-- Use Cases -->
-        <div class="comparison-section">
-            <h2 class="section-title">Best Use Cases</h2>
-            
-            <div class="comparison-grid">
-                <div style="background: #1a1a1a; padding: 2rem; border-radius: 12px;">
-                    <h3 style="color: #FF7A00; margin-bottom: 1rem;">Choose Bitcoin For:</h3>
-                    <ul style="color: #d0d0d0; line-height: 2;">
-                        <li><span data-icon="globe"></span> International remittances</li>
-                        <li><span data-icon="money"></span> Large value transfers</li>
-                        <li><span data-icon="lock"></span> Wealth preservation</li>
-                        <li><span data-icon="lightning"></span> Urgent payments</li>
-                        <li>🚫 Operating in restrictive regimes</li>
-                        <li><span data-icon="trending-up"></span> Long-term savings</li>
-                        <li>🆓 Financial sovereignty</li>
-                        <li><span data-icon="shield"></span> Protection from inflation</li>
-                    </ul>
-                </div>
-                
-                <div style="background: #1a1a1a; padding: 2rem; border-radius: 12px;">
-                    <h3 style="color: #2196f3; margin-bottom: 1rem;">Choose Banking For:</h3>
-                    <ul style="color: #d0d0d0; line-height: 2;">
-                        <li>🏪 Daily spending</li>
-                        <li>💳 Credit card benefits</li>
-                        <li><span data-icon="refresh"></span> Recurring payments</li>
-                        <li><span data-icon="shield"></span> Dispute resolution needs</li>
-                        <li>🏠 Loans and mortgages</li>
-                        <li>💼 Business operations</li>
-                        <li>📋 Tax reporting simplicity</li>
-                        <li>👥 Family accounts</li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-        
-        <!-- Conclusion -->
-        <div style="background: #1a1a1a; padding: 2rem; border-radius: 12px; margin: 3rem 0; text-align: center;">
-            <h2 style="color: #FF7A00; margin-bottom: 1rem;">The Best Approach?</h2>
-            <p style="color: #d0d0d0; max-width: 800px; margin: 0 auto; line-height: 1.8;">
-                Most people benefit from using <strong style="color: #FF7A00;">both systems</strong>. 
-                Use traditional banking for daily expenses and familiarity, while using Bitcoin for 
-                savings, international transfers, and protecting against inflation. As you gain 
-                experience with Bitcoin, you can gradually increase your allocation based on your 
-                needs and risk tolerance.
-            </p>
-        </div>
-        
+
         <!-- Back Link -->
-        <div style="text-align: center; margin: 3rem 0;">
-            <a href="../index.html" style="color: #FF7A00; text-decoration: none;">← Back to Home</a>
+        <div style="text-align: center; margin: 2.5rem 0;">
+            <a href="../index.html" style="color: #FF7A00; text-decoration: none;">&larr; Back to Home</a>
         </div>
-    </div>
-    
+    </main>
+
     <script>
         // Multi-level system
         const urlParams = new URLSearchParams(window.location.search);
         const currentLevel = urlParams.get('level') || 'beginner';
         document.body.classList.add(`level-${currentLevel}`);
-        
+
         const LEVEL_CONFIG = {
-            beginner: { 
+            beginner: {
                 name: "Beginner Mode",
                 description: "Simplified comparison for newcomers"
             },
-            intermediate: { 
+            intermediate: {
                 name: "Intermediate Mode",
                 description: "Detailed analysis with technical context"
             },
-            advanced: { 
+            advanced: {
                 name: "Advanced Mode",
                 description: "Complete economic analysis with trade-offs"
             }
         };
-        
+
         document.getElementById('current-level-name').textContent = LEVEL_CONFIG[currentLevel].name;
         document.getElementById('level-description').textContent = LEVEL_CONFIG[currentLevel].description;
-        
+
         document.querySelectorAll('.level-btn').forEach(btn => {
             if (btn.dataset.level === currentLevel) {
                 btn.classList.add('active');
@@ -714,46 +586,601 @@
                 window.location.href = url.toString();
             });
         });
-        
-        function calculateCosts() {
-            const amount = parseFloat(document.getElementById('amount').value) || 1000;
-            
-            // Bitcoin costs (simplified)
-            const btcFee = 2.50; // Approximate USD fee
-            const btcTime = '10-60 minutes';
-            const btcReceived = amount - btcFee;
-            
-            // Banking costs (realistic averages)
-            const bankFeePercent = 0.03; // 3%
-            const bankFixedFee = 15; // $15 fixed fee
-            const bankFxMarkup = amount * 0.03; // 3% FX markup
-            const bankTotalFee = (amount * bankFeePercent) + bankFixedFee + bankFxMarkup;
-            const bankReceived = amount - bankTotalFee;
-            const bankTime = '3-5 business days';
-            
-            // Savings
-            const savings = bankTotalFee - btcFee;
-            const savingsPercent = (savings / amount) * 100;
-            
-            // Update Bitcoin
-            document.getElementById('btc-cost').textContent = `$${btcFee.toFixed(2)}`;
-            document.getElementById('btc-fee').textContent = `$${btcFee.toFixed(2)}`;
-            document.getElementById('btc-time').textContent = btcTime;
-            document.getElementById('btc-received').textContent = `$${btcReceived.toFixed(2)}`;
-            
-            // Update Banking
-            document.getElementById('bank-cost').textContent = `$${bankTotalFee.toFixed(2)}`;
-            document.getElementById('bank-fee').textContent = `$${((amount * bankFeePercent) + bankFixedFee).toFixed(2)}`;
-            document.getElementById('bank-fx').textContent = `$${bankFxMarkup.toFixed(2)}`;
-            document.getElementById('bank-time').textContent = bankTime;
-            document.getElementById('bank-received').textContent = `$${bankReceived.toFixed(2)}`;
-            
-            // Update savings
-            document.getElementById('savings').textContent = `$${savings.toFixed(2)} (${savingsPercent.toFixed(2)}%)`;
+    </script>
+
+    <script id="bvb-sim">
+    (function () {
+        "use strict";
+
+        // Eleven capability dimensions.
+        var DIMENSIONS = [
+            "reversibility", "familiar_ux", "short_term", "settlement_finality",
+            "self_custody", "censorship_resistance", "borderless", "monetary_policy",
+            "privacy", "recourse", "low_cost_cross_border"
+        ];
+
+        // V1 rails. Cash is intentionally out of v1 (see spec future-extension note).
+        var RAILS = ["bank", "btc_self", "btc_provider"];
+
+        // Fixed, honest capability matrix: full | partial | none.
+        var CAPABILITY = {
+            bank: {
+                reversibility: "full", familiar_ux: "full", short_term: "full",
+                settlement_finality: "partial", self_custody: "none", censorship_resistance: "none",
+                borderless: "partial", monetary_policy: "none", privacy: "none",
+                recourse: "full", low_cost_cross_border: "partial"
+            },
+            btc_self: {
+                reversibility: "none", familiar_ux: "partial", short_term: "partial",
+                settlement_finality: "full", self_custody: "full", censorship_resistance: "full",
+                borderless: "full", monetary_policy: "full", privacy: "partial",
+                recourse: "none", low_cost_cross_border: "full"
+            },
+            btc_provider: {
+                reversibility: "partial", familiar_ux: "full", short_term: "full",
+                settlement_finality: "partial", self_custody: "none", censorship_resistance: "partial",
+                borderless: "full", monetary_policy: "full", privacy: "none",
+                recourse: "partial", low_cost_cross_border: "full"
+            }
+        };
+
+        var ILLUSTRATIVE_THRESHOLD = 5000;
+
+        // EN/ES dictionary. Keys must stay in parity (enforced by test).
+        var STRINGS = {
+            en: {
+                page_title: "Bitcoin and banking: which rail fits?",
+                page_subtitle: "Pick a situation. See which rail fits and what you give up to get it.",
+                core_question: "Which rail fits this situation best, and what tradeoff am I accepting?",
+                lang_label: "Language",
+                situation_heading: "Describe your situation",
+                group_transfer: "The transfer",
+                group_need: "What you need",
+                results_heading: "For this situation",
+                no_winner_note: "There is no single best rail. The right choice depends on your situation.",
+                flags_heading: "Things to keep in mind",
+                matrix_heading: "How each rail compares (the reasoning)",
+                illustrative_note: "Figures here are illustrative, for learning only. This tool makes no price or fee claims.",
+                in_amount: "Amount",
+                help_amount: "Illustrative only. Used to weigh the comparison, not to calculate fees or prices.",
+                in_scope: "Is this within one country or across borders?",
+                in_urgency: "How soon does it need to arrive?",
+                in_horizon: "Spend soon or hold for the long term?",
+                in_reversibility: "Do you need to be able to undo a payment?",
+                in_selfcustody: "Do you want to hold the keys yourself?",
+                in_privacy: "How private does this need to be?",
+                in_trust: "How much do you trust the institutions involved?",
+                in_polrisk: "Risk of account freezes or capital controls?",
+                in_techcomfort: "How comfortable are you managing keys and backups?",
+                opt_domestic: "Same country", opt_cross_border: "Across borders",
+                opt_days: "Can wait days", opt_within_day: "Within a day", opt_now: "Right now",
+                opt_spend_soon: "Spend soon", opt_months: "Hold months", opt_years: "Hold years",
+                opt_not: "Not important", opt_nice: "Nice to have", opt_essential: "Essential",
+                opt_low: "Low", opt_med: "Medium", opt_high: "High",
+                opt_trust: "I trust them", opt_mixed: "Mixed", opt_distrust: "I do not trust them",
+                opt_new: "New to this", opt_some: "Some experience", opt_comfortable: "Very comfortable",
+                rail_bank: "Bank or card",
+                rail_btc_self: "Bitcoin, self-custody",
+                rail_btc_provider: "Bitcoin, with a service provider",
+                band_strong: "Strong fit", band_workable: "Workable", band_poor: "Poor fit",
+                meets_count: "Meets {n} of your {m} priorities",
+                meets_partial: "plus {k} partially",
+                meets_none: "No strong priorities set yet. Adjust the situation above.",
+                marker_met: "meets", marker_partial: "partly", marker_missed: "not met",
+                gain_label: "What you gain", give_up_label: "What you give up",
+                gg_none: "nothing notable here",
+                summary_lead: "For this situation:",
+                summary_join: "; ",
+                summary_rail_band: "{rail}: {band}",
+                explain_both: "{rail} fits here because it covers {gains}. You give up {gives}.",
+                explain_gains: "{rail} fits here because it covers {gains}.",
+                explain_gives: "{rail} is a weak fit here because it cannot cover {gives}.",
+                explain_neutral: "{rail} neither stands out nor falls short for this situation.",
+                flag_freeze: "On the bank or card rail, accounts can be frozen under capital controls or disputes.",
+                flag_no_recovery: "Holding your own keys means no one can recover them for you if you lose them.",
+                flag_no_chargeback: "On-chain Bitcoin payments cannot be reversed if something goes wrong.",
+                cap_full: "strong", cap_partial: "partial", cap_none: "no",
+                matrix_dimension: "What matters", list_join: "and",
+                dim_reversibility: "the ability to undo a payment",
+                dim_familiar_ux: "familiar everyday use",
+                dim_short_term: "short-term convenience",
+                dim_settlement_finality: "final settlement",
+                dim_self_custody: "holding your own keys",
+                dim_censorship_resistance: "censorship resistance",
+                dim_borderless: "borderless transfer",
+                dim_monetary_policy: "a predictable money supply",
+                dim_privacy: "privacy from third parties",
+                dim_recourse: "regulated recourse and support",
+                dim_low_cost_cross_border: "low cost across borders"
+            },
+            es: {
+                page_title: "Bitcoin y banca: ¿qué vía encaja?",
+                page_subtitle: "Elige una situación. Mira qué vía encaja y qué cedes a cambio.",
+                core_question: "¿Qué vía encaja mejor en esta situación y qué compensación acepto?",
+                lang_label: "Idioma",
+                situation_heading: "Describe tu situación",
+                group_transfer: "La transferencia",
+                group_need: "Lo que necesitas",
+                results_heading: "Para esta situación",
+                no_winner_note: "No hay una sola vía mejor. La elección correcta depende de tu situación.",
+                flags_heading: "Cosas a tener en cuenta",
+                matrix_heading: "Cómo se compara cada vía (el razonamiento)",
+                illustrative_note: "Las cifras aquí son ilustrativas, solo para aprender. Esta herramienta no afirma precios ni comisiones.",
+                in_amount: "Monto",
+                help_amount: "Solo ilustrativo. Sirve para ponderar la comparación, no para calcular comisiones ni precios.",
+                in_scope: "¿Es dentro de un país o entre países?",
+                in_urgency: "¿Qué tan pronto debe llegar?",
+                in_horizon: "¿Gastar pronto o guardar a largo plazo?",
+                in_reversibility: "¿Necesitas poder revertir un pago?",
+                in_selfcustody: "¿Quieres custodiar tú mismo las llaves?",
+                in_privacy: "¿Qué tan privado necesita ser?",
+                in_trust: "¿Cuánto confías en las instituciones involucradas?",
+                in_polrisk: "¿Riesgo de congelamiento de cuentas o controles de capital?",
+                in_techcomfort: "¿Qué tan cómodo te sientes gestionando llaves y respaldos?",
+                opt_domestic: "Mismo país", opt_cross_border: "Entre países",
+                opt_days: "Puede esperar días", opt_within_day: "En un día", opt_now: "Ahora mismo",
+                opt_spend_soon: "Gastar pronto", opt_months: "Guardar meses", opt_years: "Guardar años",
+                opt_not: "No importa", opt_nice: "Estaría bien", opt_essential: "Imprescindible",
+                opt_low: "Bajo", opt_med: "Medio", opt_high: "Alto",
+                opt_trust: "Confío", opt_mixed: "Dudo", opt_distrust: "No confío",
+                opt_new: "Soy nuevo", opt_some: "Algo de experiencia", opt_comfortable: "Muy cómodo",
+                rail_bank: "Banco o tarjeta",
+                rail_btc_self: "Bitcoin, autocustodia",
+                rail_btc_provider: "Bitcoin, con un proveedor de servicio",
+                band_strong: "Encaja bien", band_workable: "Funcional", band_poor: "Encaja mal",
+                meets_count: "Cumple {n} de tus {m} prioridades",
+                meets_partial: "y {k} en parte",
+                meets_none: "Aún no hay prioridades marcadas. Ajusta la situación arriba.",
+                marker_met: "cumple", marker_partial: "en parte", marker_missed: "no cumple",
+                gain_label: "Lo que ganas", give_up_label: "Lo que cedes",
+                gg_none: "nada destacable aquí",
+                summary_lead: "Para esta situación:",
+                summary_join: "; ",
+                summary_rail_band: "{rail}: {band}",
+                explain_both: "{rail} encaja aquí porque cubre {gains}. Cedes {gives}.",
+                explain_gains: "{rail} encaja aquí porque cubre {gains}.",
+                explain_gives: "{rail} encaja mal aquí porque no puede cubrir {gives}.",
+                explain_neutral: "{rail} ni destaca ni se queda corta para esta situación.",
+                flag_freeze: "En la vía de banco o tarjeta, las cuentas pueden congelarse por controles de capital o disputas.",
+                flag_no_recovery: "Custodiar tus llaves significa que nadie puede recuperarlas por ti si las pierdes.",
+                flag_no_chargeback: "Los pagos de Bitcoin en cadena no se pueden revertir si algo sale mal.",
+                cap_full: "fuerte", cap_partial: "parcial", cap_none: "no",
+                matrix_dimension: "Qué importa", list_join: "y",
+                dim_reversibility: "poder revertir un pago",
+                dim_familiar_ux: "el uso cotidiano familiar",
+                dim_short_term: "la comodidad inmediata",
+                dim_settlement_finality: "la liquidación final",
+                dim_self_custody: "custodiar tus llaves",
+                dim_censorship_resistance: "la resistencia a la censura",
+                dim_borderless: "la transferencia sin fronteras",
+                dim_monetary_policy: "una emisión predecible",
+                dim_privacy: "la privacidad frente a terceros",
+                dim_recourse: "el recurso regulado y el soporte",
+                dim_low_cost_cross_border: "el bajo costo entre países"
+            }
+        };
+
+        // Option ordering per input.
+        var OPTIONS = {
+            scope: ["domestic", "cross_border"],
+            urgency: ["days", "within_day", "now"],
+            horizon: ["spend_soon", "months", "years"],
+            reversibility: ["not", "nice", "essential"],
+            selfcustody: ["not", "nice", "essential"],
+            privacy: ["low", "med", "high"],
+            trust: ["trust", "mixed", "distrust"],
+            polrisk: ["low", "med", "high"],
+            techcomfort: ["new", "some", "comfortable"]
+        };
+
+        // Map an option value to its dictionary key.
+        var OPT_KEY = {
+            domestic: "opt_domestic", cross_border: "opt_cross_border",
+            days: "opt_days", within_day: "opt_within_day", now: "opt_now",
+            spend_soon: "opt_spend_soon", months: "opt_months", years: "opt_years",
+            not: "opt_not", nice: "opt_nice", essential: "opt_essential",
+            low: "opt_low", med: "opt_med", high: "opt_high",
+            trust: "opt_trust", mixed: "opt_mixed", distrust: "opt_distrust",
+            new: "opt_new", some: "opt_some", comfortable: "opt_comfortable"
+        };
+
+        function defaultState() {
+            return {
+                amount: 1000,
+                scope: "domestic",
+                urgency: "days",
+                horizon: "spend_soon",
+                reversibility: "not",
+                selfcustody: "not",
+                privacy: "low",
+                trust: "trust",
+                polrisk: "low",
+                techcomfort: "new"
+            };
         }
-        
-        // Initialize
-        calculateCosts();
+
+        var STATE = defaultState();
+        var LANG = "en";
+
+        function getLang() {
+            try {
+                var p = new URLSearchParams(window.location.search).get("lang");
+                if (p === "es" || p === "en") { return p; }
+                var s = window.localStorage ? window.localStorage.getItem("bsa_lang") : null;
+                if (s === "es" || s === "en") { return s; }
+            } catch (e) { /* default below */ }
+            return "en";
+        }
+
+        function t(key, vars) {
+            var table = STRINGS[LANG] || STRINGS.en;
+            var s = (key in table) ? table[key] : (STRINGS.en[key] || key);
+            if (vars) {
+                Object.keys(vars).forEach(function (k) {
+                    s = s.split("{" + k + "}").join(String(vars[k]));
+                });
+            }
+            return s;
+        }
+
+        function dimLabel(dim) { return t("dim_" + dim); }
+
+        function joinList(labels) {
+            if (labels.length === 0) { return t("gg_none"); }
+            if (labels.length === 1) { return labels[0]; }
+            var join = t("list_join");
+            if (labels.length === 2) { return labels[0] + " " + join + " " + labels[1]; }
+            return labels.slice(0, -1).join(", ") + " " + join + " " + labels[labels.length - 1];
+        }
+
+        // Build the set of active priorities from a situation state.
+        // Returns { dim: "matters" | "essential" }.
+        function deriveActivePriorities(state) {
+            var pri = {};
+            function set(dim, imp) {
+                if (pri[dim] === "essential") { return; }
+                if (imp === "essential" || !pri[dim]) { pri[dim] = imp; }
+            }
+            var amount = (typeof state.amount === "number" && isFinite(state.amount) && state.amount > 0) ? state.amount : 1000;
+
+            if (state.reversibility === "nice") { set("reversibility", "matters"); }
+            if (state.reversibility === "essential") { set("reversibility", "essential"); }
+
+            if (state.selfcustody === "nice") { set("self_custody", "matters"); }
+            if (state.selfcustody === "essential") { set("self_custody", "essential"); }
+            if (state.selfcustody === "nice" || state.selfcustody === "essential") {
+                set("censorship_resistance", "matters");
+                set("settlement_finality", "matters");
+            }
+
+            if (state.privacy === "med") { set("privacy", "matters"); }
+            if (state.privacy === "high") { set("privacy", "essential"); }
+
+            if (state.polrisk === "med") { set("censorship_resistance", "matters"); set("self_custody", "matters"); }
+            if (state.polrisk === "high") { set("censorship_resistance", "essential"); set("self_custody", "essential"); }
+
+            if (state.trust === "mixed") { set("self_custody", "matters"); set("settlement_finality", "matters"); }
+            if (state.trust === "distrust") { set("self_custody", "essential"); set("settlement_finality", "essential"); }
+
+            if (state.scope === "cross_border") {
+                set("borderless", "matters");
+                set("low_cost_cross_border", amount >= ILLUSTRATIVE_THRESHOLD ? "essential" : "matters");
+            }
+
+            if (state.urgency === "within_day") { set("short_term", "matters"); }
+            if (state.urgency === "now") { set("short_term", "essential"); }
+
+            if (state.horizon === "spend_soon") { set("familiar_ux", "matters"); set("short_term", "matters"); }
+            if (state.horizon === "years") { set("monetary_policy", "essential"); }
+
+            if (amount >= ILLUSTRATIVE_THRESHOLD) { set("settlement_finality", "matters"); }
+
+            if (state.techcomfort === "new") { set("familiar_ux", "matters"); set("short_term", "matters"); }
+
+            return pri;
+        }
+
+        // Score one rail against the active priorities.
+        function scoreRail(railKey, priorities) {
+            var cap = CAPABILITY[railKey];
+            var dims = Object.keys(priorities);
+            var m = dims.length;
+            var met = 0, partial = 0, missed = 0;
+            var mattersTotal = 0, mattersMet = 0;
+            var essentialTotal = 0, essentialMetFull = 0;
+            var essentialMiss = false, essentialPartial = false;
+            var metDims = [], partialDims = [], missedDims = [];
+
+            dims.forEach(function (dim) {
+                var imp = priorities[dim];
+                var c = cap[dim];
+                if (imp === "essential") { essentialTotal++; } else { mattersTotal++; }
+                if (c === "full") {
+                    met++; metDims.push(dim);
+                    if (imp === "essential") { essentialMetFull++; } else { mattersMet++; }
+                } else if (c === "partial") {
+                    partial++; partialDims.push(dim);
+                    if (imp === "essential") { essentialPartial = true; }
+                } else {
+                    missed++; missedDims.push(dim);
+                    if (imp === "essential") { essentialMiss = true; }
+                }
+            });
+
+            var band;
+            if (m === 0) {
+                band = "workable";
+            } else if (essentialMiss) {
+                band = "poor";
+            } else if (essentialPartial) {
+                band = "workable";
+            } else {
+                var majorityMatters = (mattersTotal === 0) || (mattersMet * 2 >= mattersTotal);
+                var allEssentialFull = (essentialTotal === 0) || (essentialMetFull === essentialTotal);
+                band = (majorityMatters && allEssentialFull) ? "strong" : "workable";
+            }
+
+            return {
+                rail: railKey, band: band, m: m, n: met, partial: partial, missed: missed,
+                metDims: metDims, partialDims: partialDims, missedDims: missedDims,
+                essentialMiss: essentialMiss
+            };
+        }
+
+        var BAND_RANK = { strong: 3, workable: 2, poor: 1 };
+
+        // Rank all rails for a state. Pure: does not touch the DOM.
+        function rankRails(state) {
+            var priorities = deriveActivePriorities(state);
+            var scored = RAILS.map(function (r) { return scoreRail(r, priorities); });
+            scored.sort(function (a, b) {
+                if (BAND_RANK[b.band] !== BAND_RANK[a.band]) { return BAND_RANK[b.band] - BAND_RANK[a.band]; }
+                if (b.n !== a.n) { return b.n - a.n; }
+                var aMiss = a.essentialMiss ? 1 : 0, bMiss = b.essentialMiss ? 1 : 0;
+                return aMiss - bMiss;
+            });
+            return { priorities: priorities, scored: scored };
+        }
+
+        // Risk flags for the situation. Returns an array of dictionary keys.
+        function buildFlags(state) {
+            var flags = [];
+            if (state.polrisk === "med" || state.polrisk === "high") { flags.push("flag_freeze"); }
+            if (state.selfcustody === "essential" && state.techcomfort === "new") { flags.push("flag_no_recovery"); }
+            if (state.reversibility === "nice" || state.reversibility === "essential") { flags.push("flag_no_chargeback"); }
+            return flags;
+        }
+
+        function buildExplanation(scored) {
+            var rail = t("rail_" + scored.rail);
+            var gains = scored.metDims.slice(0, 2).map(dimLabel);
+            var gives = scored.missedDims.slice(0, 2).map(dimLabel);
+            if (gains.length && gives.length) {
+                return t("explain_both", { rail: rail, gains: joinList(gains), gives: joinList(gives) });
+            }
+            if (gains.length) { return t("explain_gains", { rail: rail, gains: joinList(gains) }); }
+            if (gives.length) { return t("explain_gives", { rail: rail, gives: joinList(gives) }); }
+            return t("explain_neutral", { rail: rail });
+        }
+
+        // ---- expose pure logic for tests (harmless in production) ----
+        window.BVB = {
+            DIMENSIONS: DIMENSIONS, RAILS: RAILS, CAPABILITY: CAPABILITY, STRINGS: STRINGS,
+            OPTIONS: OPTIONS, ILLUSTRATIVE_THRESHOLD: ILLUSTRATIVE_THRESHOLD,
+            defaultState: defaultState, deriveActivePriorities: deriveActivePriorities,
+            scoreRail: scoreRail, rankRails: rankRails, buildFlags: buildFlags,
+            setLang: function (l) { LANG = (l === "es") ? "es" : "en"; }, getState: function () { return STATE; },
+            setInput: function (name, value) { applyInput(name, value); }
+        };
+
+        // ---------------- DOM rendering ----------------
+
+        function el(tag, cls, text) {
+            var n = document.createElement(tag);
+            if (cls) { n.className = cls; }
+            if (text != null) { n.textContent = text; }
+            return n;
+        }
+
+        function buildToggles() {
+            document.querySelectorAll(".bvb-toggle[data-input]").forEach(function (group) {
+                var name = group.getAttribute("data-input");
+                group.innerHTML = "";
+                OPTIONS[name].forEach(function (val) {
+                    var b = el("button", "bvb-opt", t(OPT_KEY[val]));
+                    b.type = "button";
+                    b.setAttribute("role", "radio");
+                    b.setAttribute("data-value", val);
+                    var checked = STATE[name] === val;
+                    b.setAttribute("aria-checked", checked ? "true" : "false");
+                    b.addEventListener("click", function () { applyInput(name, val); });
+                    b.addEventListener("keydown", function (e) {
+                        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); applyInput(name, val); }
+                    });
+                    group.appendChild(b);
+                });
+            });
+        }
+
+        function syncToggleState() {
+            document.querySelectorAll(".bvb-toggle[data-input]").forEach(function (group) {
+                var name = group.getAttribute("data-input");
+                group.querySelectorAll(".bvb-opt").forEach(function (b) {
+                    b.setAttribute("aria-checked", b.getAttribute("data-value") === STATE[name] ? "true" : "false");
+                });
+            });
+        }
+
+        function applyInput(name, value) {
+            if (name === "amount") {
+                var num = parseFloat(value);
+                STATE.amount = (isFinite(num) && num > 0) ? num : 1000;
+            } else if (OPTIONS[name] && OPTIONS[name].indexOf(value) !== -1) {
+                STATE[name] = value;
+            }
+            syncToggleState();
+            render();
+        }
+
+        function localizeStatic() {
+            document.querySelectorAll("[data-i18n]").forEach(function (n) {
+                n.textContent = t(n.getAttribute("data-i18n"));
+            });
+            var title = document.getElementById("bvb-title");
+            if (title) { title.textContent = t("page_title"); }
+            var sub = document.getElementById("bvb-subtitle");
+            if (sub) { sub.textContent = t("page_subtitle"); }
+            var core = document.getElementById("bvb-core");
+            if (core) { core.textContent = t("core_question"); }
+            var ll = document.getElementById("bvb-lang-label");
+            if (ll) { ll.textContent = t("lang_label"); }
+            document.documentElement.setAttribute("lang", LANG);
+        }
+
+        function renderMatrix() {
+            var table = document.getElementById("bvb-matrix");
+            if (!table) { return; }
+            table.innerHTML = "";
+            var thead = el("thead");
+            var hr = el("tr");
+            hr.appendChild(el("th", null, t("matrix_dimension")));
+            RAILS.forEach(function (r) { hr.appendChild(el("th", null, t("rail_" + r))); });
+            thead.appendChild(hr);
+            table.appendChild(thead);
+            var tbody = el("tbody");
+            DIMENSIONS.forEach(function (dim) {
+                var tr = el("tr");
+                tr.appendChild(el("td", null, dimLabel(dim)));
+                RAILS.forEach(function (r) {
+                    var c = CAPABILITY[r][dim];
+                    var cell = el("td", "cap-" + c, t("cap_" + c));
+                    tr.appendChild(cell);
+                });
+                tbody.appendChild(tr);
+            });
+            table.appendChild(tbody);
+        }
+
+        function render() {
+            var result = rankRails(STATE);
+            var scored = result.scored;
+
+            // Summary line.
+            var parts = scored.map(function (s) {
+                return t("summary_rail_band", { rail: t("rail_" + s.rail), band: t("band_" + s.band) });
+            });
+            var summary = document.getElementById("bvb-summary");
+            if (summary) {
+                summary.textContent = t("summary_lead") + " " + parts.join(t("summary_join")) + ".";
+            }
+
+            // Rail cards.
+            var wrap = document.getElementById("bvb-rails");
+            if (wrap) {
+                wrap.innerHTML = "";
+                scored.forEach(function (s) {
+                    var card = el("div", "bvb-card" + (s.band === "strong" ? " is-strong" : ""));
+                    card.appendChild(el("div", "rail-name", t("rail_" + s.rail)));
+                    card.appendChild(el("span", "bvb-band band-" + s.band, t("band_" + s.band)));
+
+                    var meets;
+                    if (s.m === 0) {
+                        meets = el("div", "bvb-meets", t("meets_none"));
+                    } else {
+                        var txt = t("meets_count", { n: s.n, m: s.m });
+                        if (s.partial > 0) { txt += " " + t("meets_partial", { k: s.partial }); }
+                        meets = el("div", "bvb-meets", txt);
+                    }
+                    card.appendChild(meets);
+
+                    if (s.m > 0) {
+                        var ul = el("ul", "bvb-prio-list");
+                        var order = s.metDims.map(function (d) { return { d: d, k: "met" }; })
+                            .concat(s.partialDims.map(function (d) { return { d: d, k: "partial" }; }))
+                            .concat(s.missedDims.map(function (d) { return { d: d, k: "missed" }; }));
+                        order.forEach(function (item) {
+                            var li = el("li");
+                            var sym = item.k === "met" ? "✓" : (item.k === "partial" ? "~" : "✗");
+                            var mk = el("span", "marker " + item.k, sym + " " + t("marker_" + item.k) + ":");
+                            li.appendChild(mk);
+                            li.appendChild(document.createTextNode(" " + dimLabel(item.d)));
+                            ul.appendChild(li);
+                        });
+                        card.appendChild(ul);
+                    }
+
+                    card.appendChild(el("p", "bvb-explain", buildExplanation(s)));
+
+                    var gains = s.metDims.map(dimLabel);
+                    var gives = s.missedDims.map(dimLabel);
+                    var gg = el("div", "bvb-gaingive");
+                    var g1 = el("span", "gg-label", t("gain_label") + ": ");
+                    gg.appendChild(g1);
+                    gg.appendChild(document.createTextNode(joinList(gains) + ". "));
+                    var g2 = el("span", "gg-label", t("give_up_label") + ": ");
+                    gg.appendChild(g2);
+                    gg.appendChild(document.createTextNode(joinList(gives) + "."));
+                    card.appendChild(gg);
+
+                    wrap.appendChild(card);
+                });
+            }
+
+            // Flags.
+            var flags = buildFlags(STATE);
+            var flagBox = document.getElementById("bvb-flags");
+            var flagList = document.getElementById("bvb-flags-list");
+            if (flagBox && flagList) {
+                flagList.innerHTML = "";
+                if (flags.length) {
+                    flags.forEach(function (key) { flagList.appendChild(el("li", null, t(key))); });
+                    flagBox.hidden = false;
+                } else {
+                    flagBox.hidden = true;
+                }
+            }
+        }
+
+        function init() {
+            if (!document.getElementById("bvb-form")) { return; }
+            LANG = getLang();
+
+            // Language toggle.
+            document.querySelectorAll(".lang-btn").forEach(function (b) {
+                if (b.getAttribute("data-lang") === LANG) { b.classList.add("active"); b.setAttribute("aria-pressed", "true"); }
+                else { b.classList.remove("active"); b.setAttribute("aria-pressed", "false"); }
+                b.addEventListener("click", function () {
+                    LANG = b.getAttribute("data-lang") === "es" ? "es" : "en";
+                    try { if (window.localStorage) { window.localStorage.setItem("bsa_lang", LANG); } } catch (e) {}
+                    document.querySelectorAll(".lang-btn").forEach(function (x) {
+                        var on = x.getAttribute("data-lang") === LANG;
+                        x.classList.toggle("active", on);
+                        x.setAttribute("aria-pressed", on ? "true" : "false");
+                    });
+                    buildToggles();
+                    localizeStatic();
+                    renderMatrix();
+                    render();
+                });
+            });
+
+            var amountInput = document.getElementById("bvb-amount");
+            if (amountInput) {
+                amountInput.addEventListener("input", function () { applyInput("amount", amountInput.value); });
+            }
+
+            buildToggles();
+            localizeStatic();
+            renderMatrix();
+            render();
+        }
+
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", init);
+        } else {
+            init();
+        }
+    })();
     </script>
 
     <!-- Animated Icon Library -->

--- a/tests/interactive-tools.bitcoin-vs-banking.test.mjs
+++ b/tests/interactive-tools.bitcoin-vs-banking.test.mjs
@@ -1,0 +1,166 @@
+// Tests for the Bitcoin vs Banking tradeoff simulator (v1, three rails).
+// Run: node --test tests/interactive-tools.bitcoin-vs-banking.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { JSDOM } from "jsdom";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PAGE = path.join(ROOT, "interactive-demos/bitcoin-vs-banking/index.html");
+const HTML = readFileSync(PAGE, "utf8");
+
+// Load the page into jsdom without executing external <script src> tags, then
+// eval only the simulator script so its pure logic and DOM rendering run.
+function mount() {
+  const dom = new JSDOM(HTML, { pretendToBeVisual: true, runScripts: "outside-only", url: "https://example.com/interactive-demos/bitcoin-vs-banking/" });
+  const { window } = dom;
+  const sim = window.document.getElementById("bvb-sim");
+  assert.ok(sim, "simulator script #bvb-sim must exist");
+  window.eval(sim.textContent);
+  // The page wires init() on DOMContentLoaded. In jsdom that event may have
+  // already passed before eval, so fire it to ensure the simulator mounts.
+  window.document.dispatchEvent(new window.Event("DOMContentLoaded"));
+  return { dom, window };
+}
+
+function fullState(overrides) {
+  // Mirrors defaultState() in the page.
+  return Object.assign({
+    amount: 1000, scope: "domestic", urgency: "days", horizon: "spend_soon",
+    reversibility: "not", selfcustody: "not", privacy: "low", trust: "trust",
+    polrisk: "low", techcomfort: "new"
+  }, overrides || {});
+}
+
+test("page mounts: container, inputs, and three rail cards render", () => {
+  const { window } = mount();
+  const doc = window.document;
+  assert.ok(doc.getElementById("main-content"), "#main-content present");
+  assert.ok(doc.getElementById("bvb-form"), "situation form present");
+  assert.equal(doc.querySelectorAll(".bvb-toggle[data-input]").length, 9, "nine toggle inputs");
+  assert.ok(doc.getElementById("bvb-amount"), "amount input present");
+  assert.equal(doc.querySelectorAll("#bvb-rails .bvb-card").length, 3, "three rail cards rendered");
+});
+
+test("inputs update outputs: changing an input changes the result", () => {
+  const { window } = mount();
+  const before = window.document.getElementById("bvb-rails").textContent;
+  window.BVB.setInput("selfcustody", "essential");
+  window.BVB.setInput("polrisk", "high");
+  const after = window.document.getElementById("bvb-rails").textContent;
+  assert.notEqual(before, after, "rail cards re-render after input change");
+});
+
+test("bank or card can rank first (reversibility essential, domestic, spend soon)", () => {
+  const { window } = mount();
+  const state = fullState({ reversibility: "essential", selfcustody: "not", horizon: "spend_soon", scope: "domestic" });
+  const top = window.BVB.rankRails(state).scored[0];
+  assert.equal(top.rail, "bank", "bank ranks first");
+  assert.equal(top.band, "strong", "bank is a strong fit here");
+});
+
+test("Bitcoin self-custody can rank first (high political risk, self-custody essential, cross-border, long hold)", () => {
+  const { window } = mount();
+  const state = fullState({ polrisk: "high", selfcustody: "essential", scope: "cross_border", horizon: "years", reversibility: "not" });
+  const ranked = window.BVB.rankRails(state).scored;
+  assert.equal(ranked[0].rail, "btc_self", "self-custody ranks first");
+  assert.equal(ranked[0].band, "strong", "self-custody is a strong fit");
+});
+
+test("Bitcoin with a service provider can rank first (cross-border, urgent, easy use, no self-custody need)", () => {
+  const { window } = mount();
+  const state = fullState({ scope: "cross_border", urgency: "now", horizon: "spend_soon", selfcustody: "not", reversibility: "nice", techcomfort: "new" });
+  const ranked = window.BVB.rankRails(state).scored;
+  assert.equal(ranked[0].rail, "btc_provider", "provider ranks first in this situation");
+});
+
+test("provider is not treated as identical to self-custody when self-custody is essential", () => {
+  const { window } = mount();
+  const state = fullState({ selfcustody: "essential", polrisk: "high" });
+  const ranked = window.BVB.rankRails(state).scored;
+  const map = {};
+  ranked.forEach((s) => { map[s.rail] = s.band; });
+  // Provider cannot hold the user's keys, so it must fall short of an essential need.
+  assert.equal(map.btc_provider, "poor", "provider cannot satisfy an essential self-custody need");
+  assert.notEqual(map.btc_self, "poor", "self-custody at least covers the essential need");
+  const order = ranked.map((s) => s.rail);
+  assert.ok(order.indexOf("btc_self") < order.indexOf("btc_provider"), "self-custody outranks provider here");
+});
+
+test("political risk raises a freeze flag for the bank rail", () => {
+  const { window } = mount();
+  assert.ok(window.BVB.buildFlags(fullState({ polrisk: "high" })).includes("flag_freeze"));
+  assert.ok(!window.BVB.buildFlags(fullState({ polrisk: "low" })).includes("flag_freeze"));
+});
+
+test("EN and ES dictionaries have identical key sets", () => {
+  const { window } = mount();
+  const en = Object.keys(window.BVB.STRINGS.en).sort();
+  const es = Object.keys(window.BVB.STRINGS.es).sort();
+  assert.deepEqual(en, es, "EN/ES key parity");
+});
+
+test("no em dash (U+2014) anywhere in the page source", () => {
+  assert.equal(HTML.indexOf("\u2014"), -1, "no U+2014 in index.html");
+});
+
+test("no NaN or Infinity reaches the DOM across edge-case inputs", () => {
+  const { window } = mount();
+  const amounts = [0, -50, 1, 1000, 5000, 999999999, NaN, Infinity];
+  amounts.forEach((amt) => {
+    window.BVB.setInput("amount", amt);
+    ["domestic", "cross_border"].forEach((scope) => {
+      window.BVB.setInput("scope", scope);
+      const txt = window.document.getElementById("bvb-rails").textContent;
+      assert.ok(!/NaN|Infinity/.test(txt), `no NaN/Infinity for amount=${amt} scope=${scope}`);
+      window.document.querySelectorAll("#bvb-rails .bvb-band").forEach((b) => {
+        assert.ok(/^(Strong fit|Workable|Poor fit|Encaja bien|Funcional|Encaja mal)$/.test(b.textContent.trim()), "band is a valid label");
+      });
+    });
+  });
+});
+
+test("no external network calls in the simulator logic", () => {
+  const sim = HTML.match(/<script id="bvb-sim">([\s\S]*?)<\/script>/);
+  assert.ok(sim, "found simulator script");
+  const body = sim[1];
+  assert.equal(/\bfetch\s*\(/.test(body), false, "no fetch");
+  assert.equal(/XMLHttpRequest/.test(body), false, "no XMLHttpRequest");
+  assert.equal(/WebSocket/.test(body), false, "no WebSocket");
+});
+
+test("mount contract intact: route infrastructure scripts and links preserved", () => {
+  const required = [
+    '/js/config.js', '/js/demo-lock-subdomain.js', '/js/subdomain-access-control.js',
+    '/js/icon-library.js', '/js/navigation-context.js', '/js/reflect-widget.js',
+    '/js/membership-gate.js', '/js/analytics.js', '/js/email-capture.js',
+    '/js/tip-cta.js', '/js/demo-nav.js',
+    '/css/tokens.css', '/css/brand.css', '/css/widgets.css', '/css/icons.css',
+    '/css/interactive-demos.css', '/css/demo-shell.css'
+  ];
+  required.forEach((r) => assert.ok(HTML.includes(r), `preserved: ${r}`));
+  assert.ok(HTML.includes('id="main-content"'), "#main-content preserved");
+  assert.ok(HTML.includes("urlParams.get('level')"), "?level= switcher preserved");
+  assert.ok(HTML.includes('class="reflect-widget"'), "reflect widget preserved");
+  assert.ok(HTML.includes('data-email-capture="page-footer"'), "email capture block preserved");
+  assert.ok(HTML.includes('data-tip-cta="compact"'), "tip block preserved");
+  assert.ok(HTML.includes('href="../index.html"'), "back link preserved");
+});
+
+test("mobile layout sanity: responsive breakpoints present", () => {
+  assert.ok(/@media \(max-width: 968px\)[\s\S]*?\.bvb-rails\s*\{\s*grid-template-columns: 1fr/.test(HTML), "rails stack at 968px");
+  assert.ok(/@media \(max-width: 768px\)[\s\S]*?\.bvb-fields\s*\{\s*grid-template-columns: 1fr/.test(HTML), "fields stack at 768px");
+  assert.ok(/@media \(max-width: 360px\)[\s\S]*?overflow-x: hidden/.test(HTML), "no horizontal overflow at 360px");
+});
+
+test("no investment advice or price/fee claims in copy", () => {
+  const { window } = mount();
+  const both = JSON.stringify(window.BVB.STRINGS).toLowerCase();
+  ["you should buy", "should invest", "guaranteed return", "best investment"].forEach((p) => {
+    assert.equal(both.includes(p), false, `no advice phrase: ${p}`);
+  });
+  // No seed/key entry surface in the page.
+  assert.equal(/seed phrase|private key|enter your (seed|key)/i.test(HTML), false, "no seed or key entry surface");
+});


### PR DESCRIPTION
Replaces the old persuasion-style Bitcoin vs banking tool with an interactive tradeoff simulator.

Changes:
- Rebuilt interactive-demos/bitcoin-vs-banking/index.html
- Added test coverage for the simulator
- Supports EN/ES content
- Preserves mount contract and existing footer/tool infrastructure
- Keeps the learner-facing result honest: bank, Bitcoin self-custody, or provider can win depending on the situation

Verified:
- 14/14 tests pass
- Browser preview checked
- Mobile layout checked
- No em dashes in changed files
- No external calls
- No advice or price claims