### PR TITLE
Redirect Programa Colombia to FSA canonical

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -37,17 +37,37 @@
     },
     {
       "source": "/semana-:week/:rest*",
-      "destination": "/programa-colombia/semana-:week/:rest*",
+      "destination": "https://financiallysovereign.academy/programa-colombia/semana-:week/:rest*",
       "permanent": false
     },
     {
       "source": "/semana-:week",
-      "destination": "/programa-colombia/semana-:week",
+      "destination": "https://financiallysovereign.academy/programa-colombia/semana-:week/",
       "permanent": false
     },
     {
       "source": "/semana-:week/",
-      "destination": "/programa-colombia/semana-:week/",
+      "destination": "https://financiallysovereign.academy/programa-colombia/semana-:week/",
+      "permanent": false
+    },
+    {
+      "source": "/programa-colombia",
+      "destination": "https://financiallysovereign.academy/programa-colombia/",
+      "permanent": false
+    },
+    {
+      "source": "/programa-colombia/:path*",
+      "destination": "https://financiallysovereign.academy/programa-colombia/:path*",
+      "permanent": false
+    },
+    {
+      "source": "/institutional/corporations/colombia",
+      "destination": "https://financiallysovereign.academy/institutional/corporations/colombia",
+      "permanent": false
+    },
+    {
+      "source": "/institutional/corporations/colombia/:path*",
+      "destination": "https://financiallysovereign.academy/institutional/corporations/colombia",
       "permanent": false
     },
     {


### PR DESCRIPTION
This PR redirects legacy Programa Colombia routes from Bitcoin Sovereign Academy to the canonical FSA Programa Colombia pages.

Scope:
- Updates vercel.json redirects only
- Redirects /programa-colombia and subpaths to FSA
- Redirects legacy /semana-N shortcuts to the FSA week pages
- Redirects /institutional/corporations/colombia to the FSA employer page
- Leaves all BSA content files untouched

Redirect method:
- Vercel edge redirects
- Temporary 307 redirects for initial verification
- No static redirect pages
- No JavaScript redirects

SEO/canonical:
- Uses temporary redirects first to avoid irreversible caching while testing
- Existing canonical points to FSA
- Can be flipped to permanent 308 after about one week of clean behavior