### PR TITLE
Fix Sovereign Vault safety labels

### DIFF
--- a/interactive-demos/sovereign-vault/index.html
+++ b/interactive-demos/sovereign-vault/index.html
@@ -90,6 +90,7 @@
                             </svg>
                         </button>
                     </div>
+                    <span class="help-text">Create a new password just for this planning tool. Do not use a wallet seed phrase, private key, or wallet passphrase.</span>
                 </div>
 
                 <div class="form-group new-vault-only" style="display: none;">
@@ -114,6 +115,7 @@
             <div class="security-notice">
                 <h4>🔐 Client-Side Encryption</h4>
                 <p>Your data is encrypted locally before storage. We never see your password or your custody information.</p>
+                <p class="security-warning"><strong>This is a planning and documentation tool, not a wallet.</strong> Never enter a real seed phrase, private key, or wallet passphrase anywhere in it. Use aliases and notes, never real secrets.</p>
             </div>
 
             <div class="what-is-notice">
@@ -985,6 +987,98 @@
     <script src="js/export.js"></script>
     <script src="js/inheritance.js"></script>
     <script src="js/app.js"></script>
+
+    <!-- Safety guard: detect and clear seed/key-like input. Fully client-side, no network. -->
+    <script id="sv-safety-guard">
+    (function () {
+        'use strict';
+
+        // Pure detector. Returns true if the value looks like a real Bitcoin
+        // secret (BIP39 mnemonic, raw private key, WIF, or extended private key).
+        function looksLikeSecret(value) {
+            if (typeof value !== 'string') return false;
+            var v = value.trim().replace(/\s+/g, ' ');
+            if (!v) return false;
+            // BIP39 mnemonic: 12/15/18/21/24 lowercase alphabetic words (3-8 chars).
+            var tokens = v.split(' ');
+            if ([12, 15, 18, 21, 24].indexOf(tokens.length) !== -1) {
+                var allWords = tokens.every(function (t) { return /^[a-z]{3,8}$/.test(t); });
+                if (allWords) return true;
+            }
+            var single = v.replace(/\s+/g, '');
+            // Raw 32-byte private key in hex.
+            if (/^[0-9a-fA-F]{64}$/.test(single)) return true;
+            // WIF private key.
+            if (/^[5KL][1-9A-HJ-NP-Za-km-z]{50,51}$/.test(single)) return true;
+            // Extended private key (xprv / yprv / zprv).
+            if (/^(xprv|yprv|zprv)[1-9A-HJ-NP-Za-km-z]{100,115}$/.test(single)) return true;
+            return false;
+        }
+
+        // Expose the pure detector for tests. No side effects.
+        window.__svSafety = { looksLikeSecret: looksLikeSecret };
+
+        // Free-text fields where a learner might paste a real secret.
+        var GUARDED_IDS = [
+            'recovery-hint', 'wallet-name', 'wallet-purpose', 'wallet-notes',
+            'backup-alias', 'backup-notes', 'heir-instructions', 'heir-notes', 'heir-name'
+        ];
+
+        var WARNING_TEXT = 'This looks like a real seed phrase or private key. Never enter real secrets here. For your safety this field was cleared. Use an alias or a short note instead.';
+
+        function warningFor(field) {
+            var id = field.id + '-secret-warning';
+            var el = document.getElementById(id);
+            if (!el) {
+                el = document.createElement('p');
+                el.id = id;
+                el.setAttribute('role', 'alert');
+                el.setAttribute('aria-live', 'assertive');
+                el.style.cssText = 'margin:.4rem 0 0;padding:.5rem .65rem;border:1px solid #b3261e;border-radius:6px;background:rgba(179,38,30,0.08);color:#b3261e;font-size:.85rem;line-height:1.35;';
+                el.hidden = true;
+                if (field.parentNode) field.parentNode.insertBefore(el, field.nextSibling);
+            }
+            return el;
+        }
+
+        function showWarning(field) {
+            var w = warningFor(field);
+            w.textContent = WARNING_TEXT;
+            w.hidden = false;
+        }
+
+        function hideWarning(field) {
+            var w = document.getElementById(field.id + '-secret-warning');
+            if (w) w.hidden = true;
+        }
+
+        function attach(field) {
+            if (!field) return;
+            field.addEventListener('input', function () {
+                if (looksLikeSecret(field.value)) { showWarning(field); }
+                else { hideWarning(field); }
+            });
+            field.addEventListener('blur', function () {
+                if (looksLikeSecret(field.value)) {
+                    field.value = '';
+                    field.dispatchEvent(new Event('change', { bubbles: true }));
+                    showWarning(field);
+                }
+            });
+        }
+
+        function init() {
+            GUARDED_IDS.forEach(function (id) { attach(document.getElementById(id)); });
+        }
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+        } else {
+            init();
+        }
+    })();
+    </script>
+
     <script src="/js/navigation-context.js"></script>
 
     <!-- Reflect: Socratic questions after sovereign vault activity -->

--- a/interactive-demos/sovereign-vault/js/crypto.js
+++ b/interactive-demos/sovereign-vault/js/crypto.js
@@ -1,6 +1,6 @@
 /**
- * Sovereign Vault - Zero-Knowledge Encryption Module
- * 
+ * Sovereign Vault - Client-Side Encryption Module
+ *
  * All data is encrypted client-side using Web Crypto API.
  * The server (localStorage in this demo) only stores encrypted blobs.
  * Keys are derived from user's password using PBKDF2.

--- a/tests/interactive-tools.sovereign-vault.test.mjs
+++ b/tests/interactive-tools.sovereign-vault.test.mjs
@@ -1,0 +1,100 @@
+// Tests for the Sovereign Vault safety + accuracy labels.
+// Run: node --test tests/interactive-tools.sovereign-vault.test.mjs
+// Pure-Node: no jsdom dependency. The safety guard's detector is run via a
+// minimal window/document stub so the test works even without node_modules.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const VAULT = path.join(ROOT, "interactive-demos/sovereign-vault");
+const PAGE = path.join(VAULT, "index.html");
+const CRYPTO = path.join(VAULT, "js/crypto.js");
+const HTML = readFileSync(PAGE, "utf8");
+const CRYPTO_SRC = readFileSync(CRYPTO, "utf8");
+
+const JS_FILES = [
+  "js/crypto.js", "js/vault-core.js", "js/resilience.js",
+  "js/export.js", "js/inheritance.js", "js/app.js"
+].map((rel) => path.join(VAULT, rel));
+
+test("no zero-knowledge wording remains in the changed files", () => {
+  assert.equal(/zero[-\s]?knowledge/i.test(HTML), false, "index.html free of zero-knowledge");
+  assert.equal(/zero[-\s]?knowledge/i.test(CRYPTO_SRC), false, "crypto.js free of zero-knowledge");
+  assert.ok(/client-side encryption/i.test(CRYPTO_SRC), "crypto.js says client-side encryption");
+});
+
+test("clear warning against entering real seed phrases or keys is present", () => {
+  assert.ok(/not a wallet/i.test(HTML), "states it is not a wallet");
+  assert.ok(/planning and documentation tool/i.test(HTML), "states it is a planning/documentation tool");
+  assert.ok(
+    /never enter a real seed phrase, private key, or wallet passphrase/i.test(HTML),
+    "explicit no-real-secrets warning present"
+  );
+  assert.ok(
+    /do not use a wallet seed phrase, private key, or wallet passphrase/i.test(HTML),
+    "master-password helper distinguishes it from a wallet secret"
+  );
+});
+
+test("no network send is introduced anywhere in the vault scripts or the inline guard", () => {
+  const banned = [/\bfetch\s*\(/, /XMLHttpRequest/, /WebSocket/, /sendBeacon/, /navigator\.send/, /new\s+Image\s*\(/];
+  for (const file of JS_FILES) {
+    const src = readFileSync(file, "utf8");
+    for (const re of banned) {
+      assert.equal(re.test(src), false, `${path.basename(file)} has no ${re}`);
+    }
+  }
+  const guard = HTML.match(/<script id="sv-safety-guard">([\s\S]*?)<\/script>/);
+  assert.ok(guard, "inline safety guard present");
+  for (const re of banned) {
+    assert.equal(re.test(guard[1]), false, `inline guard has no ${re}`);
+  }
+});
+
+test("no em dash (U+2014) in the changed files", () => {
+  assert.equal(HTML.indexOf("—"), -1, "no U+2014 in index.html");
+  assert.equal(CRYPTO_SRC.indexOf("—"), -1, "no U+2014 in crypto.js");
+});
+
+test("mount contract preserved: scripts, main container, and footer blocks intact", () => {
+  const required = [
+    'js/crypto.js', 'js/vault-core.js', 'js/resilience.js', 'js/export.js',
+    'js/inheritance.js', 'js/app.js',
+    '/js/navigation-context.js', '/js/reflect-widget.js',
+    '/js/analytics.js', '/js/email-capture.js', '/js/tip-cta.js'
+  ];
+  required.forEach((r) => assert.ok(HTML.includes('"' + r + '"'), `preserved script: ${r}`));
+  assert.ok(HTML.includes('id="main-content"'), "#main-content preserved");
+  assert.ok(HTML.includes('class="reflect-widget"'), "reflect widget preserved");
+  assert.ok(HTML.includes('data-email-capture="family-education-vault"'), "email capture block preserved");
+  assert.ok(HTML.includes('data-tip-cta="compact"'), "tip block preserved");
+  assert.ok(HTML.includes('class="bsa-boundary-note"'), "boundary note preserved");
+});
+
+test("seed/key detector flags real secrets and leaves ordinary notes alone", () => {
+  // Run the inline guard in a minimal stub so we do not need jsdom.
+  const guard = HTML.match(/<script id="sv-safety-guard">([\s\S]*?)<\/script>/);
+  assert.ok(guard, "inline safety guard present");
+  const win = {};
+  const doc = { readyState: "complete", getElementById: () => null, addEventListener: () => {} };
+  // eslint-disable-next-line no-new-func
+  new Function("window", "document", guard[1])(win, doc);
+  const detect = win.__svSafety && win.__svSafety.looksLikeSecret;
+  assert.equal(typeof detect, "function", "detector exposed on window.__svSafety");
+
+  // Should flag (real secrets):
+  assert.equal(detect("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"), true, "12-word mnemonic flagged");
+  assert.equal(detect("legal winner thank year wave sausage worth useful legal winner thank yellow"), true, "another 12-word mnemonic flagged");
+  assert.equal(detect("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"), true, "64-char hex private key flagged");
+  assert.equal(detect("5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ"), true, "WIF private key flagged");
+
+  // Should NOT flag (ordinary planning notes / aliases):
+  assert.equal(detect("Home Safe"), false, "alias not flagged");
+  assert.equal(detect("Primary cold storage for long term savings"), false, "short note not flagged");
+  assert.equal(detect("Location Alpha, deposit box at the downtown branch, key with my sister"), false, "ordinary note not flagged");
+  assert.equal(detect(""), false, "empty not flagged");
+  assert.equal(detect("   "), false, "whitespace not flagged");
+});


### PR DESCRIPTION
Improves Sovereign Vault safety wording and prevents learners from entering real wallet secrets.

Changes:
- Replaces the remaining "zero-knowledge" wording with "client-side encryption"
- Strengthens warnings that the tool is not a wallet
- Warns learners not to enter real seed phrases, private keys, wallet passphrases, or secrets
- Adds client-side detection for seed-like or key-like input
- Adds focused tests for safety wording, no network send, no em dashes, and preserved mount behavior

Scope:
- Sovereign Vault only
- No routes, gates, footer, analytics, membership, email, tips, or unrelated infrastructure changed