### PR TITLE
Add demo-only warnings to Address Format Explorer and Wallet Security Workshop

### DIFF
--- a/interactive-demos/address-format-explorer/index.html
+++ b/interactive-demos/address-format-explorer/index.html
@@ -81,6 +81,10 @@
             <h2>Interactive Address Comparison</h2>
             <p class="section-intro">See the same wallet seed generate different addresses for each format. All addresses below are derived from the same private key!</p>
 
+            <div class="demo-address-banner" role="note" style="margin: 1rem 0 1.5rem; padding: 0.85rem 1rem; border: 2px solid #b3261e; border-radius: 8px; background: rgba(179, 38, 30, 0.08); color: var(--color-text, #e8e8e8); font-weight: 600;">
+                <span data-icon="alert"></span> Demo addresses only. Every address shown here is a teaching example from a public test seed. Never send Bitcoin to any address on this page, and never reuse these for a real wallet.
+            </div>
+
             <!-- Seed Input -->
             <div class="seed-generator">
                 <h3><span data-icon="seed"></span> Master Seed (Example)</h3>

--- a/interactive-demos/wallet-security-workshop/index.html
+++ b/interactive-demos/wallet-security-workshop/index.html
@@ -751,6 +751,8 @@
 
                     <div id="seedSecurity"></div>
 
+                    <p class="note" role="note" style="margin: 0.75rem 0 0; padding: 0.6rem 0.85rem; border-left: 3px solid #b3261e; background: rgba(179, 38, 30, 0.08); font-size: 0.9rem;"><span data-icon="alert"></span> Practice seed only. Any seed phrase shown here is for learning. Never use it for a real wallet, and never send Bitcoin to it.</p>
+
                     <div class="beginner-only tip-box">
                         <strong><span data-icon="lightbulb"></span> Why Random Words?</strong><br>
                         Using random words makes it impossible for hackers to guess. Never use words you can think of yourself!
@@ -779,8 +781,9 @@
                     </div>
 
                     <div class="input-group intermediate-only advanced-only">
-                        <label for="passphrase">Passphrase (Optional 25th Word):</label>
-                        <input type="password" id="passphrase" placeholder="Leave empty for standard wallet">
+                        <label for="passphrase">Passphrase (Demo 25th Word):</label>
+                        <input type="password" id="passphrase" placeholder="Demo only, type a practice word or leave empty" autocomplete="off">
+                        <small class="help-text">Practice field only. Do not enter a real wallet passphrase, seed phrase, or private key. Nothing here is saved or sent anywhere.</small>
                     </div>
 
                     <button class="btn shell-outline-btn" onclick="generateSecureSeed()">🎲 Generate Secure Seed</button>

--- a/tests/interactive-tools.address-wallet-demo-warnings.test.mjs
+++ b/tests/interactive-tools.address-wallet-demo-warnings.test.mjs
@@ -1,0 +1,71 @@
+// Tests for demo-safety warnings on Address Format Explorer and Wallet Security Workshop.
+// Run: node --test tests/interactive-tools.address-wallet-demo-warnings.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const AFE = path.join(ROOT, "interactive-demos/address-format-explorer/index.html");
+const WSW = path.join(ROOT, "interactive-demos/wallet-security-workshop/index.html");
+const AFE_HTML = readFileSync(AFE, "utf8");
+const WSW_HTML = readFileSync(WSW, "utf8");
+
+test("Address Format Explorer shows a prominent demo-address warning", () => {
+  assert.ok(/demo-address-banner/.test(AFE_HTML), "demo-address banner element present");
+  assert.ok(/Demo addresses only/i.test(AFE_HTML), "states demo addresses only");
+  assert.ok(/never send bitcoin to any address/i.test(AFE_HTML), "warns not to send Bitcoin to shown addresses");
+});
+
+test("Wallet Security Workshop relabels the passphrase field as demo-only", () => {
+  assert.ok(/Passphrase \(Demo 25th Word\)/.test(WSW_HTML), "passphrase label marked demo");
+  assert.ok(
+    /do not enter a real wallet passphrase, seed phrase, or private key/i.test(WSW_HTML),
+    "explicit no-real-secrets helper present"
+  );
+  assert.ok(/autocomplete="off"/.test(WSW_HTML), "passphrase field disables autocomplete");
+  assert.ok(/Practice seed only/i.test(WSW_HTML), "practice-seed warning present near seed display");
+});
+
+test("no em dash (U+2014) in either changed file", () => {
+  assert.equal(AFE_HTML.indexOf("—"), -1, "no U+2014 in Address Format Explorer");
+  assert.equal(WSW_HTML.indexOf("—"), -1, "no U+2014 in Wallet Security Workshop");
+});
+
+test("no new network send introduced by the warning markup", () => {
+  const addedAfe = AFE_HTML.match(/<div class="demo-address-banner"[\s\S]*?<\/div>/);
+  const addedWsw = WSW_HTML.match(/<small class="help-text">Practice field only[\s\S]*?<\/small>/);
+  assert.ok(addedAfe, "AFE banner block found");
+  assert.ok(addedWsw, "WSW helper block found");
+  [addedAfe[0], addedWsw[0]].forEach((block) => {
+    assert.equal(/fetch\s*\(|XMLHttpRequest|WebSocket|sendBeacon/.test(block), false, "no network call in added markup");
+  });
+});
+
+test("mount contract preserved: Address Format Explorer", () => {
+  const required = [
+    'address-generator.js', 'fee-calculator.js', 'main.js',
+    '/js/icon-library.js', '/js/navigation-context.js', '/js/reflect-widget.js',
+    '/js/membership-gate.js', '/js/analytics.js', '/js/email-capture.js',
+    '/js/tip-cta.js', '/js/demo-nav.js'
+  ];
+  required.forEach((r) => assert.ok(AFE_HTML.includes('"' + r + '"'), `preserved: ${r}`));
+  assert.ok(AFE_HTML.includes('id="main-content"'), "#main-content preserved");
+  assert.ok(AFE_HTML.includes('class="reflect-widget"'), "reflect widget preserved");
+  assert.ok(AFE_HTML.includes('data-tip-cta="compact"'), "tip block preserved");
+});
+
+test("mount contract preserved: Wallet Security Workshop", () => {
+  const required = [
+    '/js/config.js', '/js/demo-lock-subdomain.js', '/js/subdomain-access-control.js',
+    '/js/icon-library.js', '/js/navigation-context.js', '/js/reflect-widget.js',
+    '/js/membership-gate.js', '/js/analytics.js', '/js/email-capture.js',
+    '/js/tip-cta.js', '/js/demo-nav.js'
+  ];
+  required.forEach((r) => assert.ok(WSW_HTML.includes('"' + r + '"'), `preserved: ${r}`));
+  assert.ok(WSW_HTML.includes('id="main-content"'), "#main-content preserved");
+  assert.ok(WSW_HTML.includes('class="reflect-widget"'), "reflect widget preserved");
+  assert.ok(WSW_HTML.includes('data-tip-cta="compact"'), "tip block preserved");
+  assert.ok(WSW_HTML.includes('id="passphrase"'), "passphrase field still present (relabeled)");
+});


### PR DESCRIPTION
Prevents learners from mistaking demo material for real wallet assets.

Changes:
- Adds a prominent demo-address warning to Address Format Explorer
- Relabels the Wallet Security Workshop passphrase field as demo-only
- Warns learners not to enter real seed phrases, private keys, or wallet passphrases
- Adds focused tests for the warnings, no network send, no em dashes, and preserved mount behavior

Scope:
- Address Format Explorer and Wallet Security Workshop only
- No routes, gates, footer, analytics, membership, email, tips, or unrelated infrastructure changed